### PR TITLE
docs: establish V2 product and engineering contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,304 @@
+# ResearchPocket Engineering Contract
+
+This file applies to the entire `ResearchPocket` repository. It is the canonical
+contract for human contributors and coding agents working on V2. A more specific
+`AGENTS.md` may add local rules for a subtree, but it must not weaken the product,
+sync, privacy, or publication invariants in this file.
+
+## Mission
+
+ResearchPocket is a developer-focused, URL-first, local-first personal library.
+It helps one person save, curate, find, move, and deliberately share useful URLs
+without surrendering control of the library to a hosted product.
+
+The product must remain:
+
+- usable offline, without an account or a running internet-facing backend;
+- private by default and explicit about every published field;
+- human-directed: user-authored titles, notes, tags, collections, and ordering
+  are canonical;
+- portable through documented schemas, CLI output, imports, and exports;
+- accessible through the CLI, TUI, local web UI, and an authenticated GitHub
+  Pages owner mode; and
+- convergent across the owner's devices and browsers without asking the user to
+  resolve source-control conflicts.
+
+The primary V2 workflows are capture, curation, search, multi-device sync,
+recovery of a new device, authenticated hosted editing, selective publication,
+and integration with other tools.
+
+## Non-goals for V2
+
+Do not expand V2 into:
+
+- an AI memory, personal profile, RAG service, or autonomous organizer;
+- a multi-user collaboration or real-time team product;
+- a general notes/wiki application or a store for standalone notes;
+- a webpage archive, file/PDF store, highlighting system, or attachment manager;
+- a hosted account service or an application backend that must stay online;
+- a native mobile application;
+- end-to-end encrypted remote storage or encrypted sharing; or
+- silent URL deduplication. Concurrent saves of the same URL remain separate
+  items and may be surfaced to the owner for an explicit decision.
+
+Keep seams for future transports and optional enrichment, but do not implement a
+deferred capability as part of unrelated work.
+
+## Current Baseline and Target Shape
+
+The current repository is a single Rust crate. Its Pocket-era commands include
+`pocket`, `local`, `fetch`, `list`, `init`, `generate`, `export`, `handle`, and
+`notes`. Treat these as legacy compatibility and migration inputs. Do not add new
+Pocket dependencies or design new V2 behavior around the discontinued service.
+
+V2 consolidates product development in this repository. `my-list` and
+`ResearchGarden` are migration references until V2 reaches publishing parity;
+new application behavior belongs here.
+
+Evolve toward these dependency boundaries:
+
+```text
+crates/
+  research-domain/       entities, validation, CRDT semantics, projections
+  research-store/        SQLite projection, migrations, FTS, outbox
+  research-sync/         protocol envelopes, checkpoints, transport interface
+  research-app/          use cases shared by every interface
+  research-cli/          CLI binary and machine-readable output
+  research-tui/          terminal UI
+web/                     Preact/Vite SPA for local and GitHub Pages modes
+docs/v2/                 product contract, protocol, threat model, ADRs, roadmap
+tests/fixtures/           sanitized V1 import and protocol fixtures
+```
+
+The pure domain/protocol implementation is Rust and is compiled to WebAssembly
+for the hosted application. Native and WASM clients must use the same validation,
+normalization, merge, and publication-projection semantics. UI code calls the
+application layer; it does not recreate domain rules.
+
+The target CLI is:
+
+```text
+research init
+research import <v1|pocket|bookmarks|json|csv> <source>
+research add <url>
+research edit <item-id>
+research delete <item-id>
+research restore <item-id>
+research list
+research search <query>
+research ui
+research tui
+research sync setup github
+research sync
+research sync status
+research doctor
+research publish preview <collection>
+research publish setup github-pages
+```
+
+All data commands support `--format human|json|ndjson`. Machine data goes to
+stdout; progress, warnings, and diagnostics go to stderr. Do not change a stable
+machine schema without a versioned compatibility plan.
+
+`research ui` exposes a versioned loopback API under `/api/v1`. It binds only to
+`127.0.0.1`, disables CORS, validates `Origin`, and requires an unguessable
+per-session credential. The API and CLI must call the same application services.
+
+## Data and Sync Invariants
+
+These rules are hard requirements, not implementation suggestions.
+
+### Local state
+
+- SQLite is a local materialized projection and search index. It is rebuildable
+  from protocol state and is never the remote synchronization format.
+- Never copy, upload, publish, or merge a live/raw SQLite database for sync.
+- Canonical item identity is UUIDv7 and is independent of a provider ID or URL.
+- A local mutation atomically updates CRDT state, the SQLite projection, and the
+  durable outbox. A crash must not leave a visible mutation without its update
+  batch or an update batch without its corresponding local projection.
+- Metadata retrieval is asynchronous and retryable. A failed or offline fetch
+  must never prevent the URL from being saved.
+- V1 imports are read-only with respect to the source database, are idempotent,
+  and create a new V2 library in the platform data directory. Ignore credentials
+  found in a V1 database.
+
+### Application-level convergence
+
+- Use the pinned Loro Rust/WASM CRDT implementation for convergence.
+- Notes are character-level CRDT text so concurrent edits preserve both users'
+  text rather than choosing a whole-field winner.
+- Scalar fields use causal registers with a deterministic visible value and
+  recoverable immutable revision history.
+- Tags and collection membership use add-wins observed-remove sets.
+- Delete and restore use explicit lifecycle generations. Concurrent edits remain
+  recoverable but cannot accidentally resurrect a deleted item.
+- A concurrent public/private visibility decision resolves to private until a
+  later explicit edit observes and resolves both states.
+- Applying updates is deterministic and idempotent under duplication, delay,
+  reordering, partitions, and retries.
+
+### Git is transport, never the conflict resolver
+
+Git and GitHub provide storage, transport, access control, triggering, and an
+audit trail. **Git commit topology and Git merge/rebase behavior must never
+resolve application conflicts.** In particular:
+
+- Do not ask a user to merge, rebase, choose a branch, edit conflict markers, or
+  resolve a non-fast-forward update to reconcile library data.
+- Do not encode competing application state as edits to the same tracked file.
+- Do not use last-commit-wins, branch order, commit timestamps, GitHub merge
+  results, or force-pushes as domain semantics.
+- All clients exchange immutable, uniquely addressed CRDT update batches.
+  Application state converges by applying those batches through the protocol,
+  independent of commit order or history shape.
+- Repository races and GitHub `409`/`422` responses are transport failures: pull
+  unseen immutable batches, retry with bounded jitter, and preserve the outbox.
+  They are never presented as application conflicts.
+
+Store update batches at:
+
+```text
+sync/v1/ops/<device-uuid>/<zero-padded-sequence>.json
+```
+
+Each envelope includes the protocol version, library ID, device ID, durable
+device sequence, causal frontier, creation timestamp, base64 CRDT update, and
+payload hash. Never rewrite an operation file. If a target path already exists,
+an identical hash is an idempotent success; different content is an integrity
+error that must stop sync without discarding local data.
+
+Each installation receives its own device UUID and persists its next sequence
+before upload. Create immutable checkpoints after either 1,000 update batches or
+10 MiB of unapplied tail data. Checkpoints accelerate bootstrap but do not alter
+merge semantics. V2 does not prune update history; secure erasure requires a
+documented repository-history rewrite or migration to a new data repository.
+
+Sync must be safe after every local mutation, on application start/exit, through
+`research sync`, and through optional platform scheduling. Pull before push,
+apply all unseen batches, upload queued unique batches, and pull once more after
+a remote race. Never drop queued changes on timeout, rate limit, token expiry,
+process interruption, or browser reload.
+
+## Hosted Editing, Privacy, and Publishing
+
+Use separate repositories:
+
+1. A private data repository stores updates, checkpoints, publication policy,
+   and a pinned publisher workflow.
+2. A public Pages repository stores only the static application shell and
+   sanitized publication projections.
+
+The GitHub-hosted owner UI is a required management surface, not read-only. It
+persists edits to IndexedDB/outbox before network activity and synchronizes them
+as immutable application updates. It pulls on startup, focus, before and after a
+push race, and every 60 seconds while visible.
+
+Owner authentication uses a fine-grained, expiring PAT scoped only to the private
+data repository with `Contents: read/write`. Keep the token in JavaScript memory
+by default; explicit session-only storage may use `sessionStorage`. Never put the
+token in `localStorage`, IndexedDB, a URL, logs, analytics, generated output, or a
+service-worker cache. The token must not have write access to the Pages repository
+that serves the application JavaScript.
+
+Owner mode loads no third-party runtime scripts or analytics. Enforce a self-only
+content security policy and limit network connections to the required GitHub API.
+Native secrets belong in the OS credential store or a local ignored credential
+file, never SQLite, protocol updates, exports, or publication artifacts.
+
+Sync and publication are separate operations. Publishing is an allowlisted,
+collection-based projection into the Pages repository. Items and fields are
+private unless explicitly selected. Notes are excluded unless a collection
+explicitly enables them. Unresolved visibility is private.
+
+The publisher must fail closed if any secret, unselected item, private field,
+tombstone, update history, or unintended note appears in HTML, embedded JSON,
+JavaScript, source maps, feeds, caches, or other output. Preview and deployed
+projection use the same code path. Publication provides static HTML, JSON, RSS,
+and JSON Feed; it is not a second editable database.
+
+## Change Workflow
+
+- Every planned V2 change is backed by a real ResearchPocket issue and tracked in
+  GitHub Project #2 (`ResearchPocket V2`). Do not use project draft items for
+  committed implementation work.
+- Issue bodies include Context, Deliverables, Acceptance criteria, Non-goals, and
+  Dependencies. Apply the `v2`, area, priority, size, phase, and relationship
+  metadata agreed by the project charter.
+- Set an issue to **In progress** before repository edits, **In review** when its
+  pull request opens, and **Done** only after merge and acceptance verification.
+- Use parent/sub-issue and blocked-by relationships for epics and dependencies.
+  Do not begin a blocked issue by silently inventing the missing decision.
+- Architectural, protocol, security, migration, or compatibility decisions need
+  an ADR under `docs/v2/` and must link their issue.
+- Keep branches and pull requests focused on one issue or tightly coupled set of
+  acceptance criteria. Preserve unrelated user changes and avoid drive-by
+  cleanup.
+- Pull requests link their issues, explain user-visible and protocol impact, list
+  verification performed, and include UI evidence where relevant. Commit subjects
+  use the imperative mood and remain concise.
+- Schema and protocol changes include forward migration, compatibility behavior,
+  fixture updates, and recovery/rollback notes. Never mutate an existing released
+  migration or silently reinterpret a released protocol field.
+- Treat `my-list` and `ResearchGarden` as deprecated only after the consolidation
+  ADR is accepted. Add deprecation notices during alpha; archive them only after
+  V2 publishing reaches parity.
+
+## Verification
+
+Run the smallest relevant checks while iterating and the complete applicable set
+before review. The current Rust baseline is:
+
+```sh
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-targets --all-features
+cargo build --release
+```
+
+Once the V2 workspace and web package land, the repository-wide gates also
+include all workspace crates, native/WASM golden tests, and the web package's
+locked install, lint, unit test, browser test, and production build commands.
+Document the exact commands in the root README and CI rather than relying on
+developer-global tooling.
+
+Some baseline gates may fail before their dedicated foundation issues are
+completed. Track each known failure in Project #2 before enforcing that gate in
+CI. Do not hide, ignore, or weaken a new failure, and do not expand an unrelated
+change merely to repair pre-existing debt.
+
+Required coverage for the affected subsystem includes:
+
+- randomized two-to-five-client convergence with reordered, duplicated,
+  delayed, and partitioned updates;
+- identical native Rust and WASM materialized state and publication output;
+- concurrent note, scalar, tag, collection, delete/restore, duplicate-URL, and
+  visibility operations;
+- transaction interruption, outbox replay, checkpoint bootstrap, and full
+  restore from the remote log;
+- GitHub timeouts, rate limits, non-fast-forward races, duplicate upload,
+  corruption detection, and idempotent retry;
+- browser offline/reload recovery and PAT expiry or revocation with no queued
+  edit loss;
+- V1 import idempotency and authored-field preservation;
+- canonical export/import round trips;
+- negative scans proving private data is absent from every publication artifact;
+- local and hosted web end-to-end tests, TUI interaction tests, and supported
+  Linux/macOS/Windows CLI checks.
+
+## Definition of Done
+
+A change is done only when:
+
+- its acceptance criteria pass and its scope matches the linked issue;
+- code follows the boundaries and invariants above without duplicating domain
+  logic in an interface or transport;
+- migrations and protocol changes are compatible, recoverable, and documented;
+- relevant unit, integration, convergence, security, privacy, and end-to-end
+  tests pass, with any pre-existing baseline exception linked to an issue;
+- user-facing CLI/API/schema and operational documentation are updated;
+- no credential, private field, raw database, or unsafe generated artifact is
+  introduced;
+- the pull request has been reviewed and merged; and
+- the linked issue is verified against its acceptance criteria before its
+  Project status moves to **Done**.

--- a/docs/v2/PRODUCT.md
+++ b/docs/v2/PRODUCT.md
@@ -1,0 +1,188 @@
+# ResearchPocket V2 Product Contract
+
+Status: accepted direction for V2 planning and implementation
+
+## Vision
+
+ResearchPocket is a local-first, URL-first personal library for developers. It
+helps one person intentionally save, curate, retrieve, and selectively share
+knowledge without turning that knowledge into an AI profile or depending on a
+continuously running application server.
+
+The local library remains useful offline. A private GitHub repository provides
+remote durability and transport, and a GitHub Pages application provides both
+public read-only projections and an authenticated owner experience. Git is not
+the database and Git merge behavior is never used to resolve application data
+conflicts.
+
+## Product principles
+
+1. **Human first.** User-authored titles, notes, tags, collections, and status
+   are canonical. Automation may assist later, but it must not silently replace
+   a person's organization.
+2. **Local first.** Capture, editing, search, import, and export work without a
+   network connection or account.
+3. **Owned and portable.** The live library has documented, versioned formats
+   and can be reconstructed without a hosted ResearchPocket service.
+4. **Private by default.** The complete library is protected by the private
+   repository's access controls. Only explicit, allowlisted projections become
+   public.
+5. **Convergence belongs to the application.** ResearchPocket exchanges
+   immutable updates and resolves concurrent work through CRDT and causal
+   semantics. GitHub stores and transports those updates; commits, branches,
+   and merge conflicts do not decide the winning user data.
+6. **Integration is a feature.** The CLI, machine-readable output, loopback API,
+   imports, exports, and feeds are stable product surfaces rather than
+   afterthoughts.
+
+## Audience and personas
+
+V2 is intentionally developer-only. Setup may assume familiarity with a CLI,
+GitHub repositories, and fine-grained personal access tokens. Removing that
+requirement is a possible later product track, not a V2 release requirement.
+
+### Developer-owner
+
+The primary user maintains one personal library across computers and browsers.
+They want fast offline capture, transparent storage, reliable recovery, and
+control over exactly what is published. They use the CLI, TUI, local web UI,
+and hosted owner UI interchangeably.
+
+### Tool integrator
+
+A developer connects editors, scripts, browser capture tools, launchers, or
+other personal workflows to ResearchPocket. They need deterministic commands,
+versioned schemas, machine-readable output, and a loopback API.
+
+### Public reader
+
+A person follows a deliberately published collection without access to the
+owner's private library. They need a fast, accessible static site and standard
+feeds; they do not need a ResearchPocket or GitHub account.
+
+## V2 use cases
+
+### Capture and curation
+
+- Save a URL immediately while offline; metadata enrichment may be retried and
+  must never block or discard the save.
+- Edit titles, notes, tags, collection membership, favorite state, archive
+  state, and lifecycle state through the CLI, TUI, or local web UI.
+- Search locally across saved metadata and user-authored notes.
+- Keep concurrently saved copies of the same URL visible for review rather
+  than silently deleting one person's intent.
+
+### Remote use and synchronization
+
+- Restore a complete V2 library on a new device from its private GitHub data
+  repository.
+- Open the GitHub Pages application, authenticate owner mode with a
+  repository-scoped fine-grained PAT, load the complete private library, and
+  create or edit saves.
+- Continue editing in the hosted UI while temporarily offline and upload the
+  queued updates after connectivity returns.
+- Make concurrent changes in local clients, hosted browser sessions, or tabs
+  and converge without manual Git operations or lost note text.
+- Merge concurrent note edits at character granularity. Resolve other fields
+  with documented causal application semantics, including safe handling for
+  deletion, restoration, tags, collection membership, and visibility.
+
+### Publishing and integration
+
+- Select collections for publication while the rest of the library remains
+  private.
+- Preview the exact publication projection before it is deployed.
+- Publish allowlisted fields as a static site, JSON, RSS, and JSON Feed from a
+  repository separate from the private data repository.
+- Import an existing V1 SQLite library into a new V2 library without modifying
+  the source database.
+- Import Pocket exports, browser bookmarks, and documented JSON/CSV formats;
+  export canonical data in portable formats.
+- Operate and integrate through stable human, JSON, and NDJSON CLI output and a
+  versioned loopback API.
+
+## Required V2 surfaces
+
+- A Rust CLI for capture, editing, search, import/export, synchronization,
+  diagnostics, and publication setup.
+- A keyboard-oriented TUI with parity for core library management.
+- A loopback-only local web UI backed by the same application services as the
+  CLI and TUI.
+- A static GitHub Pages application with anonymous public collection views and
+  full private owner mode.
+- A private GitHub data repository containing versioned immutable updates and
+  rebuild material, protected by GitHub repository access control.
+- A separate public Pages repository containing only the application shell and
+  sanitized publication projections.
+
+The owner PAT must be fine-grained, limited to the private data repository, and
+granted only the permissions required to read and append synchronization data.
+It must not be embedded in generated files, URLs, logs, analytics, persistent
+browser storage, or service-worker caches. Owner mode must remain usable when
+the token expires or is revoked: local pending changes stay queued until the
+owner supplies valid credentials.
+
+## Success criteria
+
+V2 is successful when all of the following are true:
+
+- A developer can initialize a library, save and find a URL offline, and use
+  core editing workflows from the CLI, TUI, and local web UI.
+- A V1 database can be imported repeatedly into a new V2 library without
+  altering the original or duplicating imported records.
+- Two to five clients can edit during a network partition, reconnect in any
+  order, receive duplicate or reordered updates, and materialize identical
+  library state without a Git merge or user-selected winner.
+- Simultaneous edits to different portions of a note preserve both edits at
+  character granularity in native Rust and browser/WASM clients.
+- Hosted owner changes survive reloads, offline periods, transient GitHub API
+  failures, expired credentials, and synchronization retries.
+- A new device can rebuild the complete current library and search index from
+  remote V2 data.
+- Publication tests prove that private items, non-allowlisted fields, private
+  notes, credentials, tombstones, and synchronization history never appear in
+  public HTML, JavaScript, source maps, JSON, or feeds.
+- The documented machine interfaces remain deterministic and versioned, and
+  supported releases pass Linux, macOS, Windows, native/WASM convergence, and
+  browser end-to-end test suites.
+
+## V2 non-goals
+
+- Non-technical onboarding, hosted ResearchPocket accounts, or hiding the
+  GitHub repository/PAT setup from the owner.
+- Using Git commits, branch merges, file locking, or last-push-wins as the
+  application conflict-resolution model.
+- Multi-user or real-time collaborative libraries. V2 supports one human owner
+  using many devices, browsers, and tabs.
+- AI memory, personal profiling, RAG, autonomous organization, or canonical
+  machine-generated tags and summaries.
+- Standalone notes, full webpage archival, PDFs, attachments, highlights, or a
+  general-purpose wiki.
+- Native mobile applications.
+- End-to-end encryption of remote state or encrypted public sharing. V2 trusts
+  GitHub's private-repository access control; encryption can be added behind
+  the storage boundary later.
+- S3, WebDAV, or other remote providers. V2 defines a transport boundary but
+  ships GitHub as its only remote.
+- Secure deletion from existing Git history. V2 deletion affects materialized
+  state; erasing historical remote data requires a documented repository
+  replacement or history-rewrite procedure.
+
+## Product decisions that require an explicit V2 revision
+
+The following are contractual, not incidental implementation details:
+
+- V2 remains URL-first and developer-only.
+- The V1 database is imported into a new V2 library and is never migrated in
+  place.
+- The complete private library is editable from GitHub Pages owner mode.
+- Notes use character-level CRDT semantics; other domain fields use explicit
+  causal application rules.
+- Git is a replaceable storage/transport and audit mechanism, never the merge
+  engine for user data.
+- Publication is an explicit, field-allowlisted projection into a separate
+  repository.
+- Core V2 development is consolidated in the ResearchPocket repository.
+
+Changing any of these decisions requires an architecture decision record and
+an update to this contract before implementation diverges.

--- a/docs/v2/ROADMAP.md
+++ b/docs/v2/ROADMAP.md
@@ -1,0 +1,269 @@
+# ResearchPocket V2 Delivery Roadmap
+
+Status: implementation sequence and release gates for V2
+
+This roadmap converts the [product contract](./PRODUCT.md) into ordered delivery
+phases. Work may overlap within a phase, but no phase exits until its stated
+criteria are demonstrated. GitHub Project status reflects verified progress;
+it does not replace these release gates.
+
+## Architecture boundaries
+
+V2 must preserve the following boundaries throughout delivery:
+
+### Domain and convergence
+
+- One shared domain/protocol implementation defines item identity, validation,
+  causal metadata, character-level note CRDT behavior, and deterministic
+  materialization.
+- Native clients and the hosted browser use the same pinned Loro CRDT protocol
+  and pass cross-runtime golden tests.
+- Notes merge at character granularity. Scalar values, tags, collection
+  membership, lifecycle, and publication visibility use explicit causal rules;
+  no Git state is consulted to choose application values.
+
+### Local storage
+
+- SQLite is the local transactional projection and search index, not a file to
+  synchronize.
+- A user mutation atomically updates domain state, its SQLite projection, and a
+  durable outbound-update queue.
+- Replaying accepted immutable updates can rebuild the projection on a new
+  device. V1 sources are read-only inputs to an idempotent importer.
+
+### Remote transport
+
+- The GitHub adapter reads and appends immutable, uniquely addressed protocol
+  updates in a private repository and verifies their payload hashes.
+- Git is dumb transport and audit. The adapter may retry a branch-head race or
+  an idempotent upload, but it must never ask Git to merge library data and must
+  never surface ordinary concurrent editing as a manual Git conflict.
+- The transport interface does not expose Git commits or branches to the domain
+  layer, allowing another append-capable remote to be implemented later.
+
+### User interfaces
+
+- CLI, TUI, local web, and hosted web call the same application semantics.
+- The local API binds only to loopback, uses a per-session credential, validates
+  browser origin, and does not enable general cross-origin access.
+- Hosted owner mode stores pending updates durably while keeping its
+  repository-scoped PAT out of persistent browser storage and generated
+  artifacts.
+
+### Publication
+
+- Synchronization and publication are separate pipelines and repositories.
+- A pure projection step accepts materialized private state plus an explicit
+  collection policy and emits only allowlisted public fields.
+- Unresolved visibility is private. Any detected private-field leak fails the
+  build rather than publishing a partial result.
+
+## Phase 0: Product contract and safety
+
+### Deliverables
+
+- Adopt the V2 product contract, this roadmap, the repository `AGENTS.md`, and
+  architecture decision records for consolidation and synchronization.
+- Establish a green, reproducible Rust and JavaScript CI baseline with pinned
+  toolchains, dependency locks, and third-party Actions.
+- Disable Pocket-dependent deployment paths and prevent V1 static generation
+  from serializing private notes or credentials.
+- Document the privacy threat model, repository topology, PAT permissions,
+  browser token lifecycle, and publication boundary.
+- Build representative, sanitized fixtures for supported V1 databases and
+  legacy exports.
+
+### Exit criteria
+
+- Product, privacy, synchronization, and non-goal decisions are reviewable in
+  the repository and linked from their tracking issues.
+- CI runs formatting checks, linting, unit tests, secret scanning, and existing
+  V1 regression tests without modifying source files.
+- No supported publishing workflow depends on the retired Pocket service, and
+  privacy regression tests cover all currently generated artifacts.
+- The V1 fixture corpus contains notes, tags, favorites, archived items,
+  duplicate URLs, malformed metadata, and legacy schema variants.
+
+## Phase 1: Protocol and persistence foundations
+
+### Deliverables
+
+- Prove the pinned Loro implementation in Rust and WASM, including
+  character-level note editing, serialized update compatibility,
+  deterministic replay, and a pinned protocol version.
+- Define the versioned V2 domain schema, item identifiers, causal operations,
+  lifecycle/tombstone rules, set semantics, publication safety rule, and
+  duplicate-URL behavior.
+- Implement the V2 SQLite projection, full-text index, transactional outbox,
+  idempotent replay, checkpoint format, and rebuild path.
+- Implement read-only, idempotent import from V1 into a new platform data
+  directory. Credentials from V1 are never copied.
+- Consolidate V2 application code in ResearchPocket and mark `my-list` and
+  `ResearchGarden` as legacy migration references.
+
+### Exit criteria
+
+- Native and WASM golden tests materialize identical state from the same update
+  corpus.
+- Randomized multi-client tests converge under reordered, duplicated, delayed,
+  and partitioned delivery, including concurrent note, visibility, delete, and
+  restore operations.
+- Killing a process at each transaction boundary cannot create a projected
+  mutation without its outbound update or lose an acknowledged update.
+- A clean installation can import every V1 fixture twice with no source-file
+  changes, no duplicate records, and documented field preservation.
+
+## Phase 2: Complete local product
+
+### Deliverables
+
+- Ship V2 CLI commands for initialization, capture, CRUD, search,
+  import/export, status, diagnostics, synchronization, and publication preview,
+  with human, JSON, and NDJSON output contracts.
+- Ship the TUI with keyboard-first parity for core capture, edit, search,
+  collection, favorite, archive, delete, and restore workflows.
+- Ship the local web application through a secured loopback API using the same
+  application services and embedded frontend build.
+- Make URL capture immediate offline and metadata enrichment asynchronous,
+  observable, and retryable.
+
+### Exit criteria
+
+- A user can initialize, capture, edit, organize, search, delete, restore,
+  import, and export entirely offline in each required local interface.
+- Machine output is deterministic, schema-versioned, confined to stdout, and
+  covered by compatibility fixtures; progress and diagnostics use stderr.
+- Loopback security tests reject missing session credentials, invalid origins,
+  non-loopback binding, and cross-origin browser control.
+- Core workflows pass on Linux, macOS, and Windows, including keyboard and
+  accessibility checks for the local web interface.
+
+## Phase 3: Application-level synchronization
+
+### Deliverables
+
+- Implement the private GitHub repository adapter for immutable update upload,
+  pull, idempotent retry, checkpoints, rate-limit handling, and full restore.
+- Provide setup, explicit sync, status, diagnostics, and optional platform
+  scheduling without requiring a continuously running ResearchPocket server.
+- Keep Git branch races and transport retries inside the adapter; application
+  convergence consumes update sets and remains independent of commit order.
+- Add recovery guidance for corrupt remote objects, missing updates, credential
+  revocation, and deliberate remote replacement.
+
+### Exit criteria
+
+- Two to five offline clients can edit independently, synchronize in arbitrary
+  order, and converge without merge commits, conflict files, forced pushes, or
+  user-selected winners.
+- Duplicate upload, request timeout, rate limit, stale branch head, interrupted
+  checkpoint, and out-of-order pull simulations are lossless and idempotent.
+- A new device restores the materialized library and search index solely from
+  the private repository and detects integrity failures rather than silently
+  accepting corrupt updates.
+- Git history shape and commit ordering have no effect on the final domain
+  state for an identical set of valid updates.
+
+## Phase 4: Hosted owner mode
+
+### Deliverables
+
+- Build the same protocol/domain core for WASM and use it in the GitHub Pages
+  owner application.
+- Implement fine-grained PAT onboarding with least-privilege validation and
+  in-memory credential handling.
+- Persist the browser's private materialized state and outbound updates in
+  IndexedDB, while ensuring the PAT never enters IndexedDB, local storage,
+  service-worker caches, URLs, logs, analytics, or generated output.
+- Pull on startup, focus, before upload, after remote-head races, and at a
+  documented visible-page interval; serialize uploads and verify ambiguous
+  results by immutable update identity and hash.
+- Enforce a self-hosted dependency policy and restrictive content security
+  policy for owner mode.
+
+### Exit criteria
+
+- The hosted owner can load, search, add, edit, organize, delete, and restore
+  any private item, including while temporarily offline.
+- Reload, tab concurrency, expired/revoked PATs, transient API failures, and
+  ambiguous upload responses preserve all queued user changes.
+- Hosted browser, native clients, and multiple tabs pass the same partition and
+  convergence scenarios without relying on Git merge behavior.
+- Automated inspection proves credentials are absent from browser persistence,
+  logs, network URLs, service workers, source maps, and public artifacts.
+
+## Phase 5: Selective publication
+
+### Deliverables
+
+- Define collection publication policies and field allowlists, with notes
+  excluded unless explicitly enabled.
+- Generate accessible static collection views, JSON, RSS, and JSON Feed into a
+  separate public Pages repository.
+- Provide a local preview that uses exactly the production projection logic.
+- Add a pinned private-repository workflow that publishes through a credential
+  scoped only to the public repository.
+
+### Exit criteria
+
+- Selecting, previewing, publishing, unpublishing, and republishing a
+  collection produce deterministic artifacts.
+- Negative privacy tests scan HTML, scripts, embedded data, source maps, feeds,
+  caches, and build logs and fail on any private item or non-allowlisted field.
+- Concurrent or unresolved visibility changes remain private until a later
+  explicit owner action resolves them.
+- A public reader can browse and subscribe without JavaScript, GitHub access,
+  or a ResearchPocket account.
+
+## Phase 6: Release hardening
+
+### Deliverables
+
+- Run cross-platform upgrade, restore, offline, large-library, rate-limit,
+  browser compatibility, accessibility, and privacy test matrices.
+- Complete user and operator documentation for initialization, V1 import, PAT
+  rotation, synchronization recovery, publication, backup, and remote reset.
+- Publish versioned protocol and machine-interface compatibility guarantees.
+- Add deprecation notices to legacy repositories after equivalent V2 workflows
+  are available; archive them only after the documented parity gate passes.
+
+### Exit criteria
+
+- **Alpha:** protocol/persistence, V1 import, CLI, TUI, and local web gates pass.
+- **Beta:** GitHub synchronization, hosted owner mode, and publication gates
+  pass with recovery and privacy scenarios exercised against real test repos.
+- **GA:** all supported platforms pass, a clean-room restore drill succeeds,
+  no open P0/P1 correctness or privacy defects remain, and release docs match
+  the shipped interfaces.
+
+## GitHub Project tracking conventions
+
+- Track implementation work as repository issues attached to the `v2.0`
+  milestone and the ResearchPocket V2 project; use draft items only for ideas
+  that are not yet committed.
+- Organize work under seven epics: product governance, V1 migration, data and
+  CRDT, local experience, sync and hosted editing, publishing, and release.
+- Every actionable issue contains Context, Deliverables, Acceptance criteria,
+  Non-goals, and Dependencies. Acceptance criteria must name observable
+  behavior or a test, not only an implementation activity.
+- Set `Phase` to the roadmap phase, `Priority` to P0/P1/P2, and `Size` before an
+  issue enters Ready. Record dependency relationships in GitHub rather than
+  relying on issue-body checklists alone.
+- Use continuous flow: Backlog, Ready, In progress, In review, and Done. An
+  issue moves to In progress before repository changes, In review when its PR
+  opens, and Done only after merge plus acceptance verification.
+- Link every PR to its issue and call out protocol, privacy, migration, or
+  machine-interface changes explicitly. Such changes require their contract
+  tests and documentation in the same PR.
+- A phase is complete only when all exit criteria above have evidence linked
+  from its epic. Closing all issues is not sufficient if a release gate is
+  unverified.
+
+## Definition of done
+
+A V2 issue is Done only when its accepted behavior is implemented, tests pass
+in the required runtimes, failure and privacy cases are covered, public
+interfaces are documented, migration or recovery implications are addressed,
+and the linked PR is merged. Work that changes convergence rules additionally
+requires native/WASM compatibility fixtures and randomized multi-client tests;
+work that changes publication additionally requires negative leak tests.


### PR DESCRIPTION
## Summary

- add the canonical `AGENTS.md` engineering contract
- document V2 product use cases, boundaries, and non-goals
- define the phased V2 roadmap and CRDT-first synchronization model
- make Git transport and audit only, never the application conflict resolver

## Verification

- `cargo test --all-targets --all-features`
- whitespace scan

Closes #27
Closes #28