### PR TITLE
Add offline V2 capture and curation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,6 +1829,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.18",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]
@@ -1846,7 +1847,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "url",
  "uuid",
 ]
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,18 @@ resolver.
 
 ## Current V2 CLI
 
-The first usable V2 slice initializes a private local library, imports an existing
-V1 ResearchPocket database, lists migrated saves, and reports library status:
+The V2 CLI initializes a private local library, captures and curates saves fully
+offline, imports an existing V1 ResearchPocket database, and lists local state:
 
 ```sh
 research init
+research add https://example.com/article --tag reading
 research import v1 /path/to/v1/research.sqlite
-research status
 research list
+research edit "$ITEM_ID" --title "A better title" --favorite true
+research delete "$ITEM_ID"
+research restore "$ITEM_ID"
+research status
 ```
 
 The old Pocket-era command surface is no longer part of the shipped binary.
@@ -89,9 +93,9 @@ The complete command and output contract is in [docs/v2/CLI.md](docs/v2/CLI.md).
 
 ## Current boundary
 
-This slice is local-only. GitHub synchronization, scheduled synchronization,
-new-device restoration, hosted owner editing, TUI/local web management, and V2
-publication are not implemented yet.
+This slice is local-only. Search, GitHub synchronization, scheduled
+synchronization, new-device restoration, hosted owner editing, TUI/local web
+management, and V2 publication are not implemented yet.
 
 When synchronization lands, clients will exchange immutable CRDT update batches.
 Git commits, branches, merges, rebases, timestamps, and last-push order will never

--- a/crates/research-domain/Cargo.toml
+++ b/crates/research-domain/Cargo.toml
@@ -15,10 +15,10 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 sha2 = "0.11.0"
 thiserror = "2.0.18"
+url = "2.5.8"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "=0.2.126"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "=0.3.76"
-

--- a/crates/research-domain/src/document.rs
+++ b/crates/research-domain/src/document.rs
@@ -114,7 +114,7 @@ impl Library {
     pub fn create_item(&self, seed: &ItemSeed, operation_prefix: &str) -> DomainResult<()> {
         validate_item_id(&seed.item_id)?;
         validate_operation_prefix(operation_prefix)?;
-        validate_url(&seed.url)?;
+        validate_item_url(&seed.url)?;
         let tags = seed
             .tags
             .iter()
@@ -191,7 +191,7 @@ impl Library {
     }
 
     pub fn write_url(&self, item_id: &str, revision_id: &str, value: &str) -> DomainResult<()> {
-        validate_url(value)?;
+        validate_item_url(value)?;
         self.write_scalar(item_id, URL, revision_id, value.to_owned())
     }
 
@@ -294,12 +294,20 @@ impl Library {
         let revisions = self.lifecycle_revisions_mut(item_id)?;
         let existing = read_records::<LifecycleRevision>(&revisions)?;
         let parents = causal_heads(&existing, |revision| &revision.parents);
-        if state == LifecycleState::Active && !existing.is_empty() {
+        if !existing.is_empty() {
             let visible = lifecycle_view(existing.clone())?;
-            if visible.state != LifecycleState::Deleted {
-                return Err(DomainError::InvalidState(
-                    "restore requires an observed deleted lifecycle head".into(),
-                ));
+            match (visible.state, state) {
+                (LifecycleState::Active, LifecycleState::Active) => {
+                    return Err(DomainError::InvalidState(
+                        "restore requires an observed deleted lifecycle head".into(),
+                    ));
+                }
+                (LifecycleState::Deleted, LifecycleState::Deleted) => {
+                    return Err(DomainError::InvalidState(
+                        "delete requires an observed active lifecycle head".into(),
+                    ));
+                }
+                _ => {}
             }
         }
         let generation = parents
@@ -457,9 +465,13 @@ fn validate_operation_prefix(prefix: &str) -> DomainResult<()> {
     Ok(())
 }
 
-fn validate_url(url: &str) -> DomainResult<()> {
-    if url.trim().is_empty() {
-        return Err(DomainError::InvalidState("URL cannot be blank".into()));
+pub fn validate_item_url(url: &str) -> DomainResult<()> {
+    let parsed = url::Url::parse(url)
+        .map_err(|_| DomainError::InvalidState("URL must be an absolute HTTP(S) URL".into()))?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        return Err(DomainError::InvalidState(
+            "URL must be an absolute HTTP(S) URL".into(),
+        ));
     }
     Ok(())
 }

--- a/crates/research-domain/src/lib.rs
+++ b/crates/research-domain/src/lib.rs
@@ -7,7 +7,7 @@ mod document;
 mod envelope;
 mod projection;
 
-pub use document::{DomainError, DomainResult, ItemSeed, Library};
+pub use document::{DomainError, DomainResult, ItemSeed, Library, validate_item_url};
 pub use envelope::UpdateEnvelope;
 pub use projection::{
     CanonicalItem, CanonicalProjection, LifecycleRevision, LifecycleState, LifecycleView,

--- a/crates/research-store/Cargo.toml
+++ b/crates/research-store/Cargo.toml
@@ -15,7 +15,6 @@ sqlx = { version = "0.9.0", default-features = false, features = ["sqlite", "run
 tempfile = "3.27.0"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["fs", "sync"] }
-url = "2.5.8"
 uuid = { version = "1.23.4", features = ["serde", "v7"] }
 
 [dev-dependencies]

--- a/crates/research-store/src/error.rs
+++ b/crates/research-store/src/error.rs
@@ -26,4 +26,10 @@ pub enum StoreError {
     SourceChanged,
     #[error("a numeric value cannot be represented safely: {0}")]
     NumericRange(&'static str),
+    #[error("item {0} was not found")]
+    ItemNotFound(String),
+    #[error("the edit does not contain any changes")]
+    NoChanges,
+    #[error("invalid mutation input: {0}")]
+    InvalidInput(String),
 }

--- a/crates/research-store/src/import.rs
+++ b/crates/research-store/src/import.rs
@@ -4,7 +4,9 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use chrono::DateTime;
-use research_domain::{CanonicalProjection, ItemSeed, Library, LifecycleState};
+use research_domain::{
+    CanonicalItem, CanonicalProjection, ItemSeed, Library, LifecycleState, validate_item_url,
+};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use sqlx::sqlite::SqliteConnectOptions;
@@ -735,8 +737,7 @@ async fn commit_import(
 }
 
 fn is_supported_url(value: &str) -> bool {
-    url::Url::parse(value)
-        .is_ok_and(|url| matches!(url.scheme(), "http" | "https") && url.host_str().is_some())
+    validate_item_url(value).is_ok()
 }
 
 async fn metadata(connection: &mut SqliteConnection, key: &str) -> StoreResult<String> {
@@ -747,52 +748,61 @@ async fn metadata(connection: &mut SqliteConnection, key: &str) -> StoreResult<S
         .ok_or_else(|| StoreError::InvalidStore(format!("missing metadata key {key}")))
 }
 
-async fn persist_projection(
+pub(crate) async fn persist_projection(
     connection: &mut SqliteConnection,
     projection: &CanonicalProjection,
 ) -> StoreResult<()> {
     for (item_id, item) in &projection.items {
-        let lifecycle_state = match item.lifecycle.state {
-            LifecycleState::Active => "active",
-            LifecycleState::Deleted => "deleted",
-        };
-        let lifecycle_generation = i64::try_from(item.lifecycle.generation)
-            .map_err(|_| StoreError::NumericRange("lifecycle generation"))?;
-        sqlx::query(
-            "INSERT INTO items \
-             (item_id, url, title, excerpt, favorite, language, saved_at, note, \
-              lifecycle_state, lifecycle_generation) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
-             ON CONFLICT(item_id) DO UPDATE SET \
-             url = excluded.url, title = excluded.title, excerpt = excluded.excerpt, \
-             favorite = excluded.favorite, language = excluded.language, \
-             saved_at = excluded.saved_at, note = excluded.note, \
-             lifecycle_state = excluded.lifecycle_state, \
-             lifecycle_generation = excluded.lifecycle_generation",
-        )
+        persist_item_projection(connection, item_id, item).await?;
+    }
+    Ok(())
+}
+
+pub(crate) async fn persist_item_projection(
+    connection: &mut SqliteConnection,
+    item_id: &str,
+    item: &CanonicalItem,
+) -> StoreResult<()> {
+    let lifecycle_state = match item.lifecycle.state {
+        LifecycleState::Active => "active",
+        LifecycleState::Deleted => "deleted",
+    };
+    let lifecycle_generation = i64::try_from(item.lifecycle.generation)
+        .map_err(|_| StoreError::NumericRange("lifecycle generation"))?;
+    sqlx::query(
+        "INSERT INTO items \
+         (item_id, url, title, excerpt, favorite, language, saved_at, note, \
+          lifecycle_state, lifecycle_generation) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+         ON CONFLICT(item_id) DO UPDATE SET \
+         url = excluded.url, title = excluded.title, excerpt = excluded.excerpt, \
+         favorite = excluded.favorite, language = excluded.language, \
+         saved_at = excluded.saved_at, note = excluded.note, \
+         lifecycle_state = excluded.lifecycle_state, \
+         lifecycle_generation = excluded.lifecycle_generation",
+    )
+    .bind(item_id)
+    .bind(&item.url.value)
+    .bind(&item.title.value)
+    .bind(&item.excerpt.value)
+    .bind(item.favorite.value)
+    .bind(&item.language.value)
+    .bind(item.saved_at.value)
+    .bind(&item.note)
+    .bind(lifecycle_state)
+    .bind(lifecycle_generation)
+    .execute(&mut *connection)
+    .await?;
+    sqlx::query("DELETE FROM item_tags WHERE item_id = ?")
         .bind(item_id)
-        .bind(&item.url.value)
-        .bind(&item.title.value)
-        .bind(&item.excerpt.value)
-        .bind(item.favorite.value)
-        .bind(&item.language.value)
-        .bind(item.saved_at.value)
-        .bind(&item.note)
-        .bind(lifecycle_state)
-        .bind(lifecycle_generation)
         .execute(&mut *connection)
         .await?;
-        sqlx::query("DELETE FROM item_tags WHERE item_id = ?")
+    for tag in &item.tags {
+        sqlx::query("INSERT INTO item_tags (item_id, tag) VALUES (?, ?)")
             .bind(item_id)
+            .bind(tag)
             .execute(&mut *connection)
             .await?;
-        for tag in &item.tags {
-            sqlx::query("INSERT INTO item_tags (item_id, tag) VALUES (?, ?)")
-                .bind(item_id)
-                .bind(tag)
-                .execute(&mut *connection)
-                .await?;
-        }
     }
     Ok(())
 }

--- a/crates/research-store/src/lib.rs
+++ b/crates/research-store/src/lib.rs
@@ -3,11 +3,13 @@
 mod error;
 mod import;
 mod model;
+mod mutation;
 mod store;
 
 pub use error::{StoreError, StoreResult};
 pub use model::{
-    ImportRejection, ImportResult, ListPage, ListQuery, ListResult, SourceBundleReceipt,
-    SourceFileReceipt, StoreStatus, StoredItem,
+    CreateItemRequest, EditItemRequest, ImportRejection, ImportResult, ListPage, ListQuery,
+    ListResult, OptionalTextUpdate, SourceBundleReceipt, SourceFileReceipt, StoreStatus,
+    StoredItem,
 };
 pub use store::V2Store;

--- a/crates/research-store/src/model.rs
+++ b/crates/research-store/src/model.rs
@@ -10,6 +10,54 @@ pub struct ListQuery {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CreateItemRequest {
+    pub url: String,
+    pub title: Option<String>,
+    pub excerpt: Option<String>,
+    pub favorite: bool,
+    pub language: Option<String>,
+    /// Unix seconds. `None` captures the current time.
+    pub saved_at: Option<i64>,
+    pub note: String,
+    pub tags: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OptionalTextUpdate {
+    Set(String),
+    Clear,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct EditItemRequest {
+    pub item_id: String,
+    pub url: Option<String>,
+    pub title: Option<OptionalTextUpdate>,
+    pub excerpt: Option<OptionalTextUpdate>,
+    pub favorite: Option<bool>,
+    pub language: Option<OptionalTextUpdate>,
+    pub saved_at: Option<i64>,
+    pub note: Option<String>,
+    pub add_tags: Vec<String>,
+    pub remove_tags: Vec<String>,
+}
+
+impl EditItemRequest {
+    pub fn has_changes(&self) -> bool {
+        self.url.is_some()
+            || self.title.is_some()
+            || self.excerpt.is_some()
+            || self.favorite.is_some()
+            || self.language.is_some()
+            || self.saved_at.is_some()
+            || self.note.is_some()
+            || !self.add_tags.is_empty()
+            || !self.remove_tags.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct StoredItem {
     pub id: String,
     pub url: String,

--- a/crates/research-store/src/mutation.rs
+++ b/crates/research-store/src/mutation.rs
@@ -1,0 +1,325 @@
+use std::collections::BTreeSet;
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use research_domain::{CanonicalProjection, ItemSeed, Library, LifecycleState};
+use sqlx::{Row, SqliteConnection};
+use uuid::Uuid;
+
+use crate::import::persist_item_projection;
+use crate::store::{fresh_peer_id, now_rfc3339, sha256_hex};
+use crate::{
+    CreateItemRequest, EditItemRequest, OptionalTextUpdate, StoreError, StoreResult,
+    StoredItem, V2Store,
+};
+
+impl V2Store {
+    pub async fn create_item(&self, request: CreateItemRequest) -> StoreResult<StoredItem> {
+        let item_id = Uuid::now_v7().to_string();
+        let saved_at = request.saved_at.unwrap_or_else(|| Utc::now().timestamp());
+        validate_timestamp(saved_at)?;
+        let seed = ItemSeed {
+            item_id: item_id.clone(),
+            url: request.url,
+            title: request.title,
+            excerpt: request.excerpt,
+            favorite: request.favorite,
+            language: request.language,
+            saved_at,
+            note: request.note,
+            tags: request.tags,
+        };
+
+        self.commit_item_mutation(&item_id, move |library, projection, prefix| {
+            if projection.items.contains_key(&seed.item_id) {
+                return Err(StoreError::InvalidInput(
+                    "generated item identity already exists".into(),
+                ));
+            }
+            library.create_item(&seed, &format!("{prefix}/create"))?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn edit_item(&self, request: EditItemRequest) -> StoreResult<StoredItem> {
+        if !request.has_changes() {
+            return Err(StoreError::NoChanges);
+        }
+        if let Some(saved_at) = request.saved_at {
+            validate_timestamp(saved_at)?;
+        }
+        let has_non_note_changes = request.url.is_some()
+            || request.title.is_some()
+            || request.excerpt.is_some()
+            || request.favorite.is_some()
+            || request.language.is_some()
+            || request.saved_at.is_some()
+            || !request.add_tags.is_empty()
+            || !request.remove_tags.is_empty();
+        let add_tags = request.add_tags.iter().cloned().collect::<BTreeSet<_>>();
+        let remove_tags = request.remove_tags.iter().cloned().collect::<BTreeSet<_>>();
+        if let Some(tag) = add_tags.intersection(&remove_tags).next() {
+            return Err(StoreError::InvalidInput(format!(
+                "tag {tag:?} cannot be added and removed in one edit"
+            )));
+        }
+
+        let result_item_id = request.item_id.clone();
+        let mutation_item_id = result_item_id.clone();
+        self.commit_item_mutation(&result_item_id, move |library, projection, prefix| {
+            let current = projection
+                .items
+                .get(&mutation_item_id)
+                .ok_or_else(|| StoreError::ItemNotFound(mutation_item_id.clone()))?;
+            if request.note.as_ref() == Some(&current.note) && !has_non_note_changes {
+                return Err(StoreError::NoChanges);
+            }
+
+            if let Some(url) = &request.url {
+                library.write_url(&mutation_item_id, &format!("{prefix}/url"), url)?;
+            }
+            if let Some(title) = &request.title {
+                library.write_title(
+                    &mutation_item_id,
+                    &format!("{prefix}/title"),
+                    optional_text(title),
+                )?;
+            }
+            if let Some(excerpt) = &request.excerpt {
+                library.write_excerpt(
+                    &mutation_item_id,
+                    &format!("{prefix}/excerpt"),
+                    optional_text(excerpt),
+                )?;
+            }
+            if let Some(favorite) = request.favorite {
+                library.write_favorite(
+                    &mutation_item_id,
+                    &format!("{prefix}/favorite"),
+                    favorite,
+                )?;
+            }
+            if let Some(language) = &request.language {
+                library.write_language(
+                    &mutation_item_id,
+                    &format!("{prefix}/language"),
+                    optional_text(language),
+                )?;
+            }
+            if let Some(saved_at) = request.saved_at {
+                library.write_saved_at(
+                    &mutation_item_id,
+                    &format!("{prefix}/saved-at"),
+                    saved_at,
+                )?;
+            }
+            if let Some(note) = &request.note
+                && note != &current.note
+            {
+                let current_utf16_length = current.note.encode_utf16().count();
+                library.splice_note_utf16(&mutation_item_id, 0, current_utf16_length, note)?;
+            }
+            for tag in &remove_tags {
+                library.remove_tag(&mutation_item_id, tag)?;
+            }
+            for (index, tag) in add_tags.iter().enumerate() {
+                library.add_tag(
+                    &mutation_item_id,
+                    tag,
+                    &format!("{prefix}/tag-add/{index:020}"),
+                )?;
+            }
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn delete_item(&self, item_id: &str) -> StoreResult<StoredItem> {
+        self.transition_item(item_id, LifecycleState::Deleted).await
+    }
+
+    pub async fn restore_item(&self, item_id: &str) -> StoreResult<StoredItem> {
+        self.transition_item(item_id, LifecycleState::Active).await
+    }
+
+    async fn transition_item(
+        &self,
+        item_id: &str,
+        state: LifecycleState,
+    ) -> StoreResult<StoredItem> {
+        let result_item_id = item_id.to_owned();
+        let mutation_item_id = result_item_id.clone();
+        self.commit_item_mutation(&result_item_id, move |library, projection, prefix| {
+            if !projection.items.contains_key(&mutation_item_id) {
+                return Err(StoreError::ItemNotFound(mutation_item_id.clone()));
+            }
+            library.transition_lifecycle(
+                &mutation_item_id,
+                &format!("{prefix}/lifecycle"),
+                state,
+            )?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn commit_item_mutation<F>(&self, item_id: &str, mutate: F) -> StoreResult<StoredItem>
+    where
+        F: FnOnce(&Library, &CanonicalProjection, &str) -> StoreResult<()>,
+    {
+        let mut connection = self.pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *connection)
+            .await?;
+        let result = apply_item_mutation(&mut connection, item_id, mutate).await;
+        match result {
+            Ok(item) => {
+                sqlx::query("COMMIT").execute(&mut *connection).await?;
+                Ok(item)
+            }
+            Err(error) => {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *connection).await;
+                Err(error)
+            }
+        }
+    }
+}
+
+async fn apply_item_mutation<F>(
+    connection: &mut SqliteConnection,
+    item_id: &str,
+    mutate: F,
+) -> StoreResult<StoredItem>
+where
+    F: FnOnce(&Library, &CanonicalProjection, &str) -> StoreResult<()>,
+{
+    let library_id = metadata(connection, "library_id").await?;
+    let device_id = metadata(connection, "device_id").await?;
+    let sequence_text: String =
+        sqlx::query_scalar("SELECT next_sequence FROM devices WHERE device_id = ?")
+            .bind(&device_id)
+            .fetch_one(&mut *connection)
+            .await?;
+    let sequence = sequence_text
+        .parse::<u64>()
+        .map_err(|_| StoreError::InvalidStore("invalid device sequence".into()))?;
+    let state = sqlx::query(
+        "SELECT snapshot, snapshot_sha256 FROM canonical_state WHERE singleton = 1",
+    )
+    .fetch_one(&mut *connection)
+    .await?;
+    let snapshot: Vec<u8> = state.try_get("snapshot")?;
+    let expected_snapshot_sha256: String = state.try_get("snapshot_sha256")?;
+    if sha256_hex(&snapshot) != expected_snapshot_sha256 {
+        return Err(StoreError::InvalidStore(
+            "canonical snapshot checksum mismatch".into(),
+        ));
+    }
+
+    let library = Library::from_snapshot(&snapshot, fresh_peer_id())?;
+    let before = library.version();
+    let before_projection = library.canonical_projection()?;
+    let prefix = format!("{device_id}/{sequence_text}/mutation/{item_id}");
+    mutate(&library, &before_projection, &prefix)?;
+
+    let now = now_rfc3339();
+    let envelope = library.export_envelope(&before, &library_id, &device_id, sequence, &now)?;
+    let new_snapshot = library.export_snapshot()?;
+    let projection = library.canonical_projection()?;
+    let item = projection
+        .items
+        .get(item_id)
+        .ok_or_else(|| StoreError::ItemNotFound(item_id.to_owned()))?;
+    let stored_item = stored_item(item_id, item)?;
+
+    persist_item_projection(connection, item_id, item).await?;
+    sqlx::query(
+        "UPDATE canonical_state SET snapshot = ?, snapshot_sha256 = ?, updated_at = ? \
+         WHERE singleton = 1",
+    )
+    .bind(&new_snapshot)
+    .bind(sha256_hex(&new_snapshot))
+    .bind(&now)
+    .execute(&mut *connection)
+    .await?;
+
+    let envelope_json = serde_json::to_string(&envelope)?;
+    sqlx::query(
+        "INSERT INTO batches \
+         (device_id, sequence, payload_sha256, protocol_version, library_id, path, \
+          envelope_json, origin, applied_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'local', ?)",
+    )
+    .bind(&envelope.device_id)
+    .bind(&envelope.sequence)
+    .bind(&envelope.payload_sha256)
+    .bind(i64::from(envelope.protocol_version))
+    .bind(&envelope.library_id)
+    .bind(envelope.path())
+    .bind(envelope_json)
+    .bind(&now)
+    .execute(&mut *connection)
+    .await?;
+    sqlx::query("INSERT INTO outbox (device_id, sequence, enqueued_at) VALUES (?, ?, ?)")
+        .bind(&envelope.device_id)
+        .bind(&envelope.sequence)
+        .bind(&now)
+        .execute(&mut *connection)
+        .await?;
+    let next = sequence
+        .checked_add(1)
+        .ok_or(StoreError::NumericRange("device sequence"))?;
+    sqlx::query("UPDATE devices SET next_sequence = ? WHERE device_id = ?")
+        .bind(format!("{next:020}"))
+        .bind(&device_id)
+        .execute(&mut *connection)
+        .await?;
+
+    Ok(stored_item)
+}
+
+fn optional_text(update: &OptionalTextUpdate) -> Option<&str> {
+    match update {
+        OptionalTextUpdate::Set(value) => Some(value),
+        OptionalTextUpdate::Clear => None,
+    }
+}
+
+fn validate_timestamp(saved_at: i64) -> StoreResult<()> {
+    DateTime::<Utc>::from_timestamp(saved_at, 0)
+        .map(|_| ())
+        .ok_or_else(|| StoreError::InvalidInput("saved time is out of range".into()))
+}
+
+fn stored_item(
+    item_id: &str,
+    item: &research_domain::CanonicalItem,
+) -> StoreResult<StoredItem> {
+    let saved_at = DateTime::<Utc>::from_timestamp(item.saved_at.value, 0)
+        .ok_or_else(|| StoreError::InvalidStore("an item has an invalid timestamp".into()))?
+        .to_rfc3339_opts(SecondsFormat::Secs, true);
+    let state = match item.lifecycle.state {
+        LifecycleState::Active => "active",
+        LifecycleState::Deleted => "deleted",
+    };
+    Ok(StoredItem {
+        id: item_id.to_owned(),
+        url: item.url.value.clone(),
+        title: item.title.value.clone(),
+        excerpt: item.excerpt.value.clone(),
+        note: (!item.note.is_empty()).then(|| item.note.clone()),
+        favorite: item.favorite.value,
+        language: item.language.value.clone(),
+        saved_at,
+        tags: item.tags.clone(),
+        state: state.to_owned(),
+    })
+}
+
+async fn metadata(connection: &mut SqliteConnection, key: &str) -> StoreResult<String> {
+    sqlx::query_scalar("SELECT value FROM store_meta WHERE key = ?")
+        .bind(key)
+        .fetch_optional(&mut *connection)
+        .await?
+        .ok_or_else(|| StoreError::InvalidStore(format!("missing metadata key {key}")))
+}

--- a/crates/research-store/tests/local_mutation_contract.rs
+++ b/crates/research-store/tests/local_mutation_contract.rs
@@ -1,0 +1,126 @@
+use research_store::{
+    CreateItemRequest, EditItemRequest, ListQuery, OptionalTextUpdate, StoreError, V2Store,
+};
+
+#[tokio::test]
+async fn local_mutations_are_atomic_durable_and_lifecycle_safe() {
+    let directory = tempfile::tempdir().expect("library temp directory");
+    let library_directory = directory.path().join("library");
+    let store = V2Store::init(&library_directory)
+        .await
+        .expect("initialize store");
+
+    let first = store
+        .create_item(CreateItemRequest {
+            url: "https://example.com/shared".into(),
+            title: None,
+            excerpt: None,
+            favorite: false,
+            language: None,
+            saved_at: Some(1_700_000_000),
+            note: String::new(),
+            tags: vec!["Keep".into(), "Remove".into()],
+        })
+        .await
+        .expect("create first item");
+    assert!(first.title.is_none());
+
+    let duplicate = store
+        .create_item(CreateItemRequest {
+            url: first.url.clone(),
+            title: Some("Separate intent".into()),
+            excerpt: None,
+            favorite: false,
+            language: None,
+            saved_at: Some(1_700_000_001),
+            note: String::new(),
+            tags: Vec::new(),
+        })
+        .await
+        .expect("create duplicate URL as a distinct item");
+    assert_ne!(duplicate.id, first.id);
+
+    let edited = store
+        .edit_item(EditItemRequest {
+            item_id: first.id.clone(),
+            title: Some(OptionalTextUpdate::Set(String::new())),
+            excerpt: Some(OptionalTextUpdate::Set(String::new())),
+            favorite: Some(true),
+            language: Some(OptionalTextUpdate::Set(String::new())),
+            note: Some("human 😀 note".into()),
+            add_tags: vec!["Added".into()],
+            remove_tags: vec!["Remove".into()],
+            ..EditItemRequest::default()
+        })
+        .await
+        .expect("edit item");
+    assert_eq!(edited.title.as_deref(), Some(""));
+    assert_eq!(edited.excerpt.as_deref(), Some(""));
+    assert_eq!(edited.language.as_deref(), Some(""));
+    assert_eq!(edited.note.as_deref(), Some("human 😀 note"));
+    assert!(edited.favorite);
+    assert_eq!(edited.tags, ["Added", "Keep"]);
+
+    let no_changes = store
+        .edit_item(EditItemRequest {
+            item_id: first.id.clone(),
+            ..EditItemRequest::default()
+        })
+        .await
+        .expect_err("empty edit must fail");
+    assert!(matches!(no_changes, StoreError::NoChanges));
+
+    let deleted = store.delete_item(&first.id).await.expect("delete item");
+    assert_eq!(deleted.state, "deleted");
+    assert!(store.delete_item(&first.id).await.is_err());
+
+    let visible = store
+        .list(ListQuery {
+            limit: None,
+            ..ListQuery::default()
+        })
+        .await
+        .expect("list active items");
+    assert_eq!(visible.items.len(), 1);
+    assert_eq!(visible.items[0].id, duplicate.id);
+    let with_deleted = store
+        .list(ListQuery {
+            include_deleted: true,
+            limit: None,
+            ..ListQuery::default()
+        })
+        .await
+        .expect("list including deleted items");
+    assert_eq!(with_deleted.items.len(), 2);
+
+    let restored = store.restore_item(&first.id).await.expect("restore item");
+    assert_eq!(restored.state, "active");
+    let status = store.status().await.expect("status after mutations");
+    assert_eq!(status.active_items, 2);
+    assert_eq!(status.pending_updates, 5);
+    assert_eq!(status.next_sequence, 6);
+    drop(store);
+
+    let reopened = V2Store::open(&library_directory)
+        .await
+        .expect("reopen store");
+    let status = reopened.status().await.expect("status after restart");
+    assert_eq!(status.active_items, 2);
+    assert_eq!(status.pending_updates, 5);
+    assert_eq!(status.next_sequence, 6);
+    let persisted = reopened
+        .list(ListQuery {
+            limit: None,
+            ..ListQuery::default()
+        })
+        .await
+        .expect("list after restart");
+    let first = persisted
+        .items
+        .iter()
+        .find(|item| item.id == first.id)
+        .expect("edited item after restart");
+    assert_eq!(first.title.as_deref(), Some(""));
+    assert_eq!(first.note.as_deref(), Some("human 😀 note"));
+    assert_eq!(first.tags, ["Added", "Keep"]);
+}

--- a/docs/v2/CLI.md
+++ b/docs/v2/CLI.md
@@ -6,6 +6,10 @@ The shipped CLI is the V2 surface:
 
 ```text
 research init
+research add <URL>
+research edit <ITEM_ID>
+research delete <ITEM_ID>
+research restore <ITEM_ID>
 research import v1 <SOURCE_DB>
 research list
 research status
@@ -49,6 +53,43 @@ research init
 Initialization creates a library and device identity, applies the V2 schema, and
 prints the resolved location. It is idempotent for an existing valid V2 library.
 It refuses to overwrite a nonempty directory that is not a V2 library.
+
+## Capture
+
+```sh
+research add https://example.com/article
+research add https://example.com/article \
+  --title "Worth reading" \
+  --excerpt "Human-authored context" \
+  --tag reading,rust \
+  --favorite \
+  --note "Come back to section three"
+```
+
+Capture is immediate and makes no network request. Only the URL is required.
+Title, excerpt, language, note, favorite state, tags, and an optional original
+`--saved-at <UNIX_SECONDS>` value are stored exactly as supplied. Saving the same
+URL twice creates two distinct items.
+
+## Edit and lifecycle
+
+Use the UUID shown by `research list`:
+
+```sh
+research edit "$ITEM_ID" --title "A deliberate title" --favorite true
+research edit "$ITEM_ID" --note "" --add-tag reviewed --remove-tag reading
+research edit "$ITEM_ID" --clear-title --clear-excerpt --clear-language
+research delete "$ITEM_ID"
+research restore "$ITEM_ID"
+```
+
+`--title ""`, `--excerpt ""`, and `--language ""` store explicit empty text;
+the corresponding `--clear-*` option stores absence. Tags retain exact spelling.
+An edit may change several fields but commits as one local mutation and one
+durable outbound batch. Delete is a recoverable lifecycle transition, not
+physical erasure. Repeating delete on an already deleted item, repeating restore
+on an active item, or submitting an empty edit fails without changing local
+state or the outbox.
 
 ## Import V1
 
@@ -98,6 +139,10 @@ Human output and machine data go to stdout. Progress, warnings, and import
 diagnostics go to stderr. Machine timestamps use RFC 3339 UTC. A top-level
 `schema_version` versions CLI output independently of library and synchronization
 protocol versions.
+
+Create, edit, delete, and restore JSON output use the same materialized item
+shape as list entries, plus top-level `schema_version` and `command` fields. They
+do not expose causal revisions, CRDT bytes, or transport payloads.
 
 JSON list output has one document:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,6 +40,18 @@ pub enum Commands {
     /// Initialize a V2 library in the platform data directory
     Init,
 
+    /// Save a URL immediately without network access
+    Add(AddArgs),
+
+    /// Edit one saved item by UUID
+    Edit(EditArgs),
+
+    /// Delete one saved item without erasing its history
+    Delete(ItemIdArgs),
+
+    /// Restore one deleted item
+    Restore(ItemIdArgs),
+
     /// Import data into the V2 library
     Import {
         #[command(subcommand)]
@@ -51,6 +63,100 @@ pub enum Commands {
 
     /// Show local library, import, outbox, and sync state
     Status,
+}
+
+#[derive(Args)]
+pub struct AddArgs {
+    /// Absolute HTTP(S) URL to save
+    pub url: String,
+
+    /// Optional title; an explicit empty string remains empty
+    #[arg(long)]
+    pub title: Option<String>,
+
+    /// Optional excerpt; an explicit empty string remains empty
+    #[arg(long)]
+    pub excerpt: Option<String>,
+
+    /// Optional language; an explicit empty string remains empty
+    #[arg(long)]
+    pub language: Option<String>,
+
+    /// Mark the new save as a favorite
+    #[arg(long)]
+    pub favorite: bool,
+
+    /// Private note text
+    #[arg(long)]
+    pub note: Option<String>,
+
+    /// Exact tag text; repeat or comma-separate
+    #[arg(short, long, value_delimiter = ',', num_args = 1..)]
+    pub tag: Vec<String>,
+
+    /// Original saved time as Unix seconds; defaults to now
+    #[arg(long, value_name = "UNIX_SECONDS")]
+    pub saved_at: Option<i64>,
+}
+
+#[derive(Args)]
+pub struct EditArgs {
+    /// UUID of the saved item
+    pub item_id: String,
+
+    /// Replace the URL
+    #[arg(long)]
+    pub url: Option<String>,
+
+    /// Set the title; an explicit empty string remains empty
+    #[arg(long, conflicts_with = "clear_title")]
+    pub title: Option<String>,
+
+    /// Set the title to absent
+    #[arg(long)]
+    pub clear_title: bool,
+
+    /// Set the excerpt; an explicit empty string remains empty
+    #[arg(long, conflicts_with = "clear_excerpt")]
+    pub excerpt: Option<String>,
+
+    /// Set the excerpt to absent
+    #[arg(long)]
+    pub clear_excerpt: bool,
+
+    /// Set the language; an explicit empty string remains empty
+    #[arg(long, conflicts_with = "clear_language")]
+    pub language: Option<String>,
+
+    /// Set the language to absent
+    #[arg(long)]
+    pub clear_language: bool,
+
+    /// Set favorite state explicitly
+    #[arg(long, value_name = "BOOL")]
+    pub favorite: Option<bool>,
+
+    /// Replace the private note; pass an empty string to clear it
+    #[arg(long)]
+    pub note: Option<String>,
+
+    /// Replace the saved time using Unix seconds
+    #[arg(long, value_name = "UNIX_SECONDS")]
+    pub saved_at: Option<i64>,
+
+    /// Add exact tag text; repeat or comma-separate
+    #[arg(long, value_delimiter = ',', num_args = 1..)]
+    pub add_tag: Vec<String>,
+
+    /// Remove exact tag text; repeat or comma-separate
+    #[arg(long, value_delimiter = ',', num_args = 1..)]
+    pub remove_tag: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct ItemIdArgs {
+    /// UUID of the saved item
+    pub item_id: String,
 }
 
 #[derive(Subcommand)]

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -3,7 +3,9 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use directories::ProjectDirs;
-use research_store::{ListQuery, V2Store};
+use research_store::{
+    CreateItemRequest, EditItemRequest, ListQuery, OptionalTextUpdate, V2Store,
+};
 use serde::Serialize;
 use serde_json::{Value, json};
 
@@ -19,6 +21,54 @@ pub async fn handle(args: &CliArgs) -> CliResult<()> {
 
     match &args.command {
         Commands::Init => handle_init(&data_dir, args.format).await,
+        Commands::Add(add) => {
+            let store = V2Store::open(&data_dir).await?;
+            let item = store
+                .create_item(CreateItemRequest {
+                    url: add.url.clone(),
+                    title: add.title.clone(),
+                    excerpt: add.excerpt.clone(),
+                    favorite: add.favorite,
+                    language: add.language.clone(),
+                    saved_at: add.saved_at,
+                    note: add.note.clone().unwrap_or_default(),
+                    tags: add.tag.clone(),
+                })
+                .await?;
+            let output = command_output("add", item)?;
+            write_single(args.format, &output, human_add)
+        }
+        Commands::Edit(edit) => {
+            let store = V2Store::open(&data_dir).await?;
+            let item = store
+                .edit_item(EditItemRequest {
+                    item_id: edit.item_id.clone(),
+                    url: edit.url.clone(),
+                    title: optional_text_update(&edit.title, edit.clear_title),
+                    excerpt: optional_text_update(&edit.excerpt, edit.clear_excerpt),
+                    favorite: edit.favorite,
+                    language: optional_text_update(&edit.language, edit.clear_language),
+                    saved_at: edit.saved_at,
+                    note: edit.note.clone(),
+                    add_tags: edit.add_tag.clone(),
+                    remove_tags: edit.remove_tag.clone(),
+                })
+                .await?;
+            let output = command_output("edit", item)?;
+            write_single(args.format, &output, human_edit)
+        }
+        Commands::Delete(item) => {
+            let store = V2Store::open(&data_dir).await?;
+            let item = store.delete_item(&item.item_id).await?;
+            let output = command_output("delete", item)?;
+            write_single(args.format, &output, human_delete)
+        }
+        Commands::Restore(item) => {
+            let store = V2Store::open(&data_dir).await?;
+            let item = store.restore_item(&item.item_id).await?;
+            let output = command_output("restore", item)?;
+            write_single(args.format, &output, human_restore)
+        }
         Commands::Import {
             command: ImportCommands::V1(import),
         } => {
@@ -47,6 +97,14 @@ pub async fn handle(args: &CliArgs) -> CliResult<()> {
             write_list(args.format, &output)
         }
         Commands::Status => handle_status(&data_dir, args.format).await,
+    }
+}
+
+fn optional_text_update(value: &Option<String>, clear: bool) -> Option<OptionalTextUpdate> {
+    if clear {
+        Some(OptionalTextUpdate::Clear)
+    } else {
+        value.clone().map(OptionalTextUpdate::Set)
     }
 }
 
@@ -199,6 +257,31 @@ fn human_init(value: &Value) {
     print_string(value, "library_id", "Library");
     print_string(value, "data_dir", "Data directory");
     print_string(value, "database_path", "Database");
+}
+
+fn human_add(value: &Value) {
+    human_mutation("Saved", value);
+}
+
+fn human_edit(value: &Value) {
+    human_mutation("Updated", value);
+}
+
+fn human_delete(value: &Value) {
+    human_mutation("Deleted", value);
+}
+
+fn human_restore(value: &Value) {
+    human_mutation("Restored", value);
+}
+
+fn human_mutation(action: &str, value: &Value) {
+    println!("{action} item");
+    print_string(value, "id", "ID");
+    print_string(value, "url", "URL");
+    print_string(value, "title", "Title");
+    print_string(value, "saved_at", "Saved");
+    print_string(value, "state", "State");
 }
 
 fn human_import(value: &Value) {


### PR DESCRIPTION
## Summary

- add root V2 `add`, `edit`, `delete`, and `restore` commands
- expose typed store requests that preserve absent versus explicit-empty optional text
- validate URL rules once in the shared native/WASM domain
- atomically persist each successful domain mutation with its projection, snapshot, immutable batch, outbox entry, and sequence
- reject empty edits, invalid URLs, tag add/remove contradictions, unknown items, and repeated lifecycle transitions without changing the outbox
- document offline capture, multi-field curation, exact tags, and lifecycle behavior

## User-visible behavior

```sh
research add https://example.com/article --tag reading
research edit "$ITEM_ID" --title "A deliberate title" --favorite true
research edit "$ITEM_ID" --clear-title --add-tag reviewed
research delete "$ITEM_ID"
research restore "$ITEM_ID"
```

Capture performs no network request. Duplicate URLs remain separate UUIDv7 items. Delete remains recoverable and does not erase CRDT history.

## Protocol and privacy impact

Every successful command emits exactly one immutable Loro update batch and advances one durable device sequence in the same SQLite transaction as the canonical snapshot and changed materialized item. Failed commands roll back before any visible state or outbox change. Machine output contains only the materialized item, never causal revisions or payload bytes.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-targets --all-features`
- `cargo check --locked -p research-domain --target wasm32-unknown-unknown`
- `cargo audit --deny warnings`
- `cargo build --locked --release`
- one focused mutation contract covering offline capture, duplicate URLs, explicit-empty values, note/tag/favorite edits, failed no-op behavior, delete/restore safety, outbox counts, restart durability, and sequence continuity
- manual CLI exercise proving invalid URL rollback and JSON command behavior
- release-mode capture against a 978-item imported fixture completed in approximately 0.18 seconds

Closes #40.
