### PR TITLE
Ship durable private GitHub synchronization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -86,7 +86,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -146,10 +146,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "base64"
@@ -219,11 +248,13 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -232,6 +263,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -297,6 +334,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +364,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +387,26 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -512,7 +588,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -531,6 +607,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -552,6 +634,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "ensure-cov"
@@ -608,7 +699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -618,7 +709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -675,6 +766,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -818,9 +915,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -938,12 +1056,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1105,6 +1323,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1357,65 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1370,6 +1653,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1699,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minicov"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,7 +1722,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1442,7 +1737,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1535,6 +1830,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -1694,6 +1995,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +2120,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,14 +2175,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "research"
 version = "0.1.22"
 dependencies = [
+ "base64",
+ "chrono",
  "clap",
  "directories",
+ "reqwest",
+ "research-domain",
  "research-store",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -1851,6 +2263,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,7 +2301,82 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1894,6 +2395,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,6 +2414,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2028,6 +2561,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,7 +2618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2264,6 +2823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2286,6 +2851,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,6 +2868,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2306,7 +2901,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2351,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -2370,9 +2965,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2393,9 +2988,10 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2410,6 +3006,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,6 +3025,64 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2483,6 +3147,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2526,6 +3196,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2589,6 +3265,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -2701,6 +3386,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31d56021e873866c968588ed85ccdf56db5c426e44afdb4618c39895104b920"
 
 [[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "whoami"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2712,7 +3426,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2757,6 +3471,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2776,12 +3501,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -2870,6 +3668,12 @@ dependencies = [
  "syn 2.0.118",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,14 @@ members = [".", "crates/research-domain", "crates/research-store"]
 resolver = "2"
 
 [dependencies]
+base64 = "0.22.1"
+chrono = { version = "0.4.45", default-features = false, features = ["std"] }
 clap = { version = "4.6.1", features = ["cargo", "env", "derive"] }
 directories = "6.0.0"
+reqwest = { version = "0.13.4", features = ["json"] }
+research-domain = { path = "crates/research-domain" }
 research-store = { path = "crates/research-store" }
 serde = "1.0.228"
 serde_json = "1.0.150"
-tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros"] }
+thiserror = "2.0.18"
+tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "signal", "time"] }

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 ResearchPocket is a URL-first, local-first personal library. V2 keeps saves under
 your control, supports deliberate human organization, and uses application-level
-CRDT convergence so Git can remain storage and transport rather than a conflict
-resolver.
+CRDT convergence so a private GitHub repository can remain storage and transport
+rather than a conflict resolver.
 
 ## Current V2 CLI
 
 The V2 CLI initializes a private local library, captures and curates saves fully
-offline, imports an existing V1 ResearchPocket database, and lists local state:
+offline, imports an existing V1 ResearchPocket database, searches local state,
+and synchronizes immutable updates through a private GitHub repository:
 
 ```sh
 research init
@@ -19,6 +20,8 @@ research search 'rust sqlite'
 research edit "$ITEM_ID" --title "A better title" --favorite true
 research delete "$ITEM_ID"
 research restore "$ITEM_ID"
+research sync connect OWNER/PRIVATE_REPOSITORY
+research sync run
 research status
 ```
 
@@ -75,6 +78,31 @@ research list --limit 20
 See the [migration guide](docs/v2/MIGRATION.md) for preservation and recovery
 details.
 
+## Synchronize privately without a backend
+
+Create an empty private GitHub repository and a fine-grained PAT limited to that
+repository with `Contents: read/write` and an expiry of at most 90 days. Keep the
+PAT out of shell history by providing it through the process environment:
+
+```sh
+export RESEARCHPOCKET_GITHUB_TOKEN='github_pat_...'
+research sync connect OWNER/PRIVATE_REPOSITORY
+research sync run
+```
+
+The first command creates immutable protocol genesis, drains the durable outbox,
+and verifies the final remote state. For another device, run `research init` in
+a fresh data directory and connect it to the same repository; a pristine device
+adopts the remote library identity and rebuilds its local database while keeping
+a unique device identity.
+
+`research sync run --every 60` provides an optional foreground periodic loop.
+Network, rate-limit, server, and branch-head failures retain the exact queued
+updates for retry. Git commits and their order never choose field values, and
+the CLI never asks you to merge or rebase saves. See the complete
+[CLI workflow](docs/v2/CLI.md#private-github-synchronization) and
+[sync protocol](docs/v2/SYNC_PROTOCOL.md).
+
 ## Human and machine output
 
 Every command accepts `--format human|json|ndjson`. Options are global and may be
@@ -94,13 +122,14 @@ The complete command and output contract is in [docs/v2/CLI.md](docs/v2/CLI.md).
 
 ## Current boundary
 
-This slice is local-only. GitHub synchronization, scheduled synchronization,
-new-device restoration, hosted owner editing, TUI/local web management, and V2
-publication are not implemented yet.
+The CLI now supports private GitHub synchronization, new-device restoration, and
+an optional foreground periodic loop. Hosted owner editing, installed background
+scheduling, checkpoints, TUI/local web management, and V2 publication are not
+implemented yet.
 
-When synchronization lands, clients will exchange immutable CRDT update batches.
-Git commits, branches, merges, rebases, timestamps, and last-push order will never
-choose application values or require the owner to resolve library conflicts.
+Clients exchange immutable CRDT update batches. Git commits, branches, merges,
+rebases, timestamps, and last-push order never choose application values or
+require the owner to resolve library conflicts.
 
 ## Development
 

--- a/crates/research-domain/src/document.rs
+++ b/crates/research-domain/src/document.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 use crate::{
     CanonicalItem, CanonicalProjection, LifecycleRevision, LifecycleState, ScalarRevision,
     ScalarView, UpdateEnvelope,
+    identity::validate_uuid_v7,
     projection::{causal_heads, lifecycle_view, scalar_view},
 };
 
@@ -347,16 +348,18 @@ impl Library {
             .doc
             .export(ExportMode::updates(from))
             .map_err(loro_error)?;
-        Ok(UpdateEnvelope::new(
-            library_id, device_id, sequence, from, created_at, &update,
-        ))
+        UpdateEnvelope::new(library_id, device_id, sequence, from, created_at, &update)
     }
 
     pub fn import_envelope(&self, envelope: &UpdateEnvelope) -> DomainResult<()> {
+        self.import_envelope_has_pending(envelope).map(|_| ())
+    }
+
+    pub fn import_envelope_has_pending(&self, envelope: &UpdateEnvelope) -> DomainResult<bool> {
         let payload = envelope.verified_payload()?;
         LoroDoc::decode_import_blob_meta(&payload, true).map_err(loro_error)?;
-        self.doc.import(&payload).map_err(loro_error)?;
-        Ok(())
+        let status = self.doc.import(&payload).map_err(loro_error)?;
+        Ok(status.pending.is_some())
     }
 
     pub fn canonical_projection(&self) -> DomainResult<CanonicalProjection> {
@@ -441,25 +444,7 @@ fn loro_error(error: impl std::fmt::Display) -> DomainError {
 }
 
 fn validate_item_id(item_id: &str) -> DomainResult<()> {
-    let bytes = item_id.as_bytes();
-    let valid = bytes.len() == 36
-        && bytes[8] == b'-'
-        && bytes[13] == b'-'
-        && bytes[14] == b'7'
-        && bytes[18] == b'-'
-        && matches!(bytes[19], b'8' | b'9' | b'a' | b'b')
-        && bytes[23] == b'-'
-        && bytes.iter().enumerate().all(|(index, byte)| {
-            matches!(index, 8 | 13 | 18 | 23)
-                || byte.is_ascii_digit()
-                || matches!(byte, b'a'..=b'f')
-        });
-    if !valid {
-        return Err(DomainError::InvalidState(format!(
-            "item ID {item_id:?} is not a canonical lowercase UUIDv7"
-        )));
-    }
-    Ok(())
+    validate_uuid_v7(item_id, "item ID")
 }
 
 fn validate_operation_prefix(prefix: &str) -> DomainResult<()> {

--- a/crates/research-domain/src/envelope.rs
+++ b/crates/research-domain/src/envelope.rs
@@ -5,7 +5,7 @@ use loro::VersionVector;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::{DomainError, DomainResult};
+use crate::{DomainError, DomainResult, identity::validate_uuid_v7};
 
 pub const PROTOCOL_VERSION: u8 = 1;
 pub const DOMAIN_SCHEMA_VERSION: u16 = 2;
@@ -43,12 +43,12 @@ impl UpdateEnvelope {
         causal_frontier: &VersionVector,
         created_at: &str,
         update: &[u8],
-    ) -> Self {
+    ) -> DomainResult<Self> {
         let causal_frontier = causal_frontier
             .iter()
             .map(|(peer, counter)| (peer.to_string(), *counter))
             .collect();
-        Self {
+        let envelope = Self {
             protocol_version: PROTOCOL_VERSION,
             domain_schema_version: DOMAIN_SCHEMA_VERSION,
             loro_codec: LORO_CODEC.to_owned(),
@@ -62,14 +62,61 @@ impl UpdateEnvelope {
             created_at: created_at.to_owned(),
             payload: STANDARD.encode(update),
             payload_sha256: sha256_hex(update),
-        }
+        };
+        envelope.validate_identity(library_id, &envelope.path())?;
+        Ok(envelope)
     }
 
     pub fn path(&self) -> String {
         format!("sync/v1/ops/{}/{}.json", self.device_id, self.sequence)
     }
 
+    pub fn validate_identity(&self, expected_library_id: &str, path: &str) -> DomainResult<()> {
+        validate_uuid_v7(&self.library_id, "library ID")?;
+        validate_uuid_v7(&self.device_id, "device ID")?;
+        validate_uuid_v7(expected_library_id, "expected library ID")?;
+        if self.library_id != expected_library_id {
+            return Err(DomainError::Integrity {
+                path: path.to_owned(),
+                expected: expected_library_id.to_owned(),
+                actual: self.library_id.clone(),
+            });
+        }
+        let valid_sequence = self.sequence.len() == 20
+            && self.sequence.bytes().all(|byte| byte.is_ascii_digit())
+            && self.sequence != "00000000000000000000"
+            && self.sequence.parse::<u64>().is_ok();
+        if !valid_sequence {
+            return Err(DomainError::InvalidState(format!(
+                "batch sequence {:?} is not a nonzero fixed-width decimal",
+                self.sequence
+            )));
+        }
+        let expected_path = self.path();
+        if path != expected_path {
+            return Err(DomainError::Integrity {
+                path: path.to_owned(),
+                expected: expected_path,
+                actual: path.to_owned(),
+            });
+        }
+        if self.created_at.trim().is_empty() {
+            return Err(DomainError::InvalidState(
+                "envelope creation time cannot be blank".into(),
+            ));
+        }
+        for (peer, counter) in &self.causal_frontier {
+            if peer.parse::<u64>().is_err() || *counter < 0 {
+                return Err(DomainError::InvalidState(format!(
+                    "invalid causal frontier entry {peer:?}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) fn verified_payload(&self) -> DomainResult<Vec<u8>> {
+        self.validate_identity(&self.library_id, &self.path())?;
         if self.protocol_version != PROTOCOL_VERSION {
             return Err(DomainError::UnsupportedProtocol(self.protocol_version));
         }

--- a/crates/research-domain/src/genesis.rs
+++ b/crates/research-domain/src/genesis.rs
@@ -1,0 +1,66 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    DOMAIN_SCHEMA_VERSION, DomainError, DomainResult, LORO_CODEC, PROTOCOL_VERSION,
+    identity::validate_uuid_v7,
+};
+
+pub const SYNC_FORMAT: &str = "researchpocket-sync";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LibraryGenesis {
+    pub format: String,
+    pub protocol_version: u8,
+    pub domain_schema_version: u16,
+    pub loro_codec: String,
+    pub required_features: Vec<String>,
+    pub library_id: String,
+    pub created_at: String,
+}
+
+impl LibraryGenesis {
+    pub fn new(library_id: &str, created_at: &str) -> DomainResult<Self> {
+        let genesis = Self {
+            format: SYNC_FORMAT.to_owned(),
+            protocol_version: PROTOCOL_VERSION,
+            domain_schema_version: DOMAIN_SCHEMA_VERSION,
+            loro_codec: LORO_CODEC.to_owned(),
+            required_features: Vec::new(),
+            library_id: library_id.to_owned(),
+            created_at: created_at.to_owned(),
+        };
+        genesis.validate()?;
+        Ok(genesis)
+    }
+
+    pub fn validate(&self) -> DomainResult<()> {
+        if self.format != SYNC_FORMAT {
+            return Err(DomainError::InvalidState(format!(
+                "unsupported synchronization format {:?}",
+                self.format
+            )));
+        }
+        if self.protocol_version != PROTOCOL_VERSION {
+            return Err(DomainError::UnsupportedProtocol(self.protocol_version));
+        }
+        if self.domain_schema_version != DOMAIN_SCHEMA_VERSION {
+            return Err(DomainError::UnsupportedDomainSchema(
+                self.domain_schema_version,
+            ));
+        }
+        if self.loro_codec != LORO_CODEC {
+            return Err(DomainError::UnsupportedCodec(self.loro_codec.clone()));
+        }
+        if let Some(feature) = self.required_features.first() {
+            return Err(DomainError::UnsupportedFeature(feature.clone()));
+        }
+        validate_uuid_v7(&self.library_id, "library ID")?;
+        if self.created_at.trim().is_empty() {
+            return Err(DomainError::InvalidState(
+                "genesis creation time cannot be blank".into(),
+            ));
+        }
+        Ok(())
+    }
+}

--- a/crates/research-domain/src/identity.rs
+++ b/crates/research-domain/src/identity.rs
@@ -1,0 +1,23 @@
+use crate::{DomainError, DomainResult};
+
+pub(crate) fn validate_uuid_v7(value: &str, label: &str) -> DomainResult<()> {
+    let bytes = value.as_bytes();
+    let valid = bytes.len() == 36
+        && bytes[8] == b'-'
+        && bytes[13] == b'-'
+        && bytes[14] == b'7'
+        && bytes[18] == b'-'
+        && matches!(bytes[19], b'8' | b'9' | b'a' | b'b')
+        && bytes[23] == b'-'
+        && bytes.iter().enumerate().all(|(index, byte)| {
+            matches!(index, 8 | 13 | 18 | 23)
+                || byte.is_ascii_digit()
+                || matches!(byte, b'a'..=b'f')
+        });
+    if !valid {
+        return Err(DomainError::InvalidState(format!(
+            "{label} {value:?} is not a canonical lowercase UUIDv7"
+        )));
+    }
+    Ok(())
+}

--- a/crates/research-domain/src/lib.rs
+++ b/crates/research-domain/src/lib.rs
@@ -5,16 +5,20 @@
 
 mod document;
 mod envelope;
+mod genesis;
+mod identity;
 mod projection;
 
 pub use document::{DomainError, DomainResult, ItemSeed, Library, validate_item_url};
 pub use envelope::{DOMAIN_SCHEMA_VERSION, LORO_CODEC, PROTOCOL_VERSION, UpdateEnvelope};
+pub use genesis::{LibraryGenesis, SYNC_FORMAT};
 pub use projection::{
     CanonicalItem, CanonicalProjection, LifecycleRevision, LifecycleState, LifecycleView,
     ScalarRevision, ScalarView,
 };
 
 const ITEM_ID: &str = "0197f2b5-93d7-7ad4-8c67-21e98f0c7341";
+const LIBRARY_ID: &str = "00000000-0000-7000-8000-000000000001";
 const BASE_OPERATION_PREFIX: &str = "device-base/00000000000000000001";
 const ALICE_TITLE_REVISION: &str = "device-alice/00000000000000000001";
 const BOB_TITLE_REVISION: &str = "device-bob/00000000000000000001";
@@ -50,7 +54,7 @@ pub fn run_convergence_scenario() -> DomainResult<String> {
     let base = Library::from_snapshot(&base_snapshot, 111)?;
     let base_envelope = base.export_envelope(
         &base_before,
-        "library-fixture",
+        LIBRARY_ID,
         "00000000-0000-7000-8000-000000000101",
         1,
         "2026-07-10T00:00:00Z",
@@ -128,7 +132,7 @@ pub fn run_convergence_scenario() -> DomainResult<String> {
     alice.transition_lifecycle(ITEM_ID, ALICE_RESTORE_REVISION, LifecycleState::Active)?;
     let alice_envelope = alice.export_envelope(
         &alice_before,
-        "library-fixture",
+        LIBRARY_ID,
         "00000000-0000-7000-8000-000000000202",
         1,
         "2026-07-10T00:00:01Z",
@@ -144,7 +148,7 @@ pub fn run_convergence_scenario() -> DomainResult<String> {
     bob.transition_lifecycle(ITEM_ID, BOB_DELETE_REVISION, LifecycleState::Deleted)?;
     let bob_envelope = bob.export_envelope(
         &bob_before,
-        "library-fixture",
+        LIBRARY_ID,
         "00000000-0000-7000-8000-000000000303",
         1,
         "2026-07-10T00:00:02Z",
@@ -202,7 +206,7 @@ pub fn run_convergence_scenario() -> DomainResult<String> {
     merged.transition_lifecycle(ITEM_ID, FINAL_RESTORE_REVISION, LifecycleState::Active)?;
     let final_envelope = merged.export_envelope(
         &final_before,
-        "library-fixture",
+        LIBRARY_ID,
         "00000000-0000-7000-8000-000000000404",
         1,
         "2026-07-10T00:00:03Z",

--- a/crates/research-store/migrations/0003_sync_state.sql
+++ b/crates/research-store/migrations/0003_sync_state.sql
@@ -1,0 +1,23 @@
+CREATE TABLE sync_config (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    repository_owner TEXT NOT NULL CHECK (length(repository_owner) > 0),
+    repository_name TEXT NOT NULL CHECK (length(repository_name) > 0),
+    branch TEXT NOT NULL CHECK (length(branch) > 0),
+    configured_at TEXT NOT NULL,
+    last_success_at TEXT,
+    last_error_kind TEXT,
+    last_error_at TEXT
+);
+
+CREATE TABLE remote_observations (
+    path TEXT PRIMARY KEY,
+    blob_sha TEXT NOT NULL CHECK (length(blob_sha) IN (40, 64)),
+    observed_at TEXT NOT NULL
+);
+
+CREATE TABLE deferred_batches (
+    device_id TEXT NOT NULL,
+    sequence TEXT NOT NULL,
+    PRIMARY KEY (device_id, sequence),
+    FOREIGN KEY (device_id, sequence) REFERENCES batches(device_id, sequence) ON DELETE CASCADE
+);

--- a/crates/research-store/src/error.rs
+++ b/crates/research-store/src/error.rs
@@ -32,4 +32,10 @@ pub enum StoreError {
     NoChanges,
     #[error("invalid mutation input: {0}")]
     InvalidInput(String),
+    #[error("synchronization is not configured")]
+    SyncNotConfigured,
+    #[error("cannot adopt remote library {0}: the local library is not pristine")]
+    SyncLibraryMismatch(String),
+    #[error("synchronization integrity failure: {0}")]
+    SyncIntegrity(String),
 }

--- a/crates/research-store/src/lib.rs
+++ b/crates/research-store/src/lib.rs
@@ -5,11 +5,13 @@ mod import;
 mod model;
 mod mutation;
 mod store;
+mod sync;
 
 pub use error::{StoreError, StoreResult};
 pub use model::{
     CreateItemRequest, EditItemRequest, ImportRejection, ImportResult, ListPage, ListQuery,
-    ListResult, OptionalTextUpdate, SearchQuery, SearchResult, SourceBundleReceipt,
-    SourceFileReceipt, StoreStatus, StoredItem,
+    ListResult, OptionalTextUpdate, PendingBatch, RemoteBatchDisposition, RemoteBatchResult,
+    SearchQuery, SearchResult, SourceBundleReceipt, SourceFileReceipt, StoreStatus, StoredItem,
+    SyncConfiguration, SyncIdentity,
 };
 pub use store::V2Store;

--- a/crates/research-store/src/model.rs
+++ b/crates/research-store/src/model.rs
@@ -108,10 +108,51 @@ pub struct StoreStatus {
     pub active_items: u64,
     pub deleted_items: u64,
     pub pending_updates: u64,
+    pub deferred_updates: u64,
     pub imported_items: u64,
     pub import_sources: u64,
     pub next_sequence: u64,
     pub sync_state: String,
+    pub sync_remote: Option<SyncConfiguration>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SyncConfiguration {
+    pub owner: String,
+    pub repository: String,
+    pub branch: String,
+    pub configured_at: String,
+    pub last_success_at: Option<String>,
+    pub last_error_kind: Option<String>,
+    pub last_error_at: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SyncIdentity {
+    pub library_id: String,
+    pub device_id: String,
+    pub pristine: bool,
+}
+
+pub struct PendingBatch {
+    pub device_id: String,
+    pub sequence: String,
+    pub path: String,
+    pub payload_sha256: String,
+    pub envelope_json: String,
+    pub attempts: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RemoteBatchDisposition {
+    Applied,
+    AlreadyApplied,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RemoteBatchResult {
+    pub disposition: RemoteBatchDisposition,
+    pub acknowledged_outbox: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/research-store/src/store.rs
+++ b/crates/research-store/src/store.rs
@@ -244,10 +244,21 @@ impl V2Store {
         )
         .await?;
         let pending_updates = count_scalar(&self.pool, "SELECT COUNT(*) FROM outbox").await?;
+        let deferred_updates =
+            count_scalar(&self.pool, "SELECT COUNT(*) FROM deferred_batches").await?;
         let imported_items =
             count_scalar(&self.pool, "SELECT COUNT(*) FROM import_rows").await?;
         let import_sources =
             count_scalar(&self.pool, "SELECT COUNT(*) FROM import_sources").await?;
+        let sync_remote = self.sync_configuration().await?;
+        let sync_state = match &sync_remote {
+            None => "not_configured",
+            Some(remote) if remote.last_error_kind.is_some() => "error",
+            Some(_) if deferred_updates > 0 => "waiting_for_dependencies",
+            Some(_) if pending_updates > 0 => "pending",
+            Some(remote) if remote.last_success_at.is_some() => "in_sync",
+            Some(_) => "configured",
+        };
 
         Ok(StoreStatus {
             library_id,
@@ -255,10 +266,12 @@ impl V2Store {
             active_items,
             deleted_items,
             pending_updates,
+            deferred_updates,
             imported_items,
             import_sources,
             next_sequence,
-            sync_state: "not_configured".to_owned(),
+            sync_state: sync_state.to_owned(),
+            sync_remote,
         })
     }
 

--- a/crates/research-store/src/sync.rs
+++ b/crates/research-store/src/sync.rs
@@ -1,0 +1,486 @@
+use chrono::{DateTime, FixedOffset};
+use research_domain::{Library, LibraryGenesis, UpdateEnvelope};
+use sqlx::{Row, SqliteConnection};
+
+use crate::import::persist_projection;
+use crate::store::{fresh_peer_id, now_rfc3339, sha256_hex};
+use crate::{
+    PendingBatch, RemoteBatchDisposition, RemoteBatchResult, StoreError, StoreResult,
+    SyncConfiguration, SyncIdentity, V2Store,
+};
+
+impl V2Store {
+    pub async fn sync_identity(&self) -> StoreResult<SyncIdentity> {
+        Ok(SyncIdentity {
+            library_id: self.meta("library_id").await?,
+            device_id: self.meta("device_id").await?,
+            pristine: self.is_pristine().await?,
+        })
+    }
+
+    pub async fn sync_genesis(&self) -> StoreResult<LibraryGenesis> {
+        Ok(LibraryGenesis::new(
+            &self.meta("library_id").await?,
+            &now_rfc3339(),
+        )?)
+    }
+
+    pub async fn sync_configuration(&self) -> StoreResult<Option<SyncConfiguration>> {
+        let row = sqlx::query(
+            "SELECT repository_owner, repository_name, branch, configured_at, \
+             last_success_at, last_error_kind, last_error_at \
+             FROM sync_config WHERE singleton = 1",
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(|row| {
+            Ok(SyncConfiguration {
+                owner: row.try_get("repository_owner")?,
+                repository: row.try_get("repository_name")?,
+                branch: row.try_get("branch")?,
+                configured_at: row.try_get("configured_at")?,
+                last_success_at: row.try_get("last_success_at")?,
+                last_error_kind: row.try_get("last_error_kind")?,
+                last_error_at: row.try_get("last_error_at")?,
+            })
+        })
+        .transpose()
+    }
+
+    pub async fn configure_sync(
+        &self,
+        owner: &str,
+        repository: &str,
+        branch: &str,
+    ) -> StoreResult<SyncConfiguration> {
+        for (label, value) in [
+            ("repository owner", owner),
+            ("repository name", repository),
+            ("branch", branch),
+        ] {
+            if value.trim().is_empty() {
+                return Err(StoreError::InvalidInput(format!("{label} cannot be blank")));
+            }
+        }
+        if let Some(existing) = self.sync_configuration().await? {
+            if existing.owner == owner
+                && existing.repository == repository
+                && existing.branch == branch
+            {
+                return Ok(existing);
+            }
+            return Err(StoreError::InvalidInput(
+                "this library is already connected to another synchronization remote".into(),
+            ));
+        }
+        let now = now_rfc3339();
+        sqlx::query(
+            "INSERT INTO sync_config \
+             (singleton, repository_owner, repository_name, branch, configured_at) \
+             VALUES (1, ?, ?, ?, ?)",
+        )
+        .bind(owner)
+        .bind(repository)
+        .bind(branch)
+        .bind(&now)
+        .execute(&self.pool)
+        .await?;
+        self.sync_configuration()
+            .await?
+            .ok_or(StoreError::SyncNotConfigured)
+    }
+
+    pub async fn adopt_library_id_if_pristine(
+        &self,
+        remote_library_id: &str,
+    ) -> StoreResult<bool> {
+        LibraryGenesis::new(remote_library_id, &now_rfc3339())?;
+        let mut connection = self.pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *connection)
+            .await?;
+        let result = adopt_library_id(&mut connection, remote_library_id).await;
+        match result {
+            Ok(adopted) => {
+                sqlx::query("COMMIT").execute(&mut *connection).await?;
+                Ok(adopted)
+            }
+            Err(error) => {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *connection).await;
+                Err(error)
+            }
+        }
+    }
+
+    pub async fn pending_batches(&self) -> StoreResult<Vec<PendingBatch>> {
+        let rows = sqlx::query(
+            "SELECT b.device_id, b.sequence, b.path, b.payload_sha256, b.envelope_json, \
+             o.attempts FROM outbox o JOIN batches b USING (device_id, sequence) \
+             ORDER BY o.enqueued_at ASC, b.device_id ASC, b.sequence ASC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|row| {
+                let attempts: i64 = row.try_get("attempts")?;
+                Ok(PendingBatch {
+                    device_id: row.try_get("device_id")?,
+                    sequence: row.try_get("sequence")?,
+                    path: row.try_get("path")?,
+                    payload_sha256: row.try_get("payload_sha256")?,
+                    envelope_json: row.try_get("envelope_json")?,
+                    attempts: u64::try_from(attempts)
+                        .map_err(|_| StoreError::NumericRange("outbox attempts"))?,
+                })
+            })
+            .collect()
+    }
+
+    pub async fn remote_blob_is_current(
+        &self,
+        path: &str,
+        blob_sha: &str,
+    ) -> StoreResult<bool> {
+        let observed = self.observed_remote_blob(path).await?;
+        Ok(observed.as_deref() == Some(blob_sha))
+    }
+
+    pub async fn observed_remote_blob(&self, path: &str) -> StoreResult<Option<String>> {
+        Ok(
+            sqlx::query_scalar("SELECT blob_sha FROM remote_observations WHERE path = ?")
+                .bind(path)
+                .fetch_optional(&self.pool)
+                .await?,
+        )
+    }
+
+    pub async fn record_immutable_remote_blob(
+        &self,
+        path: &str,
+        blob_sha: &str,
+    ) -> StoreResult<()> {
+        validate_blob_sha(blob_sha)?;
+        sqlx::query(
+            "INSERT OR IGNORE INTO remote_observations (path, blob_sha, observed_at) \
+             VALUES (?, ?, ?)",
+        )
+        .bind(path)
+        .bind(blob_sha)
+        .bind(now_rfc3339())
+        .execute(&self.pool)
+        .await?;
+        let observed = self.observed_remote_blob(path).await?.ok_or_else(|| {
+            StoreError::InvalidStore("remote observation was not stored".into())
+        })?;
+        if observed != blob_sha {
+            return Err(StoreError::SyncIntegrity(
+                "an immutable remote path changed after it was observed".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub async fn receive_remote_batch(
+        &self,
+        path: &str,
+        blob_sha: &str,
+        bytes: &[u8],
+    ) -> StoreResult<RemoteBatchResult> {
+        validate_blob_sha(blob_sha)?;
+        let envelope_json = std::str::from_utf8(bytes)
+            .map_err(|_| StoreError::SyncIntegrity(format!("{path} is not UTF-8 JSON")))?;
+        let envelope: UpdateEnvelope = serde_json::from_slice(bytes)?;
+        let library_id = self.meta("library_id").await?;
+        envelope.validate_identity(&library_id, path)?;
+        validate_timestamp(&envelope.created_at, "operation creation time")?;
+
+        let mut connection = self.pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *connection)
+            .await?;
+        let result =
+            apply_remote_batch(&mut connection, path, blob_sha, envelope_json, &envelope).await;
+        match result {
+            Ok(result) => {
+                sqlx::query("COMMIT").execute(&mut *connection).await?;
+                Ok(result)
+            }
+            Err(error) => {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *connection).await;
+                Err(error)
+            }
+        }
+    }
+
+    pub async fn record_outbox_attempt(
+        &self,
+        path: &str,
+        error_kind: Option<&str>,
+    ) -> StoreResult<()> {
+        if let Some(kind) = error_kind {
+            validate_error_kind(kind)?;
+        }
+        sqlx::query(
+            "UPDATE outbox SET attempts = attempts + 1, last_error = ? \
+             WHERE EXISTS (SELECT 1 FROM batches b WHERE b.device_id = outbox.device_id \
+             AND b.sequence = outbox.sequence AND b.path = ?)",
+        )
+        .bind(error_kind)
+        .bind(path)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn record_sync_success(&self) -> StoreResult<()> {
+        let result = sqlx::query(
+            "UPDATE sync_config SET last_success_at = ?, last_error_kind = NULL, \
+             last_error_at = NULL WHERE singleton = 1",
+        )
+        .bind(now_rfc3339())
+        .execute(&self.pool)
+        .await?;
+        if result.rows_affected() != 1 {
+            return Err(StoreError::SyncNotConfigured);
+        }
+        Ok(())
+    }
+
+    pub async fn record_sync_failure(&self, error_kind: &str) -> StoreResult<()> {
+        validate_error_kind(error_kind)?;
+        sqlx::query(
+            "UPDATE sync_config SET last_error_kind = ?, last_error_at = ? \
+             WHERE singleton = 1",
+        )
+        .bind(error_kind)
+        .bind(now_rfc3339())
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn is_pristine(&self) -> StoreResult<bool> {
+        let count: i64 = sqlx::query_scalar(
+            "SELECT (SELECT COUNT(*) FROM batches) + (SELECT COUNT(*) FROM items) + \
+             (SELECT COUNT(*) FROM import_rows) + (SELECT COUNT(*) FROM outbox)",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(count == 0)
+    }
+}
+
+async fn adopt_library_id(
+    connection: &mut SqliteConnection,
+    remote_library_id: &str,
+) -> StoreResult<bool> {
+    let current: String =
+        sqlx::query_scalar("SELECT value FROM store_meta WHERE key = 'library_id'")
+            .fetch_one(&mut *connection)
+            .await?;
+    if current == remote_library_id {
+        return Ok(false);
+    }
+    let count: i64 = sqlx::query_scalar(
+        "SELECT (SELECT COUNT(*) FROM batches) + (SELECT COUNT(*) FROM items) + \
+         (SELECT COUNT(*) FROM import_rows) + (SELECT COUNT(*) FROM outbox)",
+    )
+    .fetch_one(&mut *connection)
+    .await?;
+    let next_sequence: String = sqlx::query_scalar(
+        "SELECT next_sequence FROM devices WHERE device_id = \
+         (SELECT value FROM store_meta WHERE key = 'device_id')",
+    )
+    .fetch_one(&mut *connection)
+    .await?;
+    if count != 0 || next_sequence != "00000000000000000001" {
+        return Err(StoreError::SyncLibraryMismatch(
+            remote_library_id.to_owned(),
+        ));
+    }
+    sqlx::query("UPDATE store_meta SET value = ? WHERE key = 'library_id'")
+        .bind(remote_library_id)
+        .execute(&mut *connection)
+        .await?;
+    Ok(true)
+}
+
+async fn apply_remote_batch(
+    connection: &mut SqliteConnection,
+    path: &str,
+    blob_sha: &str,
+    envelope_json: &str,
+    envelope: &UpdateEnvelope,
+) -> StoreResult<RemoteBatchResult> {
+    let existing = sqlx::query(
+        "SELECT envelope_json, payload_sha256 FROM batches \
+         WHERE device_id = ? AND sequence = ?",
+    )
+    .bind(&envelope.device_id)
+    .bind(&envelope.sequence)
+    .fetch_optional(&mut *connection)
+    .await?;
+    if let Some(existing) = existing {
+        let stored_json: String = existing.try_get("envelope_json")?;
+        let stored_payload_sha256: String = existing.try_get("payload_sha256")?;
+        if stored_json.as_bytes() != envelope_json.as_bytes()
+            || stored_payload_sha256 != envelope.payload_sha256
+        {
+            return Err(StoreError::SyncIntegrity(format!(
+                "batch identity collision at {path}"
+            )));
+        }
+        observe_remote(connection, path, blob_sha).await?;
+        let acknowledged_outbox = remove_outbox(connection, envelope).await?;
+        return Ok(RemoteBatchResult {
+            disposition: RemoteBatchDisposition::AlreadyApplied,
+            acknowledged_outbox,
+        });
+    }
+
+    let state = sqlx::query(
+        "SELECT snapshot, snapshot_sha256 FROM canonical_state WHERE singleton = 1",
+    )
+    .fetch_one(&mut *connection)
+    .await?;
+    let snapshot: Vec<u8> = state.try_get("snapshot")?;
+    let expected_snapshot_sha256: String = state.try_get("snapshot_sha256")?;
+    if sha256_hex(&snapshot) != expected_snapshot_sha256 {
+        return Err(StoreError::InvalidStore(
+            "canonical snapshot checksum mismatch".into(),
+        ));
+    }
+    let library = Library::from_snapshot(&snapshot, fresh_peer_id())?;
+    let incoming_pending = library.import_envelope_has_pending(envelope)?;
+    // A Loro snapshot does not retain an update whose causal predecessor was
+    // absent when that snapshot was exported. Receipted immutable envelopes do
+    // retain it. Replay only the explicitly deferred tail; once a predecessor
+    // arrives, previously deferred effects materialize in this transaction.
+    let deferred = sqlx::query(
+        "SELECT b.device_id, b.sequence, b.envelope_json FROM deferred_batches d \
+         JOIN batches b USING (device_id, sequence) \
+         ORDER BY b.device_id ASC, b.sequence ASC",
+    )
+    .fetch_all(&mut *connection)
+    .await?;
+    for row in deferred {
+        let device_id: String = row.try_get("device_id")?;
+        let sequence: String = row.try_get("sequence")?;
+        let stored_json: String = row.try_get("envelope_json")?;
+        let stored: UpdateEnvelope = serde_json::from_str(&stored_json)?;
+        if !library.import_envelope_has_pending(&stored)? {
+            sqlx::query("DELETE FROM deferred_batches WHERE device_id = ? AND sequence = ?")
+                .bind(device_id)
+                .bind(sequence)
+                .execute(&mut *connection)
+                .await?;
+        }
+    }
+    let new_snapshot = library.export_snapshot()?;
+    let projection = library.canonical_projection()?;
+    let now = now_rfc3339();
+    persist_projection(connection, &projection).await?;
+    sqlx::query(
+        "UPDATE canonical_state SET snapshot = ?, snapshot_sha256 = ?, updated_at = ? \
+         WHERE singleton = 1",
+    )
+    .bind(&new_snapshot)
+    .bind(sha256_hex(&new_snapshot))
+    .bind(&now)
+    .execute(&mut *connection)
+    .await?;
+    sqlx::query(
+        "INSERT INTO batches \
+         (device_id, sequence, payload_sha256, protocol_version, library_id, path, \
+          envelope_json, origin, applied_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'remote', ?)",
+    )
+    .bind(&envelope.device_id)
+    .bind(&envelope.sequence)
+    .bind(&envelope.payload_sha256)
+    .bind(i64::from(envelope.protocol_version))
+    .bind(&envelope.library_id)
+    .bind(path)
+    .bind(envelope_json)
+    .bind(&now)
+    .execute(&mut *connection)
+    .await?;
+    if incoming_pending {
+        sqlx::query("INSERT INTO deferred_batches (device_id, sequence) VALUES (?, ?)")
+            .bind(&envelope.device_id)
+            .bind(&envelope.sequence)
+            .execute(&mut *connection)
+            .await?;
+    }
+    observe_remote(connection, path, blob_sha).await?;
+    Ok(RemoteBatchResult {
+        disposition: RemoteBatchDisposition::Applied,
+        acknowledged_outbox: false,
+    })
+}
+
+async fn observe_remote(
+    connection: &mut SqliteConnection,
+    path: &str,
+    blob_sha: &str,
+) -> StoreResult<()> {
+    sqlx::query(
+        "INSERT INTO remote_observations (path, blob_sha, observed_at) VALUES (?, ?, ?) \
+         ON CONFLICT(path) DO UPDATE SET blob_sha = excluded.blob_sha, \
+         observed_at = excluded.observed_at",
+    )
+    .bind(path)
+    .bind(blob_sha)
+    .bind(now_rfc3339())
+    .execute(&mut *connection)
+    .await?;
+    Ok(())
+}
+
+async fn remove_outbox(
+    connection: &mut SqliteConnection,
+    envelope: &UpdateEnvelope,
+) -> StoreResult<bool> {
+    let result = sqlx::query("DELETE FROM outbox WHERE device_id = ? AND sequence = ?")
+        .bind(&envelope.device_id)
+        .bind(&envelope.sequence)
+        .execute(&mut *connection)
+        .await?;
+    Ok(result.rows_affected() == 1)
+}
+
+fn validate_timestamp(value: &str, label: &str) -> StoreResult<()> {
+    let parsed: DateTime<FixedOffset> = DateTime::parse_from_rfc3339(value)
+        .map_err(|_| StoreError::SyncIntegrity(format!("invalid {label}")))?;
+    if parsed.offset().local_minus_utc() != 0 {
+        return Err(StoreError::SyncIntegrity(format!("{label} is not in UTC")));
+    }
+    Ok(())
+}
+
+fn validate_blob_sha(blob_sha: &str) -> StoreResult<()> {
+    if !matches!(blob_sha.len(), 40 | 64)
+        || !blob_sha
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(StoreError::SyncIntegrity(
+            "remote blob has an invalid object ID".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_error_kind(kind: &str) -> StoreResult<()> {
+    if kind.is_empty()
+        || kind.len() > 64
+        || !kind
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte == b'_')
+    {
+        return Err(StoreError::InvalidInput(
+            "sync error kind must be lowercase ASCII words".into(),
+        ));
+    }
+    Ok(())
+}

--- a/crates/research-store/tests/sync_contract.rs
+++ b/crates/research-store/tests/sync_contract.rs
@@ -1,0 +1,274 @@
+use research_store::{
+    CreateItemRequest, EditItemRequest, ListQuery, OptionalTextUpdate, RemoteBatchDisposition,
+    SearchQuery, StoreError, V2Store,
+};
+
+#[tokio::test]
+async fn remote_replay_is_exact_idempotent_and_convergent() {
+    let root = tempfile::tempdir().expect("temporary test root");
+    let first = V2Store::init(root.path().join("first"))
+        .await
+        .expect("first store");
+    let second = V2Store::init(root.path().join("second"))
+        .await
+        .expect("second store");
+    let first_identity = first.sync_identity().await.expect("first identity");
+    let second_device = second
+        .sync_identity()
+        .await
+        .expect("second identity")
+        .device_id;
+    assert!(
+        second
+            .adopt_library_id_if_pristine(&first_identity.library_id)
+            .await
+            .expect("adopt remote library")
+    );
+    let adopted = second.sync_identity().await.expect("adopted identity");
+    assert_eq!(adopted.library_id, first_identity.library_id);
+    assert_eq!(adopted.device_id, second_device);
+    let configuration = second
+        .configure_sync("owner", "private-library", "main")
+        .await
+        .expect("configure synchronization");
+    assert_eq!(
+        second
+            .configure_sync("owner", "private-library", "main")
+            .await
+            .expect("repeat same configuration"),
+        configuration
+    );
+    assert!(matches!(
+        second
+            .configure_sync("owner", "another-library", "main")
+            .await
+            .expect_err("remote replacement must be explicit"),
+        StoreError::InvalidInput(_)
+    ));
+    second
+        .record_immutable_remote_blob("sync/v1/library.json", &"f".repeat(40))
+        .await
+        .expect("record immutable genesis");
+    assert!(matches!(
+        second
+            .record_immutable_remote_blob("sync/v1/library.json", &"e".repeat(40))
+            .await
+            .expect_err("genesis identity must not change"),
+        StoreError::SyncIntegrity(_)
+    ));
+
+    let item = first
+        .create_item(CreateItemRequest {
+            url: "https://example.com/sync-contract".into(),
+            title: Some("Initial title".into()),
+            excerpt: None,
+            favorite: false,
+            language: None,
+            saved_at: Some(1_700_000_000),
+            note: "private note".into(),
+            tags: vec!["sync".into()],
+        })
+        .await
+        .expect("create initial item");
+    let initial = first
+        .pending_batches()
+        .await
+        .expect("initial outbox")
+        .remove(0);
+    let initial_sha = "a".repeat(40);
+    let applied = second
+        .receive_remote_batch(
+            &initial.path,
+            &initial_sha,
+            initial.envelope_json.as_bytes(),
+        )
+        .await
+        .expect("apply initial remote batch");
+    assert_eq!(applied.disposition, RemoteBatchDisposition::Applied);
+    let duplicate = second
+        .receive_remote_batch(
+            &initial.path,
+            &initial_sha,
+            initial.envelope_json.as_bytes(),
+        )
+        .await
+        .expect("repeat initial remote batch");
+    assert_eq!(
+        duplicate.disposition,
+        RemoteBatchDisposition::AlreadyApplied
+    );
+    let acknowledged = first
+        .receive_remote_batch(
+            &initial.path,
+            &initial_sha,
+            initial.envelope_json.as_bytes(),
+        )
+        .await
+        .expect("confirm initial upload");
+    assert!(acknowledged.acknowledged_outbox);
+
+    first
+        .edit_item(EditItemRequest {
+            item_id: item.id.clone(),
+            favorite: Some(true),
+            ..EditItemRequest::default()
+        })
+        .await
+        .expect("first concurrent edit");
+    second
+        .edit_item(EditItemRequest {
+            item_id: item.id.clone(),
+            title: Some(OptionalTextUpdate::Set("Remote title".into())),
+            ..EditItemRequest::default()
+        })
+        .await
+        .expect("second concurrent edit");
+    let first_edit = first
+        .pending_batches()
+        .await
+        .expect("first edit outbox")
+        .remove(0);
+    let second_edit = second
+        .pending_batches()
+        .await
+        .expect("second edit outbox")
+        .remove(0);
+    let first_edit_sha = "b".repeat(40);
+    let second_edit_sha = "c".repeat(40);
+
+    let reordered = V2Store::init(root.path().join("reordered"))
+        .await
+        .expect("reordered store");
+    reordered
+        .adopt_library_id_if_pristine(&first_identity.library_id)
+        .await
+        .expect("adopt reordered library");
+    reordered
+        .receive_remote_batch(
+            &second_edit.path,
+            &second_edit_sha,
+            second_edit.envelope_json.as_bytes(),
+        )
+        .await
+        .expect("accept causally later batch first");
+    reordered
+        .receive_remote_batch(
+            &initial.path,
+            &initial_sha,
+            initial.envelope_json.as_bytes(),
+        )
+        .await
+        .expect("accept causal predecessor later");
+    let reordered_projection = reordered
+        .list(ListQuery {
+            include_deleted: true,
+            ..ListQuery::default()
+        })
+        .await
+        .expect("projection after reordered replay");
+    assert_eq!(reordered_projection.items.len(), 1);
+    assert_eq!(
+        reordered_projection.items[0].title.as_deref(),
+        Some("Remote title")
+    );
+    assert_eq!(
+        reordered
+            .status()
+            .await
+            .expect("reordered sync status")
+            .deferred_updates,
+        0
+    );
+
+    first
+        .receive_remote_batch(
+            &second_edit.path,
+            &second_edit_sha,
+            second_edit.envelope_json.as_bytes(),
+        )
+        .await
+        .expect("first receives second edit");
+    second
+        .receive_remote_batch(
+            &first_edit.path,
+            &first_edit_sha,
+            first_edit.envelope_json.as_bytes(),
+        )
+        .await
+        .expect("second receives first edit");
+    first
+        .receive_remote_batch(
+            &first_edit.path,
+            &first_edit_sha,
+            first_edit.envelope_json.as_bytes(),
+        )
+        .await
+        .expect("first edit upload confirmation");
+    second
+        .receive_remote_batch(
+            &second_edit.path,
+            &second_edit_sha,
+            second_edit.envelope_json.as_bytes(),
+        )
+        .await
+        .expect("second edit upload confirmation");
+
+    let query = ListQuery {
+        include_deleted: true,
+        ..ListQuery::default()
+    };
+    let first_projection = first.list(query.clone()).await.expect("first projection");
+    let second_projection = second.list(query).await.expect("second projection");
+    assert_eq!(first_projection, second_projection);
+    assert!(first_projection.items[0].favorite);
+    assert_eq!(
+        first_projection.items[0].title.as_deref(),
+        Some("Remote title")
+    );
+    assert_eq!(
+        second
+            .search(SearchQuery {
+                text: "Remote title".into(),
+                ..SearchQuery::default()
+            })
+            .await
+            .expect("remote projection search")
+            .page
+            .total,
+        1
+    );
+    assert!(
+        first
+            .pending_batches()
+            .await
+            .expect("first drained")
+            .is_empty()
+    );
+    assert!(
+        second
+            .pending_batches()
+            .await
+            .expect("second drained")
+            .is_empty()
+    );
+
+    let mut collision: serde_json::Value =
+        serde_json::from_str(&second_edit.envelope_json).expect("stored envelope JSON");
+    collision["created_at"] = serde_json::Value::String("2026-07-11T01:02:03.000Z".into());
+    let collision = serde_json::to_vec(&collision).expect("collision JSON");
+    let error = second
+        .receive_remote_batch(&second_edit.path, &"d".repeat(40), &collision)
+        .await
+        .expect_err("byte-different identity collision must fail");
+    assert!(matches!(error, StoreError::SyncIntegrity(_)));
+    assert_eq!(
+        second
+            .list(ListQuery {
+                include_deleted: true,
+                ..ListQuery::default()
+            })
+            .await
+            .expect("projection after rejected collision"),
+        second_projection
+    );
+}

--- a/docs/v2/CLI.md
+++ b/docs/v2/CLI.md
@@ -1,6 +1,6 @@
 # ResearchPocket V2 CLI
 
-Status: local command and output contract
+Status: command and output contract
 
 The shipped CLI is the V2 surface:
 
@@ -13,11 +13,14 @@ research restore <ITEM_ID>
 research import v1 <SOURCE_DB>
 research list
 research search <QUERY>
+research sync connect <OWNER/NAME>
+research sync run
 research status
 ```
 
-GitHub synchronization, scheduled synchronization, GitHub Pages owner editing,
-and V2 publication are not implemented in this slice. Git is not used to resolve
+Private GitHub synchronization and optional foreground periodic sync are
+implemented. GitHub Pages owner editing, background-service installation, and
+V2 publication are not implemented in this slice. Git is never used to resolve
 application changes.
 
 ## Global options
@@ -42,8 +45,8 @@ The usual defaults are:
 
 The local database is `<data-dir>/library.sqlite3`. It contains private local
 state and must not be committed, uploaded, placed in a public-output directory,
-or copied as a synchronization mechanism. Future synchronization exchanges
-immutable CRDT update envelopes instead of SQLite files.
+or copied as a synchronization mechanism. Synchronization exchanges immutable
+CRDT update envelopes instead of SQLite files.
 
 ## Initialize
 
@@ -144,6 +147,64 @@ existing materialized items. Create, import, and edit transactions update the
 index atomically; a failed or read-only search never changes the canonical state,
 outbox, or device sequence. Invalid query syntax returns a sanitized input error.
 
+## Private GitHub synchronization
+
+Create an empty private GitHub repository first. Give a fine-grained PAT with an
+expiry of at most 90 days access to only that repository with
+`Contents: read/write`, then expose it to the current process without putting it
+on a command line:
+
+```sh
+export RESEARCHPOCKET_GITHUB_TOKEN='github_pat_...'
+research sync connect OWNER/PRIVATE_REPOSITORY
+```
+
+`GH_TOKEN` is accepted as a fallback. ResearchPocket uses the token only in a
+sensitive HTTP authorization header. It never writes the token to SQLite, sync
+updates, URLs, logs, generated files, or command output. The repository must
+already exist, be private, expose a default branch name, and not be archived or
+disabled. ResearchPocket bootstraps the default branch of an empty repository;
+`--branch <NAME>` selects an existing non-default branch.
+
+On the first device, `sync connect` creates immutable
+`sync/v1/library.json`, pulls any compatible updates, uploads the exact durable
+outbox batches, and pulls once more. Repository commits are transport audit
+records only. The CLI never runs merge, rebase, or force-push and never uploads
+`library.sqlite3`.
+
+To restore on another device, initialize a completely separate empty data
+directory and connect it to the same repository:
+
+```sh
+research --data-dir /path/to/second-device init
+research --data-dir /path/to/second-device sync connect OWNER/PRIVATE_REPOSITORY
+research --data-dir /path/to/second-device list
+```
+
+Only a pristine local library may adopt the remote library identity. Its own
+device identity remains unique. A nonempty library with another identity fails
+closed instead of combining unrelated saves.
+
+Run a normal cycle explicitly or keep a foreground process polling while it is
+needed:
+
+```sh
+research sync run
+research sync run --every 60
+research --format ndjson sync run --every 60
+```
+
+The periodic interval is 15 seconds to 24 hours. Periodic JSON requires NDJSON
+because it emits a stream. Network, server, contention, and rate-limit failures
+remain recorded, keep every exact outbox byte, and retry in the foreground;
+authentication, version, integrity, and configuration failures stop for owner
+action. A one-shot failure also leaves the outbox untouched for the next
+`research sync run`.
+
+The repository layout, immutable identity rules, retries, and convergence
+contract are defined in [SYNC_PROTOCOL.md](./SYNC_PROTOCOL.md). Credential and
+repository boundaries are defined in [THREAT_MODEL.md](./THREAT_MODEL.md).
+
 ## Status
 
 ```sh
@@ -152,8 +213,10 @@ research status
 
 Status is safe before initialization and reports `initialized: false`. For an
 initialized library it shows library and device identities, active and deleted
-item counts, import summaries, pending outbox count, and synchronization state.
-Until the remote adapter ships, synchronization reports `not_configured`.
+item counts, import summaries, pending outbox and causally deferred update
+counts, synchronization state, configured repository/branch, and the last
+successful sync or sanitized error category. It never exposes a credential or
+update payload.
 
 ## Output contract
 
@@ -165,6 +228,11 @@ protocol versions.
 Create, edit, delete, and restore JSON output use the same materialized item
 shape as list entries, plus top-level `schema_version` and `command` fields. They
 do not expose causal revisions, CRDT bytes, or transport payloads.
+
+Sync JSON includes only repository identity, aggregate pull/apply/upload counts,
+whether a pristine device adopted the remote library, and the remaining pending
+count. Periodic NDJSON emits one `sync_run` record per successful cycle and a
+sanitized `sync_error` record for retryable failures.
 
 JSON list output has one document:
 

--- a/docs/v2/SYNC_PROTOCOL.md
+++ b/docs/v2/SYNC_PROTOCOL.md
@@ -206,6 +206,13 @@ Loro update, rebuilds affected projections, stores the canonical snapshot, and
 records the receipt. A duplicate identity/hash is success without a new local
 outbox item. A duplicate identity with another hash is an integrity error.
 
+If Loro reports a missing causal dependency, the same transaction stores the
+exact batch receipt plus a deferred marker. Full snapshots do not retain such a
+pending update by themselves. Each later remote arrival replays only the marked
+immutable envelopes and clears markers whose dependencies are now present. A
+pull cycle cannot report success or begin uploading local outbox data while any
+deferred marker remains after the complete discovered operation set is applied.
+
 ## Discovery and download
 
 Clients use the Git Trees API recursively to discover protocol blobs and the Git
@@ -227,9 +234,9 @@ paths, or item fields in logs.
 
 Clients sort discovered operation identities by `(device_id, sequence)` for
 repeatable diagnostics, but correctness is independent of that processing
-order. An update may arrive before its causal predecessor; Loro retains causal
-information and convergence is checked after the complete discovered set is
-applied.
+order. An update may arrive before its causal predecessor; the client retains
+its exact deferred envelope and convergence is checked after the complete
+discovered set is applied.
 
 ## Upload, idempotency, and branch races
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,6 +64,12 @@ pub enum Commands {
     /// Search URLs, authored fields, private notes, and tags
     Search(SearchArgs),
 
+    /// Connect and synchronize through a private GitHub repository
+    Sync {
+        #[command(subcommand)]
+        command: SyncCommands,
+    },
+
     /// Show local library, import, outbox, and sync state
     Status,
 }
@@ -216,7 +222,34 @@ pub struct SearchArgs {
     pub filters: ListArgs,
 }
 
-#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+#[derive(Subcommand)]
+pub enum SyncCommands {
+    /// Connect this library to an existing private GitHub repository and sync now
+    Connect(SyncConnectArgs),
+
+    /// Pull, apply, and upload immutable updates
+    Run(SyncRunArgs),
+}
+
+#[derive(Args)]
+pub struct SyncConnectArgs {
+    /// Private GitHub repository written as OWNER/NAME
+    #[arg(value_name = "OWNER/NAME")]
+    pub repository: String,
+
+    /// Repository branch; defaults to the repository's default branch
+    #[arg(long)]
+    pub branch: Option<String>,
+}
+
+#[derive(Args)]
+pub struct SyncRunArgs {
+    /// Repeat in the foreground at this interval; use NDJSON for machine output
+    #[arg(long, value_name = "SECONDS", value_parser = parse_sync_interval)]
+    pub every: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
 #[value(rename_all = "lower")]
 pub enum OutputFormat {
     #[default]
@@ -233,4 +266,14 @@ fn parse_limit(value: &str) -> Result<usize, String> {
         return Err("limit must be between 1 and 10000".to_owned());
     }
     Ok(limit)
+}
+
+fn parse_sync_interval(value: &str) -> Result<u64, String> {
+    let seconds = value
+        .parse::<u64>()
+        .map_err(|_| "sync interval must be an integer".to_owned())?;
+    if !(15..=86_400).contains(&seconds) {
+        return Err("sync interval must be between 15 and 86400 seconds".to_owned());
+    }
+    Ok(seconds)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::process::ExitCode;
 use cli::CliArgs;
 
 mod cli;
+mod sync;
 mod v2;
 
 #[tokio::main]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,929 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use chrono::{DateTime, FixedOffset};
+use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
+use reqwest::{Client, Response, StatusCode, Url};
+use research_domain::{DomainError, LibraryGenesis};
+use research_store::{
+    PendingBatch, RemoteBatchDisposition, StoreError, SyncConfiguration, V2Store,
+};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+const API_ROOT: &str = "https://api.github.com/";
+const API_VERSION: &str = "2026-03-10";
+const GENESIS_PATH: &str = "sync/v1/library.json";
+const OPS_PREFIX: &str = "sync/v1/ops/";
+const MAX_UPLOAD_ATTEMPTS: usize = 4;
+
+#[derive(Debug, Error)]
+pub enum SyncError {
+    #[error(
+        "GitHub credential is missing; set RESEARCHPOCKET_GITHUB_TOKEN or GH_TOKEN for this process"
+    )]
+    MissingCredential,
+    #[error("GitHub credential contains characters that cannot be used in an HTTP header")]
+    InvalidCredential,
+    #[error("repository must be written as OWNER/NAME")]
+    InvalidRepository,
+    #[error("the configured GitHub repository must be private")]
+    PublicRepository,
+    #[error("the configured GitHub repository is archived or disabled")]
+    UnavailableRepository,
+    #[error("the selected branch does not exist in the GitHub repository")]
+    MissingBranch,
+    #[error("this library is already connected to another synchronization remote")]
+    AlreadyConfigured,
+    #[error("GitHub transport failed before a usable response was received")]
+    Transport(#[source] reqwest::Error),
+    #[error("GitHub API request failed with HTTP {status} ({kind})")]
+    Api {
+        status: u16,
+        kind: &'static str,
+        retry_after_seconds: Option<u64>,
+    },
+    #[error("remote synchronization data is malformed: {0}")]
+    RemoteData(String),
+    #[error("remote synchronization integrity failure: {0}")]
+    Integrity(String),
+    #[error("synchronization remained contended after bounded retries")]
+    Contention,
+    #[error("local synchronization store failed: {0}")]
+    Store(#[from] StoreError),
+    #[error("synchronization domain validation failed: {0}")]
+    Domain(#[from] DomainError),
+    #[error("local synchronization JSON encoding failed: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+impl SyncError {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::MissingCredential | Self::InvalidCredential => "authentication",
+            Self::InvalidRepository | Self::MissingBranch | Self::AlreadyConfigured => {
+                "configuration"
+            }
+            Self::PublicRepository | Self::UnavailableRepository => "repository_policy",
+            Self::Transport(_) => "transport",
+            Self::Api { kind, .. } => kind,
+            Self::RemoteData(_) | Self::Integrity(_) => "integrity",
+            Self::Contention => "contention",
+            Self::Store(error) => store_error_kind(error),
+            Self::Domain(error) => domain_error_kind(error),
+            Self::Json(_) => "integrity",
+        }
+    }
+
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self.kind(),
+            "transport" | "rate_limited" | "server" | "contention"
+        )
+    }
+
+    pub fn retry_after(&self) -> Option<Duration> {
+        match self {
+            Self::Api {
+                retry_after_seconds: Some(seconds),
+                ..
+            } => Some(Duration::from_secs(*seconds)),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SyncRemote {
+    pub owner: String,
+    pub repository: String,
+    pub branch: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SyncCycleResult {
+    pub remote: SyncRemote,
+    pub remote_batches_seen: u64,
+    pub downloaded: u64,
+    pub applied: u64,
+    pub already_applied: u64,
+    pub acknowledged: u64,
+    pub uploaded: u64,
+    pub pending: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SyncConnectResult {
+    pub remote: SyncRemote,
+    pub adopted_remote_library: bool,
+    pub cycle: SyncCycleResult,
+}
+
+struct GitHubClient {
+    http: Client,
+}
+
+#[derive(Clone)]
+struct Remote {
+    owner: String,
+    repository: String,
+    branch: String,
+}
+
+#[derive(Deserialize)]
+struct RepositoryResponse {
+    private: bool,
+    archived: bool,
+    disabled: bool,
+    default_branch: String,
+    size: u64,
+}
+
+struct RepositoryInfo {
+    default_branch: String,
+    empty: bool,
+}
+
+#[derive(Default)]
+struct ProtocolTree {
+    blobs: BTreeMap<String, String>,
+}
+
+#[derive(Deserialize)]
+struct TreeResponse {
+    sha: String,
+    tree: Vec<TreeEntry>,
+    truncated: bool,
+}
+
+#[derive(Deserialize)]
+struct TreeEntry {
+    path: String,
+    mode: String,
+    #[serde(rename = "type")]
+    kind: String,
+    sha: String,
+}
+
+#[derive(Deserialize)]
+struct BlobResponse {
+    content: String,
+    encoding: String,
+    sha: String,
+    size: u64,
+}
+
+#[derive(Serialize)]
+struct PutContent<'a> {
+    message: String,
+    content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    branch: Option<&'a str>,
+}
+
+#[derive(Deserialize)]
+struct PutContentResponse {
+    content: Option<PutBlob>,
+}
+
+#[derive(Deserialize)]
+struct PutBlob {
+    sha: String,
+}
+
+enum PutResult {
+    Created(String),
+    Race,
+    Ambiguous(&'static str),
+}
+
+#[derive(Default)]
+struct PullStats {
+    seen: u64,
+    downloaded: u64,
+    applied: u64,
+    already_applied: u64,
+    acknowledged: u64,
+}
+
+impl PullStats {
+    fn add(&mut self, other: Self) {
+        self.seen += other.seen;
+        self.downloaded += other.downloaded;
+        self.applied += other.applied;
+        self.already_applied += other.already_applied;
+        self.acknowledged += other.acknowledged;
+    }
+}
+
+pub async fn connect(
+    store: &V2Store,
+    repository: &str,
+    requested_branch: Option<&str>,
+) -> Result<SyncConnectResult, SyncError> {
+    let (owner, repository) = parse_repository(repository)?;
+    let existing = store.sync_configuration().await?;
+    if existing.as_ref().is_some_and(|configuration| {
+        configuration.owner != owner || configuration.repository != repository
+    }) {
+        return Err(SyncError::AlreadyConfigured);
+    }
+    let client = GitHubClient::from_environment()?;
+    let repository_info = client.inspect_repository(&owner, &repository).await?;
+    let branch = requested_branch
+        .map(str::to_owned)
+        .or_else(|| {
+            existing
+                .as_ref()
+                .map(|configuration| configuration.branch.clone())
+        })
+        .unwrap_or_else(|| repository_info.default_branch.clone());
+    if branch.trim().is_empty() {
+        return Err(SyncError::MissingBranch);
+    }
+    if repository_info.empty && branch != repository_info.default_branch {
+        return Err(SyncError::MissingBranch);
+    }
+    if existing
+        .as_ref()
+        .is_some_and(|configuration| configuration.branch != branch)
+    {
+        return Err(SyncError::AlreadyConfigured);
+    }
+    let remote = Remote {
+        owner,
+        repository,
+        branch,
+    };
+    let (genesis, adopted_remote_library) =
+        connect_genesis(store, &client, &remote, repository_info.empty).await?;
+    genesis.validate()?;
+    validate_utc(&genesis.created_at, "genesis creation time")?;
+    store
+        .configure_sync(&remote.owner, &remote.repository, &remote.branch)
+        .await?;
+
+    let cycle = run_configured(store, &client, &remote).await;
+    match cycle {
+        Ok(cycle) => {
+            store.record_sync_success().await?;
+            Ok(SyncConnectResult {
+                remote: remote.view(),
+                adopted_remote_library,
+                cycle,
+            })
+        }
+        Err(error) => {
+            let _ = store.record_sync_failure(error.kind()).await;
+            Err(error)
+        }
+    }
+}
+
+pub async fn run_once(store: &V2Store) -> Result<SyncCycleResult, SyncError> {
+    let configuration = store
+        .sync_configuration()
+        .await?
+        .ok_or(StoreError::SyncNotConfigured)?;
+    let remote = Remote::from_configuration(&configuration);
+    let result = async {
+        let client = GitHubClient::from_environment()?;
+        run_configured(store, &client, &remote).await
+    }
+    .await;
+    match result {
+        Ok(result) => {
+            store.record_sync_success().await?;
+            Ok(result)
+        }
+        Err(error) => {
+            let _ = store.record_sync_failure(error.kind()).await;
+            Err(error)
+        }
+    }
+}
+
+async fn connect_genesis(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+    repository_empty: bool,
+) -> Result<(LibraryGenesis, bool), SyncError> {
+    let mut empty_bootstrap = repository_empty;
+    let local_genesis = store.sync_genesis().await?;
+    let local_genesis_bytes = serde_json::to_vec(&local_genesis)?;
+    for attempt in 0..MAX_UPLOAD_ATTEMPTS {
+        let tree = if empty_bootstrap {
+            ProtocolTree::default()
+        } else {
+            client.discover(remote).await?
+        };
+        if let Some(sha) = tree.blobs.get(GENESIS_PATH) {
+            let bytes = client.download_blob(remote, sha).await?;
+            let genesis = parse_genesis(&bytes)?;
+            let identity = store.sync_identity().await?;
+            let adopted = if identity.library_id == genesis.library_id {
+                false
+            } else {
+                store
+                    .adopt_library_id_if_pristine(&genesis.library_id)
+                    .await?
+            };
+            return Ok((genesis, adopted));
+        }
+        if tree.blobs.keys().any(|path| {
+            path.starts_with(OPS_PREFIX) || path.starts_with("sync/v1/checkpoints/")
+        }) {
+            return Err(SyncError::Integrity(
+                "protocol operations exist without immutable library genesis".into(),
+            ));
+        }
+
+        let branch = (!empty_bootstrap).then_some(remote.branch.as_str());
+        match client
+            .put_new(remote, GENESIS_PATH, &local_genesis_bytes, branch)
+            .await?
+        {
+            PutResult::Created(_) => return Ok((local_genesis, false)),
+            PutResult::Race | PutResult::Ambiguous(_) => {
+                empty_bootstrap = false;
+                retry_delay(GENESIS_PATH, attempt).await;
+            }
+        }
+    }
+    Err(SyncError::Contention)
+}
+
+async fn run_configured(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+) -> Result<SyncCycleResult, SyncError> {
+    client
+        .inspect_repository(&remote.owner, &remote.repository)
+        .await?;
+    let mut pull = pull_remote(store, client, remote).await?;
+    let pending = store.pending_batches().await?;
+    let mut uploaded = 0_u64;
+    for batch in pending {
+        let (created, race_pull) = ensure_uploaded(store, client, remote, &batch).await?;
+        if created {
+            uploaded += 1;
+        }
+        pull.add(race_pull);
+    }
+    pull.add(pull_remote(store, client, remote).await?);
+    let pending = u64::try_from(store.pending_batches().await?.len())
+        .map_err(|_| StoreError::NumericRange("pending sync batch count"))?;
+    Ok(SyncCycleResult {
+        remote: remote.view(),
+        remote_batches_seen: pull.seen,
+        downloaded: pull.downloaded,
+        applied: pull.applied,
+        already_applied: pull.already_applied,
+        acknowledged: pull.acknowledged,
+        uploaded,
+        pending,
+    })
+}
+
+async fn pull_remote(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+) -> Result<PullStats, SyncError> {
+    let tree = client.discover(remote).await?;
+    validate_remote_genesis(store, client, remote, &tree).await?;
+    let operations = tree
+        .blobs
+        .iter()
+        .filter(|(path, _)| path.starts_with(OPS_PREFIX))
+        .collect::<Vec<_>>();
+    let mut stats = PullStats {
+        seen: u64::try_from(operations.len())
+            .map_err(|_| StoreError::NumericRange("remote batch count"))?,
+        ..PullStats::default()
+    };
+    for (path, sha) in operations {
+        if store.remote_blob_is_current(path, sha).await? {
+            continue;
+        }
+        let bytes = client.download_blob(remote, sha).await?;
+        let result = store.receive_remote_batch(path, sha, &bytes).await?;
+        stats.downloaded += 1;
+        match result.disposition {
+            RemoteBatchDisposition::Applied => stats.applied += 1,
+            RemoteBatchDisposition::AlreadyApplied => stats.already_applied += 1,
+        }
+        if result.acknowledged_outbox {
+            stats.acknowledged += 1;
+        }
+    }
+    if store.status().await?.deferred_updates > 0 {
+        return Err(SyncError::Integrity(
+            "remote operations have missing causal dependencies".into(),
+        ));
+    }
+    Ok(stats)
+}
+
+async fn validate_remote_genesis(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+    tree: &ProtocolTree,
+) -> Result<(), SyncError> {
+    let sha = tree.blobs.get(GENESIS_PATH).ok_or_else(|| {
+        SyncError::Integrity("the configured repository has no library genesis".into())
+    })?;
+    if let Some(observed) = store.observed_remote_blob(GENESIS_PATH).await?
+        && observed != *sha
+    {
+        return Err(SyncError::Integrity(
+            "the immutable library genesis changed after it was observed".into(),
+        ));
+    }
+    let genesis = parse_genesis(&client.download_blob(remote, sha).await?)?;
+    let local = store.sync_identity().await?;
+    if genesis.library_id != local.library_id {
+        return Err(SyncError::Integrity(format!(
+            "remote library {} does not match this local library",
+            genesis.library_id
+        )));
+    }
+    store
+        .record_immutable_remote_blob(GENESIS_PATH, sha)
+        .await?;
+    Ok(())
+}
+
+async fn ensure_uploaded(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+    batch: &PendingBatch,
+) -> Result<(bool, PullStats), SyncError> {
+    let mut race_pull = PullStats::default();
+    for attempt in 0..MAX_UPLOAD_ATTEMPTS {
+        let tree = client.discover(remote).await?;
+        if let Some(sha) = tree.blobs.get(&batch.path) {
+            if !store.remote_blob_is_current(&batch.path, sha).await? {
+                let bytes = client.download_blob(remote, sha).await?;
+                store.receive_remote_batch(&batch.path, sha, &bytes).await?;
+            }
+            return Ok((false, race_pull));
+        }
+
+        let put = client
+            .put_new(
+                remote,
+                &batch.path,
+                batch.envelope_json.as_bytes(),
+                Some(&remote.branch),
+            )
+            .await;
+        match put {
+            Ok(PutResult::Created(sha)) => {
+                store.record_outbox_attempt(&batch.path, None).await?;
+                store
+                    .receive_remote_batch(&batch.path, &sha, batch.envelope_json.as_bytes())
+                    .await?;
+                return Ok((true, race_pull));
+            }
+            Ok(PutResult::Race) => {
+                store
+                    .record_outbox_attempt(&batch.path, Some("contention"))
+                    .await?;
+                race_pull.add(pull_remote(store, client, remote).await?);
+                retry_delay(&batch.path, attempt).await;
+            }
+            Ok(PutResult::Ambiguous(kind)) => {
+                store.record_outbox_attempt(&batch.path, Some(kind)).await?;
+                race_pull.add(pull_remote(store, client, remote).await?);
+                retry_delay(&batch.path, attempt).await;
+            }
+            Err(error) => {
+                let _ = store
+                    .record_outbox_attempt(&batch.path, Some(error.kind()))
+                    .await;
+                return Err(error);
+            }
+        }
+    }
+    Err(SyncError::Contention)
+}
+
+impl GitHubClient {
+    fn from_environment() -> Result<Self, SyncError> {
+        let token = env::var("RESEARCHPOCKET_GITHUB_TOKEN")
+            .ok()
+            .filter(|token| !token.trim().is_empty())
+            .or_else(|| {
+                env::var("GH_TOKEN")
+                    .ok()
+                    .filter(|token| !token.trim().is_empty())
+            })
+            .ok_or(SyncError::MissingCredential)?;
+        let mut authorization = HeaderValue::from_str(&format!("Bearer {token}"))
+            .map_err(|_| SyncError::InvalidCredential)?;
+        authorization.set_sensitive(true);
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, authorization);
+        headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/vnd.github+json"),
+        );
+        headers.insert(
+            "x-github-api-version",
+            HeaderValue::from_static(API_VERSION),
+        );
+        headers.insert(
+            USER_AGENT,
+            HeaderValue::from_static(concat!("ResearchPocket/", env!("CARGO_PKG_VERSION"))),
+        );
+        let http = Client::builder()
+            .default_headers(headers)
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(120))
+            .build()
+            .map_err(SyncError::Transport)?;
+        Ok(Self { http })
+    }
+
+    async fn inspect_repository(
+        &self,
+        owner: &str,
+        repository: &str,
+    ) -> Result<RepositoryInfo, SyncError> {
+        let remote = Remote {
+            owner: owner.to_owned(),
+            repository: repository.to_owned(),
+            branch: String::new(),
+        };
+        let response: RepositoryResponse = self.get_json(repo_url(&remote, &[])).await?;
+        if !response.private {
+            return Err(SyncError::PublicRepository);
+        }
+        if response.archived || response.disabled {
+            return Err(SyncError::UnavailableRepository);
+        }
+        Ok(RepositoryInfo {
+            default_branch: response.default_branch,
+            empty: response.size == 0,
+        })
+    }
+
+    async fn discover(&self, remote: &Remote) -> Result<ProtocolTree, SyncError> {
+        let recursive = self.fetch_tree(remote, &remote.branch, true).await;
+        let recursive = match recursive {
+            Err(SyncError::Api { status: 404, .. }) => return Err(SyncError::MissingBranch),
+            other => other?,
+        };
+        if !recursive.truncated {
+            return collect_protocol_entries(recursive.tree, "");
+        }
+
+        let mut protocol = ProtocolTree::default();
+        let mut stack = vec![(recursive.sha, String::new())];
+        while let Some((tree_sha, prefix)) = stack.pop() {
+            let tree = self.fetch_tree(remote, &tree_sha, false).await?;
+            for entry in tree.tree {
+                let path = join_path(&prefix, &entry.path);
+                validate_reserved_directory(&path, &entry)?;
+                if entry.kind == "tree" && protocol_tree_relevant(&path) {
+                    stack.push((entry.sha, path));
+                } else if path.starts_with("sync/v1/") {
+                    insert_protocol_blob(&mut protocol, &path, &entry)?;
+                }
+            }
+        }
+        Ok(protocol)
+    }
+
+    async fn fetch_tree(
+        &self,
+        remote: &Remote,
+        tree_sha: &str,
+        recursive: bool,
+    ) -> Result<TreeResponse, SyncError> {
+        let mut url = repo_url(remote, &["git", "trees", tree_sha]);
+        if recursive {
+            url.query_pairs_mut().append_pair("recursive", "1");
+        }
+        self.get_json(url).await
+    }
+
+    async fn download_blob(&self, remote: &Remote, sha: &str) -> Result<Vec<u8>, SyncError> {
+        validate_git_sha(sha)?;
+        let blob: BlobResponse = self
+            .get_json(repo_url(remote, &["git", "blobs", sha]))
+            .await?;
+        if blob.sha != sha || blob.encoding != "base64" {
+            return Err(SyncError::Integrity(
+                "GitHub returned a blob with mismatched identity or encoding".into(),
+            ));
+        }
+        let compact = blob
+            .content
+            .bytes()
+            .filter(|byte| !byte.is_ascii_whitespace())
+            .collect::<Vec<_>>();
+        let bytes = STANDARD
+            .decode(compact)
+            .map_err(|_| SyncError::RemoteData("GitHub blob Base64 is invalid".into()))?;
+        let length = u64::try_from(bytes.len())
+            .map_err(|_| SyncError::RemoteData("GitHub blob is too large".into()))?;
+        if length != blob.size {
+            return Err(SyncError::Integrity(
+                "GitHub blob size does not match its decoded content".into(),
+            ));
+        }
+        Ok(bytes)
+    }
+
+    async fn put_new(
+        &self,
+        remote: &Remote,
+        path: &str,
+        bytes: &[u8],
+        branch: Option<&str>,
+    ) -> Result<PutResult, SyncError> {
+        let body = PutContent {
+            message: format!("researchpocket: append {path}"),
+            content: STANDARD.encode(bytes),
+            branch,
+        };
+        let response = match self
+            .http
+            .put(contents_url(remote, path))
+            .json(&body)
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(_) => return Ok(PutResult::Ambiguous("transport")),
+        };
+        match response.status() {
+            StatusCode::CREATED => {
+                let created: PutContentResponse =
+                    response.json().await.map_err(SyncError::Transport)?;
+                let sha = created
+                    .content
+                    .ok_or_else(|| {
+                        SyncError::RemoteData(
+                            "GitHub create response did not contain a blob identity".into(),
+                        )
+                    })?
+                    .sha;
+                validate_git_sha(&sha)?;
+                Ok(PutResult::Created(sha))
+            }
+            StatusCode::CONFLICT | StatusCode::UNPROCESSABLE_ENTITY => Ok(PutResult::Race),
+            status if status.is_server_error() => Ok(PutResult::Ambiguous("server")),
+            StatusCode::OK => Err(SyncError::Integrity(
+                "GitHub reported an update for an immutable create request".into(),
+            )),
+            _ => Err(api_error(&response)),
+        }
+    }
+
+    async fn get_json<T: DeserializeOwned>(&self, url: Url) -> Result<T, SyncError> {
+        let response = self
+            .http
+            .get(url)
+            .send()
+            .await
+            .map_err(SyncError::Transport)?;
+        if !response.status().is_success() {
+            return Err(api_error(&response));
+        }
+        response.json().await.map_err(SyncError::Transport)
+    }
+}
+
+impl Remote {
+    fn from_configuration(configuration: &SyncConfiguration) -> Self {
+        Self {
+            owner: configuration.owner.clone(),
+            repository: configuration.repository.clone(),
+            branch: configuration.branch.clone(),
+        }
+    }
+
+    fn view(&self) -> SyncRemote {
+        SyncRemote {
+            owner: self.owner.clone(),
+            repository: self.repository.clone(),
+            branch: self.branch.clone(),
+        }
+    }
+}
+
+fn parse_repository(value: &str) -> Result<(String, String), SyncError> {
+    let mut components = value.split('/');
+    let owner = components.next().unwrap_or_default();
+    let repository = components.next().unwrap_or_default();
+    let safe = |part: &str| {
+        !part.is_empty()
+            && part.len() <= 100
+            && part
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    };
+    if components.next().is_some() || !safe(owner) || !safe(repository) {
+        return Err(SyncError::InvalidRepository);
+    }
+    Ok((owner.to_owned(), repository.to_owned()))
+}
+
+fn parse_genesis(bytes: &[u8]) -> Result<LibraryGenesis, SyncError> {
+    let genesis: LibraryGenesis = serde_json::from_slice(bytes)
+        .map_err(|_| SyncError::RemoteData("library genesis JSON is invalid".into()))?;
+    genesis.validate()?;
+    validate_utc(&genesis.created_at, "genesis creation time")?;
+    Ok(genesis)
+}
+
+fn validate_utc(value: &str, label: &str) -> Result<(), SyncError> {
+    let parsed: DateTime<FixedOffset> = DateTime::parse_from_rfc3339(value)
+        .map_err(|_| SyncError::RemoteData(format!("{label} is not RFC 3339")))?;
+    if parsed.offset().local_minus_utc() != 0 {
+        return Err(SyncError::RemoteData(format!("{label} is not UTC")));
+    }
+    Ok(())
+}
+
+fn collect_protocol_entries(
+    entries: Vec<TreeEntry>,
+    prefix: &str,
+) -> Result<ProtocolTree, SyncError> {
+    let mut protocol = ProtocolTree::default();
+    for entry in entries {
+        let path = join_path(prefix, &entry.path);
+        validate_reserved_directory(&path, &entry)?;
+        if path.starts_with("sync/v1/") && entry.kind != "tree" {
+            insert_protocol_blob(&mut protocol, &path, &entry)?;
+        }
+    }
+    Ok(protocol)
+}
+
+fn insert_protocol_blob(
+    protocol: &mut ProtocolTree,
+    path: &str,
+    entry: &TreeEntry,
+) -> Result<(), SyncError> {
+    if entry.kind != "blob" || entry.mode != "100644" {
+        return Err(SyncError::Integrity(
+            "a protocol entry is not an ordinary file".into(),
+        ));
+    }
+    validate_git_sha(&entry.sha)?;
+    if protocol
+        .blobs
+        .insert(path.to_owned(), entry.sha.clone())
+        .is_some()
+    {
+        return Err(SyncError::Integrity(
+            "a protocol path appears more than once".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_reserved_directory(path: &str, entry: &TreeEntry) -> Result<(), SyncError> {
+    if matches!(path, "sync" | "sync/v1") && entry.kind != "tree" {
+        return Err(SyncError::Integrity(
+            "the reserved synchronization path is not a directory".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn protocol_tree_relevant(path: &str) -> bool {
+    matches!(path, "sync" | "sync/v1") || path.starts_with("sync/v1/")
+}
+
+fn join_path(prefix: &str, path: &str) -> String {
+    if prefix.is_empty() {
+        path.to_owned()
+    } else {
+        format!("{prefix}/{path}")
+    }
+}
+
+fn repo_url(remote: &Remote, suffix: &[&str]) -> Url {
+    let mut url = Url::parse(API_ROOT).expect("static GitHub API URL must be valid");
+    {
+        let mut segments = url
+            .path_segments_mut()
+            .expect("GitHub API URL supports path segments");
+        segments.pop_if_empty();
+        segments.extend(["repos", &remote.owner, &remote.repository]);
+        segments.extend(suffix.iter().copied());
+    }
+    url
+}
+
+fn contents_url(remote: &Remote, path: &str) -> Url {
+    let mut url = repo_url(remote, &["contents"]);
+    {
+        let mut segments = url
+            .path_segments_mut()
+            .expect("GitHub API URL supports path segments");
+        segments.extend(path.split('/'));
+    }
+    url
+}
+
+fn validate_git_sha(sha: &str) -> Result<(), SyncError> {
+    if !matches!(sha.len(), 40 | 64)
+        || !sha
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(SyncError::Integrity(
+            "GitHub object identity is not lowercase hexadecimal".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn api_error(response: &Response) -> SyncError {
+    let status = response.status();
+    let rate_limited = status == StatusCode::TOO_MANY_REQUESTS
+        || (status == StatusCode::FORBIDDEN
+            && response
+                .headers()
+                .get("x-ratelimit-remaining")
+                .and_then(|value| value.to_str().ok())
+                == Some("0"));
+    let kind = if status == StatusCode::UNAUTHORIZED {
+        "authentication"
+    } else if rate_limited {
+        "rate_limited"
+    } else if status == StatusCode::FORBIDDEN {
+        "authorization"
+    } else if status == StatusCode::NOT_FOUND {
+        "not_found"
+    } else if status.is_server_error() {
+        "server"
+    } else {
+        "github_api"
+    };
+    let retry_after_seconds = response
+        .headers()
+        .get("retry-after")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse().ok())
+        .or_else(|| {
+            response
+                .headers()
+                .get("x-ratelimit-reset")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.parse::<u64>().ok())
+                .and_then(|reset| {
+                    let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+                    Some(reset.saturating_sub(now))
+                })
+        });
+    SyncError::Api {
+        status: status.as_u16(),
+        kind,
+        retry_after_seconds,
+    }
+}
+
+async fn retry_delay(path: &str, attempt: usize) {
+    let jitter = path.bytes().fold(0_u64, |state, byte| {
+        state.wrapping_mul(33) ^ u64::from(byte)
+    }) % 173;
+    let exponent = u32::try_from(attempt).unwrap_or(u32::MAX).min(4);
+    let base = 200_u64.saturating_mul(1_u64 << exponent);
+    tokio::time::sleep(Duration::from_millis(base + jitter)).await;
+}
+
+fn store_error_kind(error: &StoreError) -> &'static str {
+    match error {
+        StoreError::SyncNotConfigured | StoreError::InvalidInput(_) => "configuration",
+        StoreError::SyncLibraryMismatch(_) => "library_mismatch",
+        StoreError::SyncIntegrity(_) | StoreError::Json(_) => "integrity",
+        StoreError::Domain(error) => domain_error_kind(error),
+        StoreError::Io(_) | StoreError::Sqlite(_) | StoreError::Migration(_) => "local_store",
+        _ => "local_state",
+    }
+}
+
+fn domain_error_kind(error: &DomainError) -> &'static str {
+    match error {
+        DomainError::UnsupportedProtocol(_)
+        | DomainError::UnsupportedDomainSchema(_)
+        | DomainError::UnsupportedCodec(_)
+        | DomainError::UnsupportedFeature(_) => "upgrade_required",
+        _ => "integrity",
+    }
+}

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use directories::ProjectDirs;
 use research_store::{
@@ -9,7 +10,8 @@ use research_store::{
 use serde::Serialize;
 use serde_json::{Value, json};
 
-use crate::cli::{CliArgs, Commands, ImportCommands, OutputFormat};
+use crate::cli::{CliArgs, Commands, ImportCommands, OutputFormat, SyncCommands};
+use crate::sync;
 
 type CliResult<T> = Result<T, Box<dyn Error>>;
 
@@ -116,8 +118,89 @@ pub async fn handle(args: &CliArgs) -> CliResult<()> {
             let output = command_output("search", result)?;
             write_search(args.format, &output)
         }
+        Commands::Sync { command } => handle_sync(&data_dir, args.format, command).await,
         Commands::Status => handle_status(&data_dir, args.format).await,
     }
+}
+
+async fn handle_sync(
+    data_dir: &Path,
+    format: OutputFormat,
+    command: &SyncCommands,
+) -> CliResult<()> {
+    let store = V2Store::open(data_dir).await?;
+    match command {
+        SyncCommands::Connect(connect) => {
+            let result =
+                sync::connect(&store, &connect.repository, connect.branch.as_deref()).await?;
+            let output = command_output("sync_connect", result)?;
+            write_single(format, &output, human_sync_connect)
+        }
+        SyncCommands::Run(run) => {
+            if run.every.is_some() && format == OutputFormat::Json {
+                return Err(io::Error::other(
+                    "--every produces a stream; use --format ndjson or human output",
+                )
+                .into());
+            }
+            let Some(seconds) = run.every else {
+                let result = sync::run_once(&store).await?;
+                let output = command_output("sync_run", result)?;
+                return write_single(format, &output, human_sync_run);
+            };
+            loop {
+                let retry_after = match sync::run_once(&store).await {
+                    Ok(result) => {
+                        let output = command_output("sync_run", result)?;
+                        write_single(format, &output, human_sync_run)?;
+                        None
+                    }
+                    Err(error) if error.is_retryable() => {
+                        write_sync_retry(format, &error)?;
+                        error.retry_after()
+                    }
+                    Err(error) => return Err(error.into()),
+                };
+                let delay = retry_after
+                    .map(|retry_after| retry_after.max(Duration::from_secs(seconds)))
+                    .unwrap_or_else(|| Duration::from_secs(seconds));
+                tokio::select! {
+                    result = tokio::signal::ctrl_c() => {
+                        result?;
+                        return Ok(());
+                    }
+                    () = tokio::time::sleep(delay) => {}
+                }
+            }
+        }
+    }
+}
+
+fn write_sync_retry(format: OutputFormat, error: &sync::SyncError) -> CliResult<()> {
+    match format {
+        OutputFormat::Human => {
+            eprintln!("Synchronization will retry: {error}");
+        }
+        OutputFormat::Ndjson => {
+            write_json(
+                &json!({
+                    "schema_version": OUTPUT_SCHEMA_VERSION,
+                    "command": "sync_run",
+                    "type": "sync_error",
+                    "error_kind": error.kind(),
+                    "retryable": true
+                }),
+                false,
+            )?;
+        }
+        OutputFormat::Json => {
+            return Err(io::Error::other(
+                "periodic synchronization cannot emit one JSON document",
+            )
+            .into());
+        }
+    }
+    Ok(())
 }
 
 fn optional_text_update(value: &Option<String>, clear: bool) -> Option<OptionalTextUpdate> {
@@ -343,6 +426,43 @@ fn human_import(value: &Value) {
     print_bool(value, "source_unchanged", "Source unchanged");
 }
 
+fn human_sync_connect(value: &Value) {
+    println!("Connected private synchronization repository");
+    print_remote(value.get("remote"));
+    print_bool(value, "adopted_remote_library", "Adopted remote library");
+    if let Some(cycle) = value.get("cycle") {
+        print_sync_counts(cycle);
+    }
+}
+
+fn human_sync_run(value: &Value) {
+    println!("Synchronization complete");
+    print_remote(value.get("remote"));
+    print_sync_counts(value);
+}
+
+fn print_remote(remote: Option<&Value>) {
+    let Some(remote) = remote else {
+        return;
+    };
+    let owner = remote.get("owner").and_then(Value::as_str);
+    let repository = remote.get("repository").and_then(Value::as_str);
+    if let (Some(owner), Some(repository)) = (owner, repository) {
+        println!("Repository: {owner}/{repository}");
+    }
+    print_string(remote, "branch", "Branch");
+}
+
+fn print_sync_counts(value: &Value) {
+    print_number(value, "remote_batches_seen", "Remote batches observed");
+    print_number(value, "downloaded", "Downloaded");
+    print_number(value, "applied", "Applied");
+    print_number(value, "already_applied", "Already applied");
+    print_number(value, "acknowledged", "Acknowledged");
+    print_number(value, "uploaded", "Uploaded");
+    print_number(value, "pending", "Pending");
+}
+
 fn human_status(value: &Value) {
     let initialized = value
         .get("initialized")
@@ -363,6 +483,7 @@ fn human_status(value: &Value) {
     print_number(value, "active_items", "Active saves");
     print_number(value, "deleted_items", "Deleted saves");
     print_number(value, "pending_updates", "Pending updates");
+    print_number(value, "deferred_updates", "Deferred remote updates");
     let sync_state = value
         .get("sync")
         .and_then(|sync| sync.get("state"))
@@ -370,6 +491,11 @@ fn human_status(value: &Value) {
         .or_else(|| value.get("sync_state").and_then(Value::as_str));
     if let Some(state) = sync_state {
         println!("Sync: {state}");
+    }
+    if let Some(remote) = value.get("sync_remote") {
+        print_remote(Some(remote));
+        print_string(remote, "last_success_at", "Last successful sync");
+        print_string(remote, "last_error_kind", "Last sync error");
     }
 }
 


### PR DESCRIPTION
Closes #46

Ships the first usable V2 multi-device workflow without an always-on backend or Git conflict handling.

What changed:

- adds strict immutable library genesis and operation identity/version validation
- adds SQLite sync configuration, remote receipts, causally deferred-envelope recovery, outbox attempt state, and atomic remote replay
- adds GitHub Trees/Blobs discovery plus serialized Contents creates with exact-byte acknowledgement and bounded branch-race retries
- adds private-repository enforcement, sensitive in-memory authorization headers, rate-limit handling, and no credential persistence
- adds `research sync connect OWNER/REPO`, `research sync run`, and `research sync run --every SECONDS`
- restores an existing remote library onto a pristine second device while retaining a unique local device ID
- reports remote/status/count/error categories in schema-versioned output without exposing payloads or credentials
- documents first-device setup, second-device restore, periodic sync, retry behavior, and current boundaries

The one new sync contract covers exact idempotency, byte-different collision rejection, concurrent two-replica convergence, FTS projection, immutable genesis, outbox acknowledgement, and causally reordered replay. That last case found and now protects an important Loro behavior: pending updates must be retained as immutable deferred envelopes because a snapshot alone does not retain them.

Dependency state:

- adds current stable `reqwest 0.13.4`
- refreshes the lockfile to the registry's latest compatible resolution
- keeps Loro pinned at the protocol codec `1.13.6`

Verification:

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-targets --all-features`
- WASM convergence artifact builds successfully; Chrome execution is in CI
- `cargo audit --deny warnings`
- authenticated read-only live check rejects the public ResearchPocket repository before any write
- release binary upgraded a disposable copy of the real 978-save library to migration 3: 978 items, 978 FTS rows, one preserved outbox batch, zero deferred batches, ~0.01s status; source DB/WAL/SHM hashes unchanged

No remote repository was created or mutated during validation. The user-facing connect command requires an explicit existing private repository and token.
