### PR TITLE
Ship keyboard-first V2 TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac436601d6bdde674a0d7fb593e829ffe7b3387c351b356dd20e2d40f5bf3ee5"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +238,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +260,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -374,6 +398,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +425,15 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -469,6 +516,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook 0.3.18",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,8 +576,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -521,15 +605,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive_arbitrary"
@@ -539,6 +653,28 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
  "syn 2.0.118",
 ]
 
@@ -600,6 +736,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -722,6 +867,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -975,6 +1126,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
@@ -1323,6 +1479,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,6 +1526,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1429,6 +1616,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,6 +1671,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,6 +1690,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1653,6 +1866,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,6 +1943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1774,6 +1997,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +2043,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,6 +2080,30 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "parking"
@@ -1933,6 +2195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,6 +2221,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2138,6 +2412,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags",
+ "compact_str",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2221,14 +2561,18 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "crossterm",
  "directories",
+ "ratatui",
  "reqwest",
  "research-domain",
  "research-store",
  "serde",
  "serde_json",
+ "signal-hook 0.4.4",
  "thiserror 2.0.18",
  "tokio",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2387,6 +2731,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,7 +2824,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45958fce4903f67e871fbf15ac78e289269b21ebd357d6fecacdba233629112e"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -2560,6 +2910,37 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook 0.3.18",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -2807,6 +3188,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,6 +3209,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "subtle"
@@ -2953,6 +3361,27 @@ checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinystr"
@@ -3199,6 +3628,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools 0.14.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3422,6 +3874,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3429,6 +3897,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,15 @@ resolver = "2"
 base64 = "0.22.1"
 chrono = { version = "0.4.45", default-features = false, features = ["std"] }
 clap = { version = "4.6.1", features = ["cargo", "env", "derive"] }
+crossterm = "0.29.0"
 directories = "6.0.0"
+ratatui = { version = "0.30.2", default-features = false, features = ["crossterm_0_29"] }
 reqwest = { version = "0.13.4", features = ["json"] }
 research-domain = { path = "crates/research-domain" }
 research-store = { path = "crates/research-store" }
 serde = "1.0.228"
 serde_json = "1.0.150"
+signal-hook = { version = "0.4.4", default-features = false }
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "signal", "time"] }
+unicode-width = "0.2.2"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ research add https://example.com/article --tag reading
 research import v1 /path/to/v1/research.sqlite
 research list
 research search 'rust sqlite'
+research tui
 research edit "$ITEM_ID" --title "A better title" --favorite true
 research delete "$ITEM_ID"
 research restore "$ITEM_ID"
@@ -121,6 +122,22 @@ onboarding and browser pull/push are the next hosted-owner slice; this foundatio
 does not claim that browser-only changes are remotely backed up yet. See the
 [hosted application contract](docs/v2/WEB.md).
 
+## Terminal interface
+
+Run `research tui` from an interactive terminal to manage the selected local V2
+library without a network request. It uses the same `V2Store` transactions as the
+CLI, so capture, edit, favorite, delete, and restore each atomically update the
+CRDT snapshot, SQLite projection, and durable outbox.
+
+The main shortcuts are `a` to capture, `e` or Enter to edit, `/` to search, Space
+to toggle favorite, `x` to delete, `r` to restore, `f` to filter favorites, and
+`d` to cycle active/all/deleted views. Press `?` for complete keyboard help.
+Forms use Tab and Shift+Tab between fields, `Ctrl+N` for a note newline, and
+`Ctrl+S` to save one mutation. Use `q` from the library or `Ctrl+C` anywhere to
+exit and restore the terminal.
+The footer shows pending outbox and synchronization state but the TUI never reads
+a GitHub token or starts synchronization.
+
 ## Human and machine output
 
 Every command accepts `--format human|json|ndjson`. Options are global and may be
@@ -141,10 +158,11 @@ The complete command and output contract is in [docs/v2/CLI.md](docs/v2/CLI.md).
 ## Current boundary
 
 The CLI supports private GitHub synchronization, new-device restoration, and an
-optional foreground periodic loop. The static owner UI supports offline local
-editing through the shared WASM core. Browser GitHub synchronization, installed
-background scheduling, checkpoints, TUI/local web management, and V2 publication
-are not implemented yet.
+optional foreground periodic loop. The TUI supports local capture, curation,
+search, and recoverable lifecycle management. The static owner UI supports
+offline local editing through the shared WASM core. Browser GitHub
+synchronization, installed background scheduling, checkpoints, local web
+management, and V2 publication are not implemented yet.
 
 Clients exchange immutable CRDT update batches. Git commits, branches, merges,
 rebases, timestamps, and last-push order never choose application values or

--- a/crates/research-store/src/error.rs
+++ b/crates/research-store/src/error.rs
@@ -30,6 +30,8 @@ pub enum StoreError {
     ItemNotFound(String),
     #[error("the edit does not contain any changes")]
     NoChanges,
+    #[error("the item changed after editing began; reopen it before saving")]
+    StaleEdit,
     #[error("invalid mutation input: {0}")]
     InvalidInput(String),
     #[error("synchronization is not configured")]

--- a/crates/research-store/src/model.rs
+++ b/crates/research-store/src/model.rs
@@ -39,6 +39,9 @@ pub struct EditItemRequest {
     pub language: Option<OptionalTextUpdate>,
     pub saved_at: Option<i64>,
     pub note: Option<String>,
+    /// Reject a note replacement unless the current note still has this value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_note: Option<String>,
     pub add_tags: Vec<String>,
     pub remove_tags: Vec<String>,
 }

--- a/crates/research-store/src/mutation.rs
+++ b/crates/research-store/src/mutation.rs
@@ -71,6 +71,14 @@ impl V2Store {
                 .items
                 .get(&mutation_item_id)
                 .ok_or_else(|| StoreError::ItemNotFound(mutation_item_id.clone()))?;
+            if request.note.is_some()
+                && request
+                    .expected_note
+                    .as_ref()
+                    .is_some_and(|expected| expected != &current.note)
+            {
+                return Err(StoreError::StaleEdit);
+            }
             if request.note.as_ref() == Some(&current.note) && !has_non_note_changes {
                 return Err(StoreError::NoChanges);
             }

--- a/crates/research-store/tests/local_mutation_contract.rs
+++ b/crates/research-store/tests/local_mutation_contract.rs
@@ -61,6 +61,16 @@ async fn local_mutations_are_atomic_durable_and_lifecycle_safe() {
     assert_eq!(edited.note.as_deref(), Some("human 😀 note"));
     assert!(edited.favorite);
     assert_eq!(edited.tags, ["Added", "Keep"]);
+    let stale_note = store
+        .edit_item(EditItemRequest {
+            item_id: first.id.clone(),
+            note: Some("stale replacement".into()),
+            expected_note: Some(String::new()),
+            ..EditItemRequest::default()
+        })
+        .await
+        .expect_err("stale note replacement must fail");
+    assert!(matches!(stale_note, StoreError::StaleEdit));
     let search = store
         .search(SearchQuery {
             text: "human".into(),

--- a/docs/v2/CLI.md
+++ b/docs/v2/CLI.md
@@ -13,6 +13,7 @@ research restore <ITEM_ID>
 research import v1 <SOURCE_DB>
 research list
 research search <QUERY>
+research tui
 research sync connect <OWNER/NAME>
 research sync run
 research status
@@ -146,6 +147,61 @@ Opening a library created before the search migration builds its index from the
 existing materialized items. Create, import, and edit transactions update the
 index atomically; a failed or read-only search never changes the canonical state,
 outbox, or device sequence. Invalid query syntax returns a sanitized input error.
+
+## Terminal interface
+
+```sh
+research tui
+```
+
+The TUI requires an interactive terminal and uses the resolved V2 data directory.
+It does not support JSON/NDJSON output, make network requests, read GitHub
+credentials, or start synchronization. Its footer reports active/deleted counts,
+the pending outbox count, and sanitized synchronization state.
+
+Main view shortcuts:
+
+| Key | Action |
+| --- | --- |
+| `j`/`k`, arrows | Move selection |
+| `g`/`G`, Home/End | First/last save |
+| `Ctrl+U`/`Ctrl+D` | Scroll long item details |
+| `a` | Capture a URL |
+| `e` or Enter | Edit the selected save |
+| `/` | Search URL, title, excerpt, private note, and tags through SQLite FTS |
+| Space | Toggle favorite |
+| `x` | Confirm recoverable deletion |
+| `r` | Restore a deleted save |
+| `f` | Toggle favorite-only results |
+| `d` | Cycle active, all, and deleted lifecycle views |
+| `R` | Refresh local state |
+| `?` | Open keyboard help |
+| `q` in the main view or `Ctrl+C` anywhere | Exit and restore the terminal |
+
+Capture and edit forms use Tab/Shift+Tab to move through URL, title, excerpt,
+private note, exact tags, and favorite state. `Ctrl+N` inserts a note newline,
+`Ctrl+S` commits, and Escape cancels. Pasting multiline text into the note field
+preserves newlines; other fields normalize pasted newlines to spaces.
+The tags field accepts a convenient comma-separated list for ordinary tags or a
+JSON string array for exact commas and leading/trailing whitespace. Existing
+tags open as JSON, so saving an untouched field is lossless.
+Search accepts the same SQLite FTS5 syntax as `research search`, including quoted
+phrases and `*` prefix queries; malformed syntax is reported without changing the
+active result set.
+
+If another local or synchronized writer changes a note after its edit form opens,
+the TUI refuses the stale whole-note replacement and asks the owner to reopen the
+item. This prevents an old form buffer from erasing newer character-level note
+updates.
+
+Stored control characters are rendered as inert replacement glyphs, so imported
+or synchronized content cannot emit terminal escape sequences. The underlying
+authored value remains unchanged.
+
+Every successful authored action calls the existing `V2Store` API. It therefore
+has the same atomic CRDT snapshot, projection, immutable batch, outbox, validation,
+and error behavior as the corresponding CLI action. The TUI does not duplicate
+domain or synchronization rules.
 
 ## Private GitHub synchronization
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,6 +64,9 @@ pub enum Commands {
     /// Search URLs, authored fields, private notes, and tags
     Search(SearchArgs),
 
+    /// Manage the local library in a keyboard-first terminal interface
+    Tui,
+
     /// Connect and synchronize through a private GitHub repository
     Sync {
         #[command(subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use cli::CliArgs;
 
 mod cli;
 mod sync;
+mod tui;
 mod v2;
 
 #[tokio::main]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,0 +1,1516 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::io::{self, IsTerminal, Stdout};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use crossterm::cursor::{Hide, Show};
+use crossterm::event::{
+    self, DisableBracketedPaste, EnableBracketedPaste, Event, KeyCode, KeyEvent, KeyEventKind,
+    KeyModifiers,
+};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap};
+use ratatui::{Frame, Terminal};
+use research_store::{
+    CreateItemRequest, EditItemRequest, ListQuery, OptionalTextUpdate, SearchQuery,
+    StoreStatus, StoredItem, V2Store,
+};
+use serde_json::Value;
+use unicode_width::UnicodeWidthStr;
+
+type TuiResult<T> = Result<T, Box<dyn Error>>;
+
+const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const ACTION_LATCH_IDLE: Duration = Duration::from_secs(2);
+const MIN_COMFORTABLE_WIDTH: u16 = 72;
+const MIN_COMFORTABLE_HEIGHT: u16 = 20;
+
+pub async fn run(store: &V2Store) -> TuiResult<()> {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err(io::Error::other("the TUI requires an interactive terminal").into());
+    }
+
+    let mut terminal = TerminalSession::new()?;
+    let shutdown = install_signal_handlers()?;
+    let mut app = App::load(store).await?;
+
+    while !app.should_quit && !shutdown.load(Ordering::Relaxed) {
+        terminal.terminal.draw(|frame| render(frame, &mut app))?;
+        if !event::poll(EVENT_POLL_INTERVAL)? {
+            app.clear_action_latch();
+            continue;
+        }
+        match event::read()? {
+            Event::Key(key) if key.kind == KeyEventKind::Press && app.accept_key_press(key) => {
+                app.handle_key(store, key).await;
+            }
+            Event::Key(key) if key.kind == KeyEventKind::Repeat => {
+                app.note_key_repeat(key);
+                app.handle_repeat_key(key);
+            }
+            Event::Key(key) if key.kind == KeyEventKind::Release => {
+                app.release_key(key);
+            }
+            Event::Paste(text) => app.handle_paste(text),
+            Event::Resize(_, _) => {}
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn install_signal_handlers() -> io::Result<Arc<AtomicBool>> {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    #[cfg(unix)]
+    for signal in [
+        signal_hook::consts::signal::SIGHUP,
+        signal_hook::consts::signal::SIGINT,
+        signal_hook::consts::signal::SIGTERM,
+    ] {
+        signal_hook::flag::register(signal, Arc::clone(&shutdown))?;
+    }
+    Ok(shutdown)
+}
+
+struct TerminalSession {
+    terminal: Terminal<CrosstermBackend<Stdout>>,
+}
+
+impl TerminalSession {
+    fn new() -> io::Result<Self> {
+        enable_raw_mode()?;
+        let mut stdout = io::stdout();
+        if let Err(error) = execute!(stdout, EnterAlternateScreen, EnableBracketedPaste, Hide) {
+            let _ = execute!(stdout, Show, DisableBracketedPaste, LeaveAlternateScreen);
+            let _ = disable_raw_mode();
+            return Err(error);
+        }
+        match Terminal::new(CrosstermBackend::new(stdout)) {
+            Ok(terminal) => Ok(Self { terminal }),
+            Err(error) => {
+                let mut stdout = io::stdout();
+                let _ = execute!(stdout, Show, DisableBracketedPaste, LeaveAlternateScreen);
+                let _ = disable_raw_mode();
+                Err(error)
+            }
+        }
+    }
+}
+
+impl Drop for TerminalSession {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(
+            self.terminal.backend_mut(),
+            Show,
+            DisableBracketedPaste,
+            LeaveAlternateScreen
+        );
+        let _ = self.terminal.show_cursor();
+    }
+}
+
+struct App {
+    items: Vec<StoredItem>,
+    selected: usize,
+    list_state: ListState,
+    query: String,
+    favorite_only: bool,
+    lifecycle: LifecycleFilter,
+    status: StoreStatus,
+    mode: Mode,
+    notice: Option<Notice>,
+    detail_scroll: u16,
+    should_quit: bool,
+    action_latch: Option<(ModeKind, KeyCode, KeyModifiers, Instant)>,
+}
+
+impl App {
+    async fn load(store: &V2Store) -> TuiResult<Self> {
+        let status = store.status().await?;
+        let mut app = Self {
+            items: Vec::new(),
+            selected: 0,
+            list_state: ListState::default(),
+            query: String::new(),
+            favorite_only: false,
+            lifecycle: LifecycleFilter::Active,
+            status,
+            mode: Mode::Browse,
+            notice: None,
+            detail_scroll: 0,
+            should_quit: false,
+            action_latch: None,
+        };
+        app.refresh(store, None).await?;
+        Ok(app)
+    }
+
+    async fn refresh(&mut self, store: &V2Store, preferred_id: Option<&str>) -> TuiResult<()> {
+        let selected_id = preferred_id
+            .map(str::to_owned)
+            .or_else(|| self.selected_item().map(|item| item.id.clone()));
+        let include_deleted = self.lifecycle != LifecycleFilter::Active;
+        let mut items = if self.query.trim().is_empty() {
+            store
+                .list(ListQuery {
+                    favorite_only: self.favorite_only,
+                    include_deleted,
+                    limit: None,
+                    ..ListQuery::default()
+                })
+                .await?
+                .items
+        } else {
+            store
+                .search(SearchQuery {
+                    text: self.query.clone(),
+                    favorite_only: self.favorite_only,
+                    include_deleted,
+                    limit: None,
+                    ..SearchQuery::default()
+                })
+                .await?
+                .items
+        };
+        if self.lifecycle == LifecycleFilter::Deleted {
+            items.retain(|item| item.state == "deleted");
+        }
+        let status = store.status().await?;
+
+        let next_selected = selected_id
+            .as_ref()
+            .and_then(|id| items.iter().position(|item| item.id == *id))
+            .unwrap_or_else(|| self.selected.min(items.len().saturating_sub(1)));
+        let next_selected_id = items.get(next_selected).map(|item| item.id.as_str());
+        if selected_id.as_deref() != next_selected_id {
+            self.detail_scroll = 0;
+        }
+        self.items = items;
+        self.selected = next_selected;
+        self.sync_selection();
+        self.status = status;
+        Ok(())
+    }
+
+    async fn handle_key(&mut self, store: &V2Store, key: KeyEvent) {
+        if control_shortcut(key) && key.code == KeyCode::Char('c') {
+            self.should_quit = true;
+            return;
+        }
+        self.notice = None;
+
+        match &mut self.mode {
+            Mode::Browse => self.handle_browse_key(store, key).await,
+            Mode::Search(input) => {
+                if key.code == KeyCode::Esc {
+                    self.mode = Mode::Browse;
+                    return;
+                }
+                if key.code == KeyCode::Enter && command_key(key) {
+                    let previous_query = std::mem::replace(&mut self.query, input.value());
+                    match self.refresh(store, None).await {
+                        Ok(()) => self.mode = Mode::Browse,
+                        Err(error) => {
+                            self.query = previous_query;
+                            self.notice_error(error);
+                        }
+                    }
+                    return;
+                }
+                input.handle_key(key, false);
+            }
+            Mode::Form(form) => {
+                if key.code == KeyCode::Esc {
+                    self.mode = Mode::Browse;
+                    return;
+                }
+                if control_shortcut(key) && key.code == KeyCode::Char('s') {
+                    self.submit_form(store).await;
+                    return;
+                }
+                form.handle_key(key);
+            }
+            Mode::ConfirmDelete => match key.code {
+                KeyCode::Enter | KeyCode::Char('y') if command_key(key) => {
+                    self.delete_selected(store).await;
+                }
+                KeyCode::Char('n') if command_key(key) => self.mode = Mode::Browse,
+                KeyCode::Esc => self.mode = Mode::Browse,
+                _ => {}
+            },
+            Mode::Help => {
+                if key.code == KeyCode::Esc
+                    || command_key(key)
+                        && matches!(key.code, KeyCode::Char('?') | KeyCode::Enter)
+                {
+                    self.mode = Mode::Browse;
+                }
+            }
+        }
+    }
+
+    fn accept_key_press(&mut self, key: KeyEvent) -> bool {
+        let mode = self.mode.kind();
+        let signature = (key.code, key.modifiers);
+        if let Some((latched_mode, code, modifiers, observed_at)) = &mut self.action_latch
+            && (*latched_mode, *code, *modifiers) == (mode, signature.0, signature.1)
+        {
+            *observed_at = Instant::now();
+            return false;
+        }
+        self.action_latch = self
+            .is_one_shot_key(key)
+            .then(|| (mode, signature.0, signature.1, Instant::now()));
+        true
+    }
+
+    fn release_key(&mut self, key: KeyEvent) {
+        if self
+            .action_latch
+            .as_ref()
+            .is_some_and(|(_, code, modifiers, _)| {
+                (*code, *modifiers) == (key.code, key.modifiers)
+            })
+        {
+            self.action_latch = None;
+        }
+    }
+
+    fn note_key_repeat(&mut self, key: KeyEvent) {
+        if let Some((_, code, modifiers, observed_at)) = &mut self.action_latch
+            && (*code, *modifiers) == (key.code, key.modifiers)
+        {
+            *observed_at = Instant::now();
+        }
+    }
+
+    fn clear_action_latch(&mut self) {
+        if self
+            .action_latch
+            .as_ref()
+            .is_some_and(|(_, _, _, observed_at)| observed_at.elapsed() >= ACTION_LATCH_IDLE)
+        {
+            self.action_latch = None;
+        }
+    }
+
+    fn is_one_shot_key(&self, key: KeyEvent) -> bool {
+        if control_shortcut(key) && key.code == KeyCode::Char('c') {
+            return true;
+        }
+        match &self.mode {
+            Mode::Browse => {
+                key.code == KeyCode::Esc && !self.query.is_empty()
+                    || command_key(key)
+                        && matches!(
+                            key.code,
+                            KeyCode::Char('?' | '/' | 'a' | 'e' | ' ' | 'x' | 'r')
+                                | KeyCode::Enter
+                        )
+            }
+            Mode::Search(_) => {
+                key.code == KeyCode::Esc || key.code == KeyCode::Enter && command_key(key)
+            }
+            Mode::Form(form) => {
+                key.code == KeyCode::Esc
+                    || control_shortcut(key) && key.code == KeyCode::Char('s')
+                    || form.active == form.fields.len()
+                        && key.code == KeyCode::Char(' ')
+                        && command_key(key)
+            }
+            Mode::ConfirmDelete => {
+                key.code == KeyCode::Esc
+                    || command_key(key)
+                        && matches!(key.code, KeyCode::Enter | KeyCode::Char('y' | 'n'))
+            }
+            Mode::Help => {
+                key.code == KeyCode::Esc
+                    || command_key(key)
+                        && matches!(key.code, KeyCode::Char('?') | KeyCode::Enter)
+            }
+        }
+    }
+
+    fn handle_repeat_key(&mut self, key: KeyEvent) {
+        self.notice = None;
+        match &mut self.mode {
+            Mode::Browse => match key.code {
+                KeyCode::Down | KeyCode::Char('j') if command_key(key) => self.select_next(1),
+                KeyCode::Up | KeyCode::Char('k') if command_key(key) => self.select_previous(1),
+                KeyCode::PageDown if command_key(key) => self.select_next(10),
+                KeyCode::PageUp if command_key(key) => self.select_previous(10),
+                KeyCode::Char('d') if control_shortcut(key) => {
+                    self.detail_scroll = self.detail_scroll.saturating_add(5);
+                }
+                KeyCode::Char('u') if control_shortcut(key) => {
+                    self.detail_scroll = self.detail_scroll.saturating_sub(5);
+                }
+                _ => {}
+            },
+            Mode::Search(_) | Mode::Form(_) | Mode::ConfirmDelete | Mode::Help => {}
+        }
+    }
+
+    async fn handle_browse_key(&mut self, store: &V2Store, key: KeyEvent) {
+        match key.code {
+            KeyCode::Char('q') if command_key(key) => self.should_quit = true,
+            KeyCode::Char('?') if command_key(key) => self.mode = Mode::Help,
+            KeyCode::Down | KeyCode::Char('j') if command_key(key) => self.select_next(1),
+            KeyCode::Up | KeyCode::Char('k') if command_key(key) => self.select_previous(1),
+            KeyCode::PageDown if command_key(key) => self.select_next(10),
+            KeyCode::PageUp if command_key(key) => self.select_previous(10),
+            KeyCode::Home | KeyCode::Char('g') if command_key(key) => self.select_first(),
+            KeyCode::End | KeyCode::Char('G') if command_key(key) => self.select_last(),
+            KeyCode::Char('/') if command_key(key) => {
+                self.mode = Mode::Search(TextInput::new(self.query.clone()));
+            }
+            KeyCode::Esc if !self.query.is_empty() => {
+                let previous_query = self.query.clone();
+                self.query.clear();
+                if !self.refresh_or_notice(store, None).await {
+                    self.query = previous_query;
+                }
+            }
+            KeyCode::Char('f') if command_key(key) => {
+                self.favorite_only = !self.favorite_only;
+                if !self.refresh_or_notice(store, None).await {
+                    self.favorite_only = !self.favorite_only;
+                }
+            }
+            KeyCode::Char('d') if control_shortcut(key) => {
+                self.detail_scroll = self.detail_scroll.saturating_add(5);
+            }
+            KeyCode::Char('u') if control_shortcut(key) => {
+                self.detail_scroll = self.detail_scroll.saturating_sub(5);
+            }
+            KeyCode::Char('d') if command_key(key) => {
+                let previous = self.lifecycle;
+                self.lifecycle = self.lifecycle.next();
+                if !self.refresh_or_notice(store, None).await {
+                    self.lifecycle = previous;
+                }
+            }
+            KeyCode::Char('R') if command_key(key) => {
+                let _ = self.refresh_or_notice(store, None).await;
+            }
+            KeyCode::Char('a') if command_key(key) => {
+                self.mode = Mode::Form(Box::new(ItemForm::create()));
+            }
+            KeyCode::Char('e') | KeyCode::Enter if command_key(key) => {
+                if let Some(item) = self.selected_item().cloned() {
+                    self.mode = Mode::Form(Box::new(ItemForm::edit(item)));
+                }
+            }
+            KeyCode::Char(' ') if command_key(key) => self.toggle_favorite(store).await,
+            KeyCode::Char('x') if command_key(key) => {
+                if self
+                    .selected_item()
+                    .is_some_and(|item| item.state == "active")
+                {
+                    self.mode = Mode::ConfirmDelete;
+                }
+            }
+            KeyCode::Char('r') if command_key(key) => self.restore_selected(store).await,
+            _ => {}
+        }
+    }
+
+    fn handle_paste(&mut self, text: String) {
+        match &mut self.mode {
+            Mode::Search(input) => input.insert_text(&single_line(&text)),
+            Mode::Form(form) => form.insert_text(text),
+            _ => {}
+        }
+    }
+
+    async fn submit_form(&mut self, store: &V2Store) {
+        let Mode::Form(form) = &self.mode else {
+            return;
+        };
+        let submission = match form.submission() {
+            Ok(submission) => submission,
+            Err(error) => {
+                self.notice_error(error);
+                return;
+            }
+        };
+        let result = match submission {
+            FormSubmission::Create(request) => store.create_item(request).await,
+            FormSubmission::Edit(request) => store.edit_item(request).await,
+        };
+        match result {
+            Ok(item) => {
+                let item_id = item.id.clone();
+                let action = if form.original.is_some() {
+                    "Saved changes"
+                } else {
+                    "Captured save"
+                };
+                self.mode = Mode::Browse;
+                self.notice = Some(Notice::info(action));
+                let _ = self.refresh_or_notice(store, Some(&item_id)).await;
+            }
+            Err(error) => self.notice_error(error),
+        }
+    }
+
+    async fn toggle_favorite(&mut self, store: &V2Store) {
+        let Some(item) = self.selected_item().cloned() else {
+            return;
+        };
+        let item_id = item.id.clone();
+        let result = store
+            .edit_item(EditItemRequest {
+                item_id: item.id,
+                favorite: Some(!item.favorite),
+                ..EditItemRequest::default()
+            })
+            .await;
+        match result {
+            Ok(_) => {
+                self.notice = Some(Notice::info(if item.favorite {
+                    "Removed favorite"
+                } else {
+                    "Marked favorite"
+                }));
+                let _ = self.refresh_or_notice(store, Some(&item_id)).await;
+            }
+            Err(error) => self.notice_error(error),
+        }
+    }
+
+    async fn delete_selected(&mut self, store: &V2Store) {
+        let Some(item_id) = self.selected_item().map(|item| item.id.clone()) else {
+            self.mode = Mode::Browse;
+            return;
+        };
+        match store.delete_item(&item_id).await {
+            Ok(_) => {
+                self.mode = Mode::Browse;
+                self.notice = Some(Notice::info("Moved save to deleted"));
+                let _ = self.refresh_or_notice(store, None).await;
+            }
+            Err(error) => self.notice_error(error),
+        }
+    }
+
+    async fn restore_selected(&mut self, store: &V2Store) {
+        let Some(item) = self.selected_item().cloned() else {
+            return;
+        };
+        if item.state != "deleted" {
+            self.notice = Some(Notice::info("Selected save is already active"));
+            return;
+        }
+        let item_id = item.id.clone();
+        match store.restore_item(&item_id).await {
+            Ok(_) => {
+                self.notice = Some(Notice::info("Restored save"));
+                let _ = self.refresh_or_notice(store, Some(&item_id)).await;
+            }
+            Err(error) => self.notice_error(error),
+        }
+    }
+
+    async fn refresh_or_notice(&mut self, store: &V2Store, preferred_id: Option<&str>) -> bool {
+        match self.refresh(store, preferred_id).await {
+            Ok(()) => true,
+            Err(error) => {
+                self.notice_error(error);
+                false
+            }
+        }
+    }
+
+    fn notice_error(&mut self, error: impl std::fmt::Display) {
+        self.notice = Some(Notice::error(error.to_string()));
+    }
+
+    fn selected_item(&self) -> Option<&StoredItem> {
+        self.items.get(self.selected)
+    }
+
+    fn select_next(&mut self, amount: usize) {
+        if !self.items.is_empty() {
+            self.selected = (self.selected + amount).min(self.items.len() - 1);
+            self.detail_scroll = 0;
+            self.sync_selection();
+        }
+    }
+
+    fn select_previous(&mut self, amount: usize) {
+        self.selected = self.selected.saturating_sub(amount);
+        self.detail_scroll = 0;
+        self.sync_selection();
+    }
+
+    fn select_first(&mut self) {
+        self.selected = 0;
+        self.detail_scroll = 0;
+        self.sync_selection();
+    }
+
+    fn select_last(&mut self) {
+        self.selected = self.items.len().saturating_sub(1);
+        self.detail_scroll = 0;
+        self.sync_selection();
+    }
+
+    fn sync_selection(&mut self) {
+        self.list_state
+            .select((!self.items.is_empty()).then_some(self.selected));
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum LifecycleFilter {
+    Active,
+    All,
+    Deleted,
+}
+
+impl LifecycleFilter {
+    fn next(self) -> Self {
+        match self {
+            Self::Active => Self::All,
+            Self::All => Self::Deleted,
+            Self::Deleted => Self::Active,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::All => "all",
+            Self::Deleted => "deleted",
+        }
+    }
+}
+
+enum Mode {
+    Browse,
+    Search(TextInput),
+    Form(Box<ItemForm>),
+    ConfirmDelete,
+    Help,
+}
+
+impl Mode {
+    fn kind(&self) -> ModeKind {
+        match self {
+            Self::Browse => ModeKind::Browse,
+            Self::Search(_) => ModeKind::Search,
+            Self::Form(_) => ModeKind::Form,
+            Self::ConfirmDelete => ModeKind::ConfirmDelete,
+            Self::Help => ModeKind::Help,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum ModeKind {
+    Browse,
+    Search,
+    Form,
+    ConfirmDelete,
+    Help,
+}
+
+struct Notice {
+    text: String,
+    error: bool,
+}
+
+impl Notice {
+    fn info(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            error: false,
+        }
+    }
+
+    fn error(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            error: true,
+        }
+    }
+}
+
+struct ItemForm {
+    fields: Vec<FormField>,
+    active: usize,
+    favorite: bool,
+    original: Option<StoredItem>,
+}
+
+impl ItemForm {
+    fn create() -> Self {
+        Self {
+            fields: vec![
+                FormField::new("URL", "", false),
+                FormField::new("Title", "", false),
+                FormField::new("Excerpt", "", false),
+                FormField::new("Note", "", true),
+                FormField::new("Tags (comma list or JSON)", "", false),
+            ],
+            active: 0,
+            favorite: false,
+            original: None,
+        }
+    }
+
+    fn edit(item: StoredItem) -> Self {
+        Self {
+            fields: vec![
+                FormField::new("URL", &item.url, false),
+                FormField::new("Title", item.title.as_deref().unwrap_or_default(), false),
+                FormField::new(
+                    "Excerpt",
+                    item.excerpt.as_deref().unwrap_or_default(),
+                    false,
+                ),
+                FormField::new("Note", item.note.as_deref().unwrap_or_default(), true),
+                FormField::new("Tags (comma list or JSON)", &format_tags(&item.tags), false),
+            ],
+            active: 0,
+            favorite: item.favorite,
+            original: Some(item),
+        }
+    }
+
+    fn title(&self) -> &'static str {
+        if self.original.is_some() {
+            "Edit save"
+        } else {
+            "Capture save"
+        }
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Tab | KeyCode::Down | KeyCode::Enter if command_key(key) => {
+                self.active = (self.active + 1) % (self.fields.len() + 1);
+            }
+            KeyCode::BackTab | KeyCode::Up if command_key(key) => {
+                self.active = self.active.checked_sub(1).unwrap_or(self.fields.len());
+            }
+            KeyCode::Char(' ') if self.active == self.fields.len() && command_key(key) => {
+                self.favorite = !self.favorite;
+            }
+            KeyCode::Char('j' | 'n')
+                if control_shortcut(key)
+                    && self.active < self.fields.len()
+                    && self.fields[self.active].multiline =>
+            {
+                self.fields[self.active].input.insert_char('\n');
+            }
+            _ if self.active < self.fields.len() => {
+                let multiline = self.fields[self.active].multiline;
+                self.fields[self.active].input.handle_key(key, multiline);
+            }
+            _ => {}
+        }
+    }
+
+    fn insert_text(&mut self, text: String) {
+        if self.active >= self.fields.len() {
+            return;
+        }
+        let value = if self.fields[self.active].multiline {
+            text.replace("\r\n", "\n").replace('\r', "\n")
+        } else {
+            single_line(&text)
+        };
+        self.fields[self.active].input.insert_text(&value);
+    }
+
+    fn submission(&self) -> Result<FormSubmission, String> {
+        let url = self.fields[0].input.value().trim().to_owned();
+        let title = self.fields[1].input.value().to_owned();
+        let excerpt = self.fields[2].input.value().to_owned();
+        let note = self.fields[3].input.value().to_owned();
+        let tags = parse_tags(&self.fields[4].input.value())?;
+
+        let Some(original) = &self.original else {
+            return Ok(FormSubmission::Create(CreateItemRequest {
+                url,
+                title: nonempty(title),
+                excerpt: nonempty(excerpt),
+                favorite: self.favorite,
+                language: None,
+                saved_at: None,
+                note,
+                tags,
+            }));
+        };
+
+        let old_tags = original.tags.iter().cloned().collect::<BTreeSet<_>>();
+        let new_tags = tags.into_iter().collect::<BTreeSet<_>>();
+        let original_note = original.note.as_deref().unwrap_or_default();
+        let note_changed = note != original_note;
+        Ok(FormSubmission::Edit(EditItemRequest {
+            item_id: original.id.clone(),
+            url: (url != original.url).then_some(url),
+            title: optional_text_change(original.title.as_deref(), &title),
+            excerpt: optional_text_change(original.excerpt.as_deref(), &excerpt),
+            favorite: (self.favorite != original.favorite).then_some(self.favorite),
+            language: None,
+            saved_at: None,
+            note: note_changed.then_some(note),
+            expected_note: note_changed.then(|| original_note.to_owned()),
+            add_tags: new_tags.difference(&old_tags).cloned().collect(),
+            remove_tags: old_tags.difference(&new_tags).cloned().collect(),
+        }))
+    }
+}
+
+enum FormSubmission {
+    Create(CreateItemRequest),
+    Edit(EditItemRequest),
+}
+
+struct FormField {
+    label: &'static str,
+    input: TextInput,
+    multiline: bool,
+}
+
+impl FormField {
+    fn new(label: &'static str, value: &str, multiline: bool) -> Self {
+        Self {
+            label,
+            input: TextInput::new(value.to_owned()),
+            multiline,
+        }
+    }
+}
+
+struct TextInput {
+    chars: Vec<char>,
+    cursor: usize,
+}
+
+impl TextInput {
+    fn new(value: String) -> Self {
+        let chars = value.chars().collect::<Vec<_>>();
+        let cursor = chars.len();
+        Self { chars, cursor }
+    }
+
+    fn value(&self) -> String {
+        self.chars.iter().collect()
+    }
+
+    fn display_value(&self, focused: bool, max_width: usize) -> String {
+        let marker = usize::from(focused);
+        let rendered_width = UnicodeWidthStr::width(self.value().as_str()) + marker;
+        if rendered_width <= max_width.max(1) {
+            let mut chars = self.chars.clone();
+            if focused {
+                chars.insert(self.cursor, '|');
+            }
+            return chars.into_iter().collect();
+        }
+
+        let capacity = max_width.saturating_sub(marker + 6).max(1);
+        let mut start = if focused {
+            self.cursor.saturating_sub(capacity / 2)
+        } else {
+            0
+        };
+        let mut end = (start + capacity).min(self.chars.len());
+        start = end.saturating_sub(capacity);
+        while UnicodeWidthStr::width(self.chars[start..end].iter().collect::<String>().as_str())
+            > capacity
+            && end > start
+        {
+            if self.cursor.saturating_sub(start) > end.saturating_sub(self.cursor) {
+                start += 1;
+            } else {
+                end -= 1;
+            }
+        }
+        let mut visible = self.chars[start..end].to_vec();
+        if focused {
+            visible.insert(self.cursor.clamp(start, end) - start, '|');
+        }
+        format!(
+            "{}{}{}",
+            if start > 0 { "..." } else { "" },
+            visible.into_iter().collect::<String>(),
+            if end < self.chars.len() { "..." } else { "" }
+        )
+    }
+
+    fn rendered_value(&self, focused: bool) -> String {
+        let mut chars = self.chars.clone();
+        if focused {
+            chars.insert(self.cursor, '|');
+        }
+        chars.into_iter().collect()
+    }
+
+    fn current_line_value(&self, max_width: usize) -> String {
+        let start = self.chars[..self.cursor]
+            .iter()
+            .rposition(|character| *character == '\n')
+            .map_or(0, |position| position + 1);
+        let end = self.chars[self.cursor..]
+            .iter()
+            .position(|character| *character == '\n')
+            .map_or(self.chars.len(), |position| self.cursor + position);
+        Self {
+            chars: self.chars[start..end].to_vec(),
+            cursor: self.cursor - start,
+        }
+        .display_value(true, max_width)
+    }
+
+    fn scroll_offset(&self, width: u16, height: u16) -> (u16, u16) {
+        let before = self.chars[..self.cursor].iter().collect::<String>();
+        let line = before.matches('\n').count();
+        let column = UnicodeWidthStr::width(before.rsplit('\n').next().unwrap_or_default());
+        (
+            u16::try_from(line.saturating_sub(usize::from(height.saturating_sub(1))))
+                .unwrap_or(u16::MAX),
+            u16::try_from(column.saturating_sub(usize::from(width.saturating_sub(1))))
+                .unwrap_or(u16::MAX),
+        )
+    }
+
+    fn insert_char(&mut self, character: char) {
+        self.chars.insert(self.cursor, character);
+        self.cursor += 1;
+    }
+
+    fn insert_text(&mut self, text: &str) {
+        for character in text.chars() {
+            self.insert_char(character);
+        }
+    }
+
+    fn handle_key(&mut self, key: KeyEvent, multiline: bool) {
+        match key.code {
+            KeyCode::Char('a') if control_shortcut(key) => self.cursor = 0,
+            KeyCode::Char('e') if control_shortcut(key) => {
+                self.cursor = self.chars.len();
+            }
+            KeyCode::Char('u') if control_shortcut(key) => {
+                self.chars.drain(..self.cursor);
+                self.cursor = 0;
+            }
+            KeyCode::Char(character) if text_entry_key(key) => {
+                self.insert_char(character);
+            }
+            KeyCode::Left => self.cursor = self.cursor.saturating_sub(1),
+            KeyCode::Right => self.cursor = (self.cursor + 1).min(self.chars.len()),
+            KeyCode::Home => self.cursor = 0,
+            KeyCode::End => self.cursor = self.chars.len(),
+            KeyCode::Backspace if self.cursor > 0 => {
+                self.cursor -= 1;
+                self.chars.remove(self.cursor);
+            }
+            KeyCode::Delete if self.cursor < self.chars.len() => {
+                self.chars.remove(self.cursor);
+            }
+            KeyCode::Enter if multiline => self.insert_char('\n'),
+            _ => {}
+        }
+    }
+}
+
+fn render(frame: &mut Frame<'_>, app: &mut App) {
+    let area = frame.area();
+    frame.render_widget(
+        Block::default().style(Style::default().bg(Color::Black)),
+        area,
+    );
+    if area.width < 40 || area.height < 12 {
+        frame.render_widget(
+            Paragraph::new(
+                "ResearchPocket needs at least a 40 x 12 terminal. Resize, press Esc to close a dialog, or Ctrl+C to exit.",
+            )
+                .alignment(Alignment::Center)
+                .wrap(Wrap { trim: false }),
+            area,
+        );
+        return;
+    }
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(2),
+        ])
+        .split(area);
+    render_header(frame, rows[0], app);
+    render_body(frame, rows[1], app);
+    render_footer(frame, rows[2], app);
+
+    match &app.mode {
+        Mode::Form(form) => render_form(frame, area, form),
+        Mode::ConfirmDelete => render_confirmation(frame, area, app.selected_item()),
+        Mode::Help => render_help(frame, area),
+        Mode::Browse | Mode::Search(_) => {}
+    }
+}
+
+fn render_header(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let search = if app.query.is_empty() {
+        "no search".to_owned()
+    } else {
+        format!("search: {}", terminal_safe(&app.query))
+    };
+    let filter = format!(
+        "{} | {}{}",
+        search,
+        app.lifecycle.label(),
+        if app.favorite_only {
+            " | favorites"
+        } else {
+            ""
+        }
+    );
+    let title = Line::from(vec![
+        Span::styled(
+            "ResearchPocket",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(filter, Style::default().fg(Color::DarkGray)),
+    ]);
+    frame.render_widget(
+        Paragraph::new(title)
+            .block(Block::default().borders(Borders::BOTTOM))
+            .alignment(Alignment::Left),
+        area,
+    );
+}
+
+fn render_body(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
+    if area.width < MIN_COMFORTABLE_WIDTH || area.height < MIN_COMFORTABLE_HEIGHT {
+        let parts = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+            .split(area);
+        render_list(frame, parts[0], app);
+        render_detail(frame, parts[1], app.selected_item(), app.detail_scroll);
+    } else {
+        let parts = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(44), Constraint::Percentage(56)])
+            .split(area);
+        render_list(frame, parts[0], app);
+        render_detail(frame, parts[1], app.selected_item(), app.detail_scroll);
+    }
+}
+
+fn render_list(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
+    let items = app
+        .items
+        .iter()
+        .map(|item| {
+            let title = item
+                .title
+                .as_deref()
+                .filter(|title| !title.is_empty())
+                .unwrap_or("Untitled");
+            let marker = if item.favorite { "* " } else { "  " };
+            let state = if item.state == "deleted" {
+                " [deleted]"
+            } else {
+                ""
+            };
+            ListItem::new(vec![
+                Line::from(format!("{marker}{}{state}", terminal_safe(title))),
+                Line::from(Span::styled(
+                    terminal_safe(&item.url),
+                    Style::default().fg(Color::DarkGray),
+                )),
+            ])
+        })
+        .collect::<Vec<_>>();
+    let title = format!(" Saves ({}) ", app.items.len());
+    let list = List::new(items)
+        .block(Block::default().title(title).borders(Borders::ALL))
+        .highlight_symbol("> ")
+        .highlight_style(
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        );
+    frame.render_stateful_widget(list, area, &mut app.list_state);
+}
+
+fn render_detail(frame: &mut Frame<'_>, area: Rect, item: Option<&StoredItem>, scroll: u16) {
+    let text = item.map_or_else(
+        || Text::from("No saves match the current view."),
+        |item| {
+            let mut lines = vec![
+                detail_line("Title", item.title.as_deref().unwrap_or("Untitled")),
+                detail_line("URL", &item.url),
+                detail_line("Saved", &item.saved_at),
+                detail_line("State", &item.state),
+                detail_line("Favorite", if item.favorite { "yes" } else { "no" }),
+                detail_line(
+                    "Tags",
+                    if item.tags.is_empty() {
+                        "-".to_owned()
+                    } else {
+                        item.tags.join(", ")
+                    },
+                ),
+            ];
+            if let Some(excerpt) = &item.excerpt {
+                lines.push(Line::default());
+                lines.push(heading("Excerpt"));
+                lines.extend(excerpt.lines().map(|line| Line::from(terminal_safe(line))));
+            }
+            if let Some(note) = &item.note {
+                lines.push(Line::default());
+                lines.push(heading("Private note"));
+                lines.extend(note.lines().map(|line| Line::from(terminal_safe(line))));
+            }
+            lines.push(Line::default());
+            lines.push(detail_line("ID", &item.id));
+            Text::from(lines)
+        },
+    );
+    frame.render_widget(
+        Paragraph::new(text)
+            .block(Block::default().title(" Details ").borders(Borders::ALL))
+            .scroll((scroll, 0))
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn render_footer(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let compact = area.width < 78;
+    let status = if compact {
+        format!(
+            "{} active | {} deleted | {} pending",
+            app.status.active_items, app.status.deleted_items, app.status.pending_updates
+        )
+    } else {
+        format!(
+            "{} active | {} deleted | {} pending | sync: {}",
+            app.status.active_items,
+            app.status.deleted_items,
+            app.status.pending_updates,
+            app.status.sync_state
+        )
+    };
+    let message = match &app.mode {
+        Mode::Search(input) => Line::from(vec![
+            Span::styled("Search: ", Style::default().fg(Color::Cyan)),
+            Span::raw(terminal_safe(
+                &input.display_value(true, usize::from(area.width.saturating_sub(28))),
+            )),
+            Span::styled(
+                app.notice
+                    .as_ref()
+                    .map_or("  Enter apply | Esc cancel".to_owned(), |notice| {
+                        format!("  error: {}", terminal_safe(&notice.text))
+                    }),
+                Style::default().fg(if app.notice.is_some() {
+                    Color::Red
+                } else {
+                    Color::DarkGray
+                }),
+            ),
+        ]),
+        _ => {
+            if let Some(notice) = &app.notice {
+                Line::styled(
+                    terminal_safe(&notice.text),
+                    Style::default().fg(if notice.error {
+                        Color::Red
+                    } else {
+                        Color::Green
+                    }),
+                )
+            } else {
+                Line::styled(
+                    if compact {
+                        "a add | / search | ? help | q quit"
+                    } else {
+                        "a add | e edit | / search | f favorites | d lifecycle | ? help | q quit"
+                    },
+                    Style::default().fg(Color::DarkGray),
+                )
+            }
+        }
+    };
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::styled(status, Style::default().fg(Color::DarkGray)),
+            message,
+        ]),
+        area,
+    );
+}
+
+fn render_form(frame: &mut Frame<'_>, area: Rect, form: &ItemForm) {
+    if area.width < 50 || area.height < 24 {
+        render_compact_form(frame, area, form);
+        return;
+    }
+    let popup = centered_rect(area, 90, 26);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(format!(" {} ", form.title()))
+        .borders(Borders::ALL)
+        .style(Style::default().bg(Color::Black));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let mut constraints = vec![Constraint::Length(3); form.fields.len()];
+    constraints[3] = Constraint::Min(4);
+    constraints.push(Constraint::Length(2));
+    constraints.push(Constraint::Length(2));
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
+        .split(inner);
+
+    for (index, field) in form.fields.iter().enumerate() {
+        let active = index == form.active;
+        let border_style =
+            Style::default().fg(if active { Color::Cyan } else { Color::DarkGray });
+        let input_area = rows[index];
+        let input_width = input_area.width.saturating_sub(2).max(1);
+        let input_height = input_area.height.saturating_sub(2).max(1);
+        let rendered = field.input.rendered_value(active);
+        let rendered = if field.multiline {
+            terminal_safe_multiline(&rendered)
+        } else {
+            terminal_safe(&rendered)
+        };
+        frame.render_widget(
+            Paragraph::new(rendered)
+                .block(
+                    Block::default()
+                        .title(format!(" {} ", field.label))
+                        .borders(Borders::ALL)
+                        .border_style(border_style),
+                )
+                .scroll(if active {
+                    field.input.scroll_offset(input_width, input_height)
+                } else {
+                    (0, 0)
+                }),
+            rows[index],
+        );
+    }
+    let favorite_style = if form.active == form.fields.len() {
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+    };
+    frame.render_widget(
+        Paragraph::new(format!(
+            "{}{} Favorite",
+            if form.active == form.fields.len() {
+                "> "
+            } else {
+                "  "
+            },
+            if form.favorite { "[x]" } else { "[ ]" }
+        ))
+        .style(favorite_style),
+        rows[form.fields.len()],
+    );
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from("Tab/Shift+Tab fields | Space favorite | Ctrl+N note newline"),
+            Line::from("Ctrl+S save | Esc cancel"),
+        ])
+        .style(Style::default().fg(Color::DarkGray)),
+        rows[form.fields.len() + 1],
+    );
+}
+
+fn render_compact_form(frame: &mut Frame<'_>, area: Rect, form: &ItemForm) {
+    let popup = centered_rect(area, 48, 10);
+    frame.render_widget(Clear, popup);
+    let text = if let Some(field) = form.fields.get(form.active) {
+        format!(
+            "{}\n\n{}\n\nFavorite: {}\nTab fields | Ctrl+S save | Esc cancel",
+            field.label,
+            terminal_safe(
+                &field
+                    .input
+                    .current_line_value(usize::from(popup.width.saturating_sub(4))),
+            ),
+            if form.favorite { "yes" } else { "no" }
+        )
+    } else {
+        format!(
+            "Favorite: {}\n\nSpace toggles\nTab fields | Ctrl+S save | Esc cancel",
+            if form.favorite { "yes" } else { "no" }
+        )
+    };
+    frame.render_widget(
+        Paragraph::new(text)
+            .block(
+                Block::default()
+                    .title(format!(" {} ", form.title()))
+                    .borders(Borders::ALL),
+            )
+            .wrap(Wrap { trim: false }),
+        popup,
+    );
+}
+
+fn render_confirmation(frame: &mut Frame<'_>, area: Rect, item: Option<&StoredItem>) {
+    let popup = centered_rect(area, 58, 7);
+    frame.render_widget(Clear, popup);
+    let title = item
+        .and_then(|item| item.title.as_deref())
+        .filter(|title| !title.is_empty())
+        .unwrap_or("this save");
+    frame.render_widget(
+        Paragraph::new(format!(
+            "Delete {}?\n\nThis is recoverable. Press y/Enter to confirm or n/Esc to cancel.",
+            terminal_snippet(title, usize::from(popup.width.saturating_sub(12)))
+        ))
+        .block(
+            Block::default()
+                .title(" Confirm delete ")
+                .borders(Borders::ALL),
+        )
+        .wrap(Wrap { trim: false }),
+        popup,
+    );
+}
+
+fn render_help(frame: &mut Frame<'_>, area: Rect) {
+    if area.width < 78 || area.height < 24 {
+        let popup = centered_rect(area, 48, 10);
+        frame.render_widget(Clear, popup);
+        let help = [
+            "j/k or arrows move | g/G first/last",
+            "a add | e edit | / search",
+            "Space favorite | x delete | r restore",
+            "f favorites | d views | R refresh",
+            "Esc cancel/clear | ? close help",
+            "q in library or Ctrl+C exits",
+        ];
+        frame.render_widget(
+            Paragraph::new(help.join("\n"))
+                .block(
+                    Block::default()
+                        .title(" Keyboard help ")
+                        .borders(Borders::ALL),
+                )
+                .wrap(Wrap { trim: false }),
+            popup,
+        );
+        return;
+    }
+    let popup = centered_rect(area, 76, 24);
+    frame.render_widget(Clear, popup);
+    let help = [
+        "Navigation",
+        "  j/k or arrows   move selection     g/G or Home/End   first/last",
+        "  PgUp/PgDn       move ten            R                 refresh",
+        "  Ctrl+U/Ctrl+D   scroll details",
+        "",
+        "Library",
+        "  a add           e/Enter edit        Space toggle favorite",
+        "  x delete        r restore           / search",
+        "  f favorites     d lifecycle view    Esc clear search",
+        "",
+        "Forms",
+        "  Tab/Shift+Tab fields                Space toggles favorite",
+        "  Ctrl+N note newline                 Ctrl+S commits one mutation",
+        "  Esc cancel",
+        "",
+        "The TUI is offline. It uses the same local V2 transactions as the CLI and",
+        "does not read a GitHub token or start synchronization.",
+        "",
+        "Press ?, Enter, or Esc to close help.",
+    ];
+    frame.render_widget(
+        Paragraph::new(help.join("\n"))
+            .block(
+                Block::default()
+                    .title(" Keyboard help ")
+                    .borders(Borders::ALL),
+            )
+            .wrap(Wrap { trim: false }),
+        popup,
+    );
+}
+
+fn centered_rect(area: Rect, max_width: u16, max_height: u16) -> Rect {
+    let width = max_width.min(area.width.saturating_sub(2)).max(1);
+    let height = max_height.min(area.height.saturating_sub(2)).max(1);
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+}
+
+fn heading(text: &'static str) -> Line<'static> {
+    Line::styled(
+        text,
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+fn detail_line<'a>(label: &'static str, value: impl Into<String>) -> Line<'a> {
+    Line::from(vec![
+        Span::styled(
+            format!("{label}: "),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(terminal_safe(&value.into())),
+    ])
+}
+
+fn optional_text_change(original: Option<&str>, value: &str) -> Option<OptionalTextUpdate> {
+    if original.unwrap_or_default() == value {
+        None
+    } else if value.is_empty() {
+        Some(OptionalTextUpdate::Clear)
+    } else {
+        Some(OptionalTextUpdate::Set(value.to_owned()))
+    }
+}
+
+fn format_tags(tags: &[String]) -> String {
+    Value::Array(tags.iter().cloned().map(Value::String).collect()).to_string()
+}
+
+fn parse_tags(value: &str) -> Result<Vec<String>, String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(Vec::new());
+    }
+    let tags = if value.starts_with('[') {
+        serde_json::from_str::<Vec<String>>(value).map_err(|_| {
+            "tags JSON must be an array of strings, such as [\"reading\", \"rust\"]".to_owned()
+        })?
+    } else {
+        value
+            .split(',')
+            .map(str::trim)
+            .filter(|tag| !tag.is_empty())
+            .map(str::to_owned)
+            .collect()
+    };
+    if tags.iter().any(|tag| tag.trim().is_empty()) {
+        return Err("tags cannot be empty or whitespace-only".to_owned());
+    }
+    Ok(tags
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect())
+}
+
+fn nonempty(value: String) -> Option<String> {
+    (!value.is_empty()).then_some(value)
+}
+
+fn single_line(value: &str) -> String {
+    value.replace("\r\n", " ").replace(['\r', '\n'], " ")
+}
+
+fn terminal_safe(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                '\u{fffd}'
+            } else {
+                character
+            }
+        })
+        .collect()
+}
+
+fn terminal_snippet(value: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+    let value = terminal_safe(value);
+    if UnicodeWidthStr::width(value.as_str()) <= max_width {
+        return value;
+    }
+    let mut snippet = String::new();
+    for character in value.chars() {
+        snippet.push(character);
+        if UnicodeWidthStr::width(snippet.as_str()) >= max_width.saturating_sub(1) {
+            while UnicodeWidthStr::width(snippet.as_str()) > max_width.saturating_sub(1) {
+                snippet.pop();
+            }
+            break;
+        }
+    }
+    snippet.push('…');
+    snippet
+}
+
+fn terminal_safe_multiline(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character == '\n' {
+                '\n'
+            } else if character.is_control() {
+                '\u{fffd}'
+            } else {
+                character
+            }
+        })
+        .collect()
+}
+
+fn control_shortcut(key: KeyEvent) -> bool {
+    key.modifiers == KeyModifiers::CONTROL
+}
+
+fn command_key(key: KeyEvent) -> bool {
+    !key.modifiers.intersects(
+        KeyModifiers::CONTROL
+            | KeyModifiers::ALT
+            | KeyModifiers::SUPER
+            | KeyModifiers::HYPER
+            | KeyModifiers::META,
+    )
+}
+
+fn text_entry_key(key: KeyEvent) -> bool {
+    command_key(key)
+        || key
+            .modifiers
+            .contains(KeyModifiers::CONTROL | KeyModifiers::ALT)
+            && !key
+                .modifiers
+                .intersects(KeyModifiers::SUPER | KeyModifiers::HYPER | KeyModifiers::META)
+}

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use serde_json::{Value, json};
 
 use crate::cli::{CliArgs, Commands, ImportCommands, OutputFormat, SyncCommands};
-use crate::sync;
+use crate::{sync, tui};
 
 type CliResult<T> = Result<T, Box<dyn Error>>;
 
@@ -52,6 +52,7 @@ pub async fn handle(args: &CliArgs) -> CliResult<()> {
                     language: optional_text_update(&edit.language, edit.clear_language),
                     saved_at: edit.saved_at,
                     note: edit.note.clone(),
+                    expected_note: None,
                     add_tags: edit.add_tag.clone(),
                     remove_tags: edit.remove_tag.clone(),
                 })
@@ -117,6 +118,13 @@ pub async fn handle(args: &CliArgs) -> CliResult<()> {
                 .await?;
             let output = command_output("search", result)?;
             write_search(args.format, &output)
+        }
+        Commands::Tui => {
+            if args.format != OutputFormat::Human {
+                return Err(io::Error::other("the TUI supports only human output").into());
+            }
+            let store = V2Store::open(&data_dir).await?;
+            tui::run(&store).await
         }
         Commands::Sync { command } => handle_sync(&data_dir, args.format, command).await,
         Commands::Status => handle_status(&data_dir, args.format).await,


### PR DESCRIPTION
Closes #3

## What changed

- adds the local-first research tui workflow for browse, search, capture, edit, favorite, delete, and restore
- keeps all mutations on the shared V2 store and adds stale-note protection inside the write transaction
- makes terminal input safe across small screens, key repeats, AltGr text entry, signals, and untrusted saved content
- documents keyboard controls and exact JSON tag editing

## Verification

- cargo fmt --all -- --check
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- cargo test --locked --workspace --all-targets --all-features
- cargo audit --deny warnings
- cargo build --locked --release
- web npm test, npm run build, npm audit --omit=dev
- manual PTY coverage for search, mutations, repeated keys, help, signals, exact tags, and terminal restoration