### PR TITLE
Add local full-text library search

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ research init
 research add https://example.com/article --tag reading
 research import v1 /path/to/v1/research.sqlite
 research list
+research search 'rust sqlite'
 research edit "$ITEM_ID" --title "A better title" --favorite true
 research delete "$ITEM_ID"
 research restore "$ITEM_ID"
@@ -93,9 +94,9 @@ The complete command and output contract is in [docs/v2/CLI.md](docs/v2/CLI.md).
 
 ## Current boundary
 
-This slice is local-only. Search, GitHub synchronization, scheduled
-synchronization, new-device restoration, hosted owner editing, TUI/local web
-management, and V2 publication are not implemented yet.
+This slice is local-only. GitHub synchronization, scheduled synchronization,
+new-device restoration, hosted owner editing, TUI/local web management, and V2
+publication are not implemented yet.
 
 When synchronization lands, clients will exchange immutable CRDT update batches.
 Git commits, branches, merges, rebases, timestamps, and last-push order will never

--- a/crates/research-store/migrations/0002_item_search.sql
+++ b/crates/research-store/migrations/0002_item_search.sql
@@ -1,0 +1,21 @@
+CREATE VIRTUAL TABLE item_search USING fts5(
+    item_id UNINDEXED,
+    url,
+    title,
+    excerpt,
+    note,
+    tags,
+    tokenize = 'unicode61 remove_diacritics 2'
+);
+
+INSERT INTO item_search (item_id, url, title, excerpt, note, tags)
+SELECT
+    i.item_id,
+    i.url,
+    COALESCE(i.title, ''),
+    COALESCE(i.excerpt, ''),
+    i.note,
+    COALESCE(group_concat(it.tag, ' '), '')
+FROM items i
+LEFT JOIN item_tags it ON it.item_id = i.item_id
+GROUP BY i.item_id;

--- a/crates/research-store/src/import.rs
+++ b/crates/research-store/src/import.rs
@@ -804,5 +804,21 @@ pub(crate) async fn persist_item_projection(
             .execute(&mut *connection)
             .await?;
     }
+    sqlx::query("DELETE FROM item_search WHERE item_id = ?")
+        .bind(item_id)
+        .execute(&mut *connection)
+        .await?;
+    sqlx::query(
+        "INSERT INTO item_search (item_id, url, title, excerpt, note, tags) \
+         VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(item_id)
+    .bind(&item.url.value)
+    .bind(item.title.value.as_deref().unwrap_or(""))
+    .bind(item.excerpt.value.as_deref().unwrap_or(""))
+    .bind(&item.note)
+    .bind(item.tags.join(" "))
+    .execute(&mut *connection)
+    .await?;
     Ok(())
 }

--- a/crates/research-store/src/lib.rs
+++ b/crates/research-store/src/lib.rs
@@ -9,7 +9,7 @@ mod store;
 pub use error::{StoreError, StoreResult};
 pub use model::{
     CreateItemRequest, EditItemRequest, ImportRejection, ImportResult, ListPage, ListQuery,
-    ListResult, OptionalTextUpdate, SourceBundleReceipt, SourceFileReceipt, StoreStatus,
-    StoredItem,
+    ListResult, OptionalTextUpdate, SearchQuery, SearchResult, SourceBundleReceipt,
+    SourceFileReceipt, StoreStatus, StoredItem,
 };
 pub use store::V2Store;

--- a/crates/research-store/src/model.rs
+++ b/crates/research-store/src/model.rs
@@ -84,6 +84,23 @@ pub struct ListResult {
     pub items: Vec<StoredItem>,
 }
 
+#[derive(Clone, Debug, Default)]
+pub struct SearchQuery {
+    pub text: String,
+    pub tags: Vec<String>,
+    pub favorite_only: bool,
+    pub include_deleted: bool,
+    pub limit: Option<usize>,
+    pub offset: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SearchResult {
+    pub query: String,
+    pub page: ListPage,
+    pub items: Vec<StoredItem>,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct StoreStatus {
     pub library_id: String,

--- a/crates/research-store/src/store.rs
+++ b/crates/research-store/src/store.rs
@@ -13,7 +13,8 @@ use sqlx::{Connection, FromRow, Pool, QueryBuilder, Row, Sqlite, SqliteConnectio
 use uuid::Uuid;
 
 use crate::{
-    ListPage, ListQuery, ListResult, StoreError, StoreResult, StoreStatus, StoredItem,
+    ListPage, ListQuery, ListResult, SearchQuery, SearchResult, StoreError, StoreResult,
+    StoreStatus, StoredItem,
 };
 
 const DATABASE_FILE: &str = "library.sqlite3";
@@ -138,34 +139,80 @@ impl V2Store {
             .fetch_all(&self.pool)
             .await?;
 
-        let mut items = Vec::with_capacity(rows.len());
-        for row in rows {
-            let tags = sqlx::query_scalar::<_, String>(
-                "SELECT tag FROM item_tags WHERE item_id = ? ORDER BY tag ASC",
-            )
-            .bind(&row.item_id)
-            .fetch_all(&self.pool)
-            .await?;
-            let saved_at = DateTime::<Utc>::from_timestamp(row.saved_at, 0)
-                .ok_or_else(|| {
-                    StoreError::InvalidStore("an item has an invalid timestamp".into())
-                })?
-                .to_rfc3339_opts(SecondsFormat::Secs, true);
-            items.push(StoredItem {
-                id: row.item_id,
-                url: row.url,
-                title: row.title,
-                excerpt: row.excerpt,
-                note: (!row.note.is_empty()).then_some(row.note),
-                favorite: row.favorite,
-                language: row.language,
-                saved_at,
-                tags,
-                state: row.lifecycle_state,
-            });
-        }
+        let items = self.materialize_rows(rows).await?;
 
         Ok(ListResult {
+            page: ListPage {
+                total,
+                offset: query.offset,
+                returned: items.len(),
+            },
+            items,
+        })
+    }
+
+    pub async fn search(&self, query: SearchQuery) -> StoreResult<SearchResult> {
+        let text = query.text.trim();
+        if text.is_empty() {
+            return Err(StoreError::InvalidInput(
+                "search query cannot be blank".into(),
+            ));
+        }
+        let offset =
+            i64::try_from(query.offset).map_err(|_| StoreError::NumericRange("offset"))?;
+        let limit = match query.limit {
+            Some(value) => {
+                i64::try_from(value).map_err(|_| StoreError::NumericRange("limit"))?
+            }
+            None => -1,
+        };
+
+        let mut count_builder = QueryBuilder::<Sqlite>::new(
+            "SELECT COUNT(*) FROM item_search JOIN items i \
+             ON i.item_id = item_search.item_id WHERE item_search MATCH ",
+        );
+        count_builder.push_bind(text.to_owned());
+        append_item_filters(
+            &mut count_builder,
+            &query.tags,
+            query.favorite_only,
+            query.include_deleted,
+        );
+        let total: i64 = count_builder
+            .build_query_scalar()
+            .fetch_one(&self.pool)
+            .await
+            .map_err(search_error)?;
+        let total = u64::try_from(total)
+            .map_err(|_| StoreError::NumericRange("search result count"))?;
+
+        let mut builder = QueryBuilder::<Sqlite>::new(
+            "SELECT i.item_id, i.url, i.title, i.excerpt, i.favorite, i.language, \
+             i.saved_at, i.note, i.lifecycle_state \
+             FROM item_search JOIN items i ON i.item_id = item_search.item_id \
+             WHERE item_search MATCH ",
+        );
+        builder.push_bind(text.to_owned());
+        append_item_filters(
+            &mut builder,
+            &query.tags,
+            query.favorite_only,
+            query.include_deleted,
+        );
+        builder
+            .push(" ORDER BY bm25(item_search), i.saved_at DESC, i.item_id ASC LIMIT ")
+            .push_bind(limit)
+            .push(" OFFSET ")
+            .push_bind(offset);
+        let rows = builder
+            .build_query_as::<ItemRow>()
+            .fetch_all(&self.pool)
+            .await
+            .map_err(search_error)?;
+        let items = self.materialize_rows(rows).await?;
+
+        Ok(SearchResult {
+            query: text.to_owned(),
             page: ListPage {
                 total,
                 offset: query.offset,
@@ -258,6 +305,36 @@ impl V2Store {
         let count: i64 = builder.build_query_scalar().fetch_one(&self.pool).await?;
         u64::try_from(count).map_err(|_| StoreError::NumericRange("item count"))
     }
+
+    async fn materialize_rows(&self, rows: Vec<ItemRow>) -> StoreResult<Vec<StoredItem>> {
+        let mut items = Vec::with_capacity(rows.len());
+        for row in rows {
+            let tags = sqlx::query_scalar::<_, String>(
+                "SELECT tag FROM item_tags WHERE item_id = ? ORDER BY tag ASC",
+            )
+            .bind(&row.item_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let saved_at = DateTime::<Utc>::from_timestamp(row.saved_at, 0)
+                .ok_or_else(|| {
+                    StoreError::InvalidStore("an item has an invalid timestamp".into())
+                })?
+                .to_rfc3339_opts(SecondsFormat::Secs, true);
+            items.push(StoredItem {
+                id: row.item_id,
+                url: row.url,
+                title: row.title,
+                excerpt: row.excerpt,
+                note: (!row.note.is_empty()).then_some(row.note),
+                favorite: row.favorite,
+                language: row.language,
+                saved_at,
+                tags,
+                state: row.lifecycle_state,
+            });
+        }
+        Ok(items)
+    }
 }
 
 #[derive(FromRow)]
@@ -274,18 +351,46 @@ struct ItemRow {
 }
 
 fn append_list_filters(builder: &mut QueryBuilder<Sqlite>, query: &ListQuery) {
-    if !query.include_deleted {
+    append_item_filters(
+        builder,
+        &query.tags,
+        query.favorite_only,
+        query.include_deleted,
+    );
+}
+
+fn append_item_filters(
+    builder: &mut QueryBuilder<Sqlite>,
+    tags: &[String],
+    favorite_only: bool,
+    include_deleted: bool,
+) {
+    if !include_deleted {
         builder.push(" AND i.lifecycle_state = 'active'");
     }
-    if query.favorite_only {
+    if favorite_only {
         builder.push(" AND i.favorite = 1");
     }
-    for tag in &query.tags {
+    for tag in tags {
         builder
             .push(" AND EXISTS (SELECT 1 FROM item_tags it WHERE it.item_id = i.item_id AND it.tag = ")
             .push_bind(tag.clone())
             .push(")");
     }
+}
+
+fn search_error(error: sqlx::Error) -> StoreError {
+    if let sqlx::Error::Database(database) = &error {
+        let message = database.message().to_ascii_lowercase();
+        if message.contains("fts5:")
+            || message.contains("malformed match")
+            || message.contains("unterminated string")
+            || message.contains("syntax error")
+        {
+            return StoreError::InvalidInput("invalid full-text search query".into());
+        }
+    }
+    StoreError::Sqlite(error)
 }
 
 async fn connect(database_path: &Path, create: bool) -> StoreResult<Pool<Sqlite>> {

--- a/crates/research-store/tests/local_mutation_contract.rs
+++ b/crates/research-store/tests/local_mutation_contract.rs
@@ -1,5 +1,6 @@
 use research_store::{
-    CreateItemRequest, EditItemRequest, ListQuery, OptionalTextUpdate, StoreError, V2Store,
+    CreateItemRequest, EditItemRequest, ListQuery, OptionalTextUpdate, SearchQuery, StoreError,
+    V2Store,
 };
 
 #[tokio::test]
@@ -60,6 +61,28 @@ async fn local_mutations_are_atomic_durable_and_lifecycle_safe() {
     assert_eq!(edited.note.as_deref(), Some("human 😀 note"));
     assert!(edited.favorite);
     assert_eq!(edited.tags, ["Added", "Keep"]);
+    let search = store
+        .search(SearchQuery {
+            text: "human".into(),
+            limit: None,
+            ..SearchQuery::default()
+        })
+        .await
+        .expect("search edited note");
+    assert_eq!(search.items.len(), 1);
+    assert_eq!(search.items[0].id, first.id);
+    assert!(
+        store
+            .search(SearchQuery {
+                text: "Remove".into(),
+                limit: None,
+                ..SearchQuery::default()
+            })
+            .await
+            .expect("search removed tag")
+            .items
+            .is_empty()
+    );
 
     let no_changes = store
         .edit_item(EditItemRequest {
@@ -83,6 +106,32 @@ async fn local_mutations_are_atomic_durable_and_lifecycle_safe() {
         .expect("list active items");
     assert_eq!(visible.items.len(), 1);
     assert_eq!(visible.items[0].id, duplicate.id);
+    assert!(
+        store
+            .search(SearchQuery {
+                text: "human".into(),
+                limit: None,
+                ..SearchQuery::default()
+            })
+            .await
+            .expect("search hides deleted item")
+            .items
+            .is_empty()
+    );
+    assert_eq!(
+        store
+            .search(SearchQuery {
+                text: "human".into(),
+                include_deleted: true,
+                limit: None,
+                ..SearchQuery::default()
+            })
+            .await
+            .expect("search includes deleted item")
+            .items
+            .len(),
+        1
+    );
     let with_deleted = store
         .list(ListQuery {
             include_deleted: true,
@@ -95,10 +144,43 @@ async fn local_mutations_are_atomic_durable_and_lifecycle_safe() {
 
     let restored = store.restore_item(&first.id).await.expect("restore item");
     assert_eq!(restored.state, "active");
+    assert_eq!(
+        store
+            .search(SearchQuery {
+                text: "human".into(),
+                limit: None,
+                ..SearchQuery::default()
+            })
+            .await
+            .expect("search restored item")
+            .items
+            .len(),
+        1
+    );
     let status = store.status().await.expect("status after mutations");
     assert_eq!(status.active_items, 2);
     assert_eq!(status.pending_updates, 5);
     assert_eq!(status.next_sequence, 6);
+    assert!(matches!(
+        store
+            .search(SearchQuery {
+                text: "   ".into(),
+                ..SearchQuery::default()
+            })
+            .await
+            .expect_err("blank search must fail"),
+        StoreError::InvalidInput(_)
+    ));
+    assert!(matches!(
+        store
+            .search(SearchQuery {
+                text: "\"".into(),
+                ..SearchQuery::default()
+            })
+            .await
+            .expect_err("invalid FTS syntax must fail"),
+        StoreError::InvalidInput(_)
+    ));
     drop(store);
 
     let reopened = V2Store::open(&library_directory)

--- a/docs/v2/CLI.md
+++ b/docs/v2/CLI.md
@@ -12,6 +12,7 @@ research delete <ITEM_ID>
 research restore <ITEM_ID>
 research import v1 <SOURCE_DB>
 research list
+research search <QUERY>
 research status
 ```
 
@@ -122,6 +123,27 @@ contain every requested tag.
 The human view is compact. JSON and NDJSON expose materialized item fields but
 never raw CRDT containers, causal revisions, update payloads, or credentials.
 
+## Search
+
+```sh
+research search rust
+research search 'rust sqlite' --favorite-only
+research search 'local*' --tags research --limit 20
+research search '"exact phrase"' --include-deleted
+```
+
+Search is entirely local and covers URL, title, excerpt, private note text, and
+tags through the rebuildable SQLite FTS5 projection. Space-separated terms use
+FTS AND semantics; quoted phrases and `*` prefix queries are supported. Exact tag
+filters are applied in addition to the full-text query. Results rank by FTS
+relevance, then saved time descending and item ID ascending. Deleted items remain
+hidden unless `--include-deleted` is supplied.
+
+Opening a library created before the search migration builds its index from the
+existing materialized items. Create, import, and edit transactions update the
+index atomically; a failed or read-only search never changes the canonical state,
+outbox, or device sequence. Invalid query syntax returns a sanitized input error.
+
 ## Status
 
 ```sh
@@ -175,6 +197,10 @@ line:
 {"schema_version":1,"type":"list_page","total":1,"offset":0,"returned":1}
 {"schema_version":1,"type":"item","item":{"id":"019...","url":"https://example.com"}}
 ```
+
+JSON search output adds the normalized `query` beside the same `page` and
+`items` fields. NDJSON uses a `search_page` first record containing that query,
+followed by the same item records.
 
 Do not parse human output in integrations. The JSON and NDJSON schemas are the
 machine interfaces and require an explicit compatibility plan before a breaking

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,9 @@ pub enum Commands {
     /// List saves in the V2 library
     List(ListArgs),
 
+    /// Search URLs, authored fields, private notes, and tags
+    Search(SearchArgs),
+
     /// Show local library, import, outbox, and sync state
     Status,
 }
@@ -202,6 +205,15 @@ pub struct ListArgs {
     /// Skip this many matching items
     #[arg(long, default_value_t = 0)]
     pub offset: usize,
+}
+
+#[derive(Args)]
+pub struct SearchArgs {
+    /// SQLite FTS5 query
+    pub query: String,
+
+    #[command(flatten)]
+    pub filters: ListArgs,
 }
 
 #[derive(Clone, Copy, Debug, Default, ValueEnum)]

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use directories::ProjectDirs;
 use research_store::{
-    CreateItemRequest, EditItemRequest, ListQuery, OptionalTextUpdate, V2Store,
+    CreateItemRequest, EditItemRequest, ListQuery, OptionalTextUpdate, SearchQuery, V2Store,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -95,6 +95,26 @@ pub async fn handle(args: &CliArgs) -> CliResult<()> {
                 .await?;
             let output = command_output("list", result)?;
             write_list(args.format, &output)
+        }
+        Commands::Search(search) => {
+            let store = V2Store::open(&data_dir).await?;
+            let filters = &search.filters;
+            let result = store
+                .search(SearchQuery {
+                    text: search.query.clone(),
+                    tags: filters.tags.clone(),
+                    favorite_only: filters.favorite_only,
+                    include_deleted: filters.include_deleted,
+                    limit: if filters.all {
+                        None
+                    } else {
+                        Some(filters.limit.unwrap_or(50))
+                    },
+                    offset: filters.offset,
+                })
+                .await?;
+            let output = command_output("search", result)?;
+            write_search(args.format, &output)
         }
         Commands::Status => handle_status(&data_dir, args.format).await,
     }
@@ -195,8 +215,16 @@ fn write_single(format: OutputFormat, value: &Value, human: fn(&Value)) -> CliRe
 }
 
 fn write_list(format: OutputFormat, value: &Value) -> CliResult<()> {
+    write_items(format, value, human_list)
+}
+
+fn write_search(format: OutputFormat, value: &Value) -> CliResult<()> {
+    write_items(format, value, human_search)
+}
+
+fn write_items(format: OutputFormat, value: &Value, human: fn(&Value)) -> CliResult<()> {
     match format {
-        OutputFormat::Human => human_list(value),
+        OutputFormat::Human => human(value),
         OutputFormat::Json => write_json(value, true)?,
         OutputFormat::Ndjson => {
             let object = value
@@ -206,13 +234,21 @@ fn write_list(format: OutputFormat, value: &Value) -> CliResult<()> {
                 .get("items")
                 .and_then(Value::as_array)
                 .ok_or_else(|| io::Error::other("V2 list output has no items array"))?;
-            let page = json!({
+            let page_type = if value.get("query").is_some() {
+                "search_page"
+            } else {
+                "list_page"
+            };
+            let mut page = json!({
                 "schema_version": OUTPUT_SCHEMA_VERSION,
-                "type": "list_page",
+                "type": page_type,
                 "total": value.pointer("/page/total").cloned().unwrap_or(Value::from(items.len())),
                 "offset": value.pointer("/page/offset").cloned().unwrap_or(Value::from(0)),
                 "returned": value.pointer("/page/returned").cloned().unwrap_or(Value::from(items.len()))
             });
+            if let Some(query) = value.get("query") {
+                page["query"] = query.clone();
+            }
             write_json(&page, false)?;
             for item in items {
                 write_json(
@@ -372,6 +408,13 @@ fn human_list(value: &Value) {
             println!("  state: deleted");
         }
     }
+}
+
+fn human_search(value: &Value) {
+    if let Some(query) = value.get("query").and_then(Value::as_str) {
+        println!("Search: {query}");
+    }
+    human_list(value);
 }
 
 fn report_rejections(value: &Value) {


### PR DESCRIPTION
## Summary

- add a forward SQLite FTS5 migration that rebuilds existing V2 libraries
- index URL, title, excerpt, private note text, and tags from the materialized projection
- keep the search projection atomic with V1 import and every local item mutation
- add root `research search <QUERY>` with tag, favorite, lifecycle, limit, all, and offset filters
- add deterministic relevance/saved-time/item-ID ordering and human/JSON/NDJSON output
- sanitize blank and malformed FTS queries without changing canonical state or the outbox

## User-visible behavior

```sh
research search rust
research search 'rust sqlite' --favorite-only
research search 'local*' --tags research --limit 20
research search '"exact phrase"' --include-deleted
```

Search remains fully local. Space-separated terms use FTS AND semantics; quoted phrases and prefix queries are supported.

## Privacy and persistence

The FTS table is a rebuildable private projection inside local `library.sqlite3`; it is not protocol or publication state. Search output uses the existing materialized item allowlist and never exposes CRDT revisions, update payloads, credentials, or import provenance. Reads do not advance the device sequence or touch the outbox.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-targets --all-features`
- `cargo check --locked -p research-domain --target wasm32-unknown-unknown`
- `cargo audit --deny warnings`
- `cargo build --locked --release`
- extended the existing local mutation contract (no new test file) to cover note/tag index freshness, deleted/restore filtering, blank input, and malformed FTS syntax
- upgraded a private copy of the pre-search 978-item library: 978 FTS rows rebuilt, `http*` returned 978 items, and pending outbox/next sequence remained 1/2

Closes #42.
