### PR TITLE
Ship browser private GitHub sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3307,7 +3307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3682,9 +3682,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4185,6 +4185,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "bd2f034a4bebf216c9e4b7083603e024cf930873fd67830cfb083c9fa33129d9"

--- a/README.md
+++ b/README.md
@@ -117,10 +117,13 @@ npm ci
 npm run dev
 ```
 
-The production build is deployed as a credential-free GitHub Pages shell. PAT
-onboarding and browser pull/push are the next hosted-owner slice; this foundation
-does not claim that browser-only changes are remotely backed up yet. See the
-[hosted application contract](docs/v2/WEB.md).
+The production build is deployed as a credential-free GitHub Pages shell. Its
+Private sync panel connects a separate private data repository with an expiring,
+repository-scoped fine-grained PAT. The browser pulls on startup, focus, network
+recovery, and every 60 seconds while visible; local changes also request a sync.
+The token stays in JavaScript memory unless the owner explicitly chooses
+tab-only `sessionStorage`, and it never enters IndexedDB, URLs, logs, or the
+service-worker cache. See the [hosted application contract](docs/v2/WEB.md).
 
 ## Terminal interface
 
@@ -157,12 +160,11 @@ The complete command and output contract is in [docs/v2/CLI.md](docs/v2/CLI.md).
 
 ## Current boundary
 
-The CLI supports private GitHub synchronization, new-device restoration, and an
-optional foreground periodic loop. The TUI supports local capture, curation,
-search, and recoverable lifecycle management. The static owner UI supports
-offline local editing through the shared WASM core. Browser GitHub
-synchronization, installed background scheduling, checkpoints, local web
-management, and V2 publication are not implemented yet.
+The CLI and hosted owner UI support private GitHub synchronization and
+new-device restoration. The TUI supports local capture, curation, search, and
+recoverable lifecycle management. Installed background scheduling, checkpoints,
+the loopback local web server, and selective V2 publication are not implemented
+yet.
 
 Clients exchange immutable CRDT update batches. Git commits, branches, merges,
 rebases, timestamps, and last-push order never choose application values or

--- a/crates/research-domain/src/genesis.rs
+++ b/crates/research-domain/src/genesis.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -56,9 +57,11 @@ impl LibraryGenesis {
             return Err(DomainError::UnsupportedFeature(feature.clone()));
         }
         validate_uuid_v7(&self.library_id, "library ID")?;
-        if self.created_at.trim().is_empty() {
+        let created_at: DateTime<FixedOffset> = DateTime::parse_from_rfc3339(&self.created_at)
+            .map_err(|_| DomainError::InvalidState("invalid genesis creation time".into()))?;
+        if created_at.offset().local_minus_utc() != 0 {
             return Err(DomainError::InvalidState(
-                "genesis creation time cannot be blank".into(),
+                "genesis creation time is not in UTC".into(),
             ));
         }
         Ok(())

--- a/crates/research-domain/src/wasm.rs
+++ b/crates/research-domain/src/wasm.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    CanonicalProjection, DomainError, DomainResult, ItemSeed, Library, LifecycleState,
-    UpdateEnvelope, identity::validate_uuid_v7,
+    CanonicalProjection, DomainError, DomainResult, ItemSeed, Library, LibraryGenesis,
+    LifecycleState, UpdateEnvelope, identity::validate_uuid_v7,
 };
 
 #[derive(Serialize)]
@@ -74,6 +74,8 @@ enum BrowserMutation {
         saved_at: OptionalField<i64>,
         #[serde(default)]
         note: OptionalField<TextUpdate>,
+        #[serde(default)]
+        expected_note: OptionalField<NullableText>,
         #[serde(default)]
         add_tags: Vec<String>,
         #[serde(default)]
@@ -178,6 +180,23 @@ pub fn apply_remote_envelopes(
         envelope_json_array,
     )
     .map_err(js_error)
+}
+
+/// Create the immutable protocol genesis with the native domain constants.
+#[wasm_bindgen(js_name = createSyncGenesis)]
+pub fn create_sync_genesis(library_id: &str, created_at: &str) -> Result<String, JsValue> {
+    let genesis = LibraryGenesis::new(library_id, created_at).map_err(js_error)?;
+    serde_json::to_string(&genesis).map_err(|error| js_error(error.into()))
+}
+
+/// Validate remote protocol genesis and return its canonical library identity.
+#[wasm_bindgen(js_name = validateSyncGenesis)]
+pub fn validate_sync_genesis(genesis_json: &str) -> Result<String, JsValue> {
+    let genesis: LibraryGenesis = serde_json::from_str(genesis_json)
+        .map_err(DomainError::from)
+        .map_err(js_error)?;
+    genesis.validate().map_err(js_error)?;
+    Ok(genesis.library_id)
 }
 
 fn initialize(peer_id: &str) -> DomainResult<String> {
@@ -345,6 +364,7 @@ fn apply_one_mutation(
             language,
             saved_at,
             note,
+            expected_note,
             add_tags,
             remove_tags,
         } => apply_edit(
@@ -360,6 +380,7 @@ fn apply_one_mutation(
             language.0,
             saved_at.0,
             note.0,
+            expected_note.0,
             add_tags,
             remove_tags,
         ),
@@ -396,6 +417,7 @@ fn apply_edit(
     language: Option<TextUpdate>,
     saved_at: Option<i64>,
     note: Option<TextUpdate>,
+    expected_note: Option<NullableText>,
     add_tags: Vec<String>,
     remove_tags: Vec<String>,
 ) -> DomainResult<()> {
@@ -445,6 +467,13 @@ fn apply_edit(
         library.write_saved_at(item_id, &format!("{prefix}/saved-at"), saved_at)?;
     }
     if let Some(note) = note {
+        if let Some(expected_note) = expected_note
+            && expected_note.0.as_deref().unwrap_or_default() != current.note.as_str()
+        {
+            return Err(DomainError::InvalidState(
+                "the note changed after this edit form opened".into(),
+            ));
+        }
         let replacement = note.value().unwrap_or_default();
         if replacement == current.note && !has_non_note_changes {
             return Err(DomainError::InvalidState(

--- a/crates/research-domain/tests/wasm_convergence.rs
+++ b/crates/research-domain/tests/wasm_convergence.rs
@@ -43,6 +43,36 @@ fn browser_snapshot_boundary_preserves_the_mutation_and_replay_contract() {
             "tags": ["z", "a", "a"]
         }),
     );
+    let note_advanced = mutation(
+        created["snapshot"].as_str().expect("created snapshot"),
+        "2",
+        json!({
+            "type": "edit",
+            "item_id": ITEM_ID,
+            "note": {"type": "set", "value": "hello from sync"},
+            "expected_note": "hello"
+        }),
+    );
+    assert!(
+        apply_mutation(
+            note_advanced["snapshot"]
+                .as_str()
+                .expect("advanced-note snapshot"),
+            "18446744073709551614",
+            LIBRARY_ID,
+            "00000000-0000-7000-8000-000000000002",
+            "3",
+            "2026-07-11T00:00:00Z",
+            &json!({
+                "type": "edit",
+                "item_id": ITEM_ID,
+                "note": {"type": "set", "value": "stale replacement"},
+                "expected_note": "hello"
+            })
+            .to_string(),
+        )
+        .is_err()
+    );
     let edited = mutation(
         created["snapshot"].as_str().expect("created snapshot"),
         "2",

--- a/docs/v2/MIGRATION.md
+++ b/docs/v2/MIGRATION.md
@@ -112,8 +112,9 @@ not public publication artifacts.
 
 ## Current alpha boundary
 
-Migration creates a local V2 library only. GitHub synchronization, new-device
-restore from GitHub, and GitHub Pages owner editing are not implemented yet. Do
-not synchronize `library.sqlite3` through Git. The later sync adapter will upload
-immutable CRDT update envelopes and will never use Git merge behavior to resolve
-library changes.
+Migration first creates a local V2 library. Connect that library through the CLI
+or hosted owner's Private sync panel to upload immutable CRDT envelopes to a
+separate private data repository. A pristine CLI or browser device can then
+adopt the repository's library identity and restore all saves. Never synchronize
+`library.sqlite3` through Git; Git merge behavior does not resolve library
+changes.

--- a/docs/v2/THREAT_MODEL.md
+++ b/docs/v2/THREAT_MODEL.md
@@ -57,10 +57,9 @@ from existing Git history are outside the V2 guarantee.
 | Publisher workflow | Trusted, pinned workflow in the private repository. It reads private state and writes only an allowlisted projection using a separate credential. |
 | Third-party pages and networks | Untrusted. They receive no owner data, analytics events, referrers containing secrets, or runtime requests from owner mode. |
 
-The implemented offline browser-store layout and static-shell behavior are
-documented in [WEB.md](./WEB.md). That implementation does not yet accept a PAT;
-the credential lifecycle below remains the binding contract for the browser
-synchronization slice.
+The implemented browser-store, static-shell, and private synchronization
+behavior is documented in [WEB.md](./WEB.md). The credential lifecycle below is
+the binding contract for that owner surface.
 
 ## Repository and credential topology
 

--- a/docs/v2/WEB.md
+++ b/docs/v2/WEB.md
@@ -1,7 +1,6 @@
 # ResearchPocket V2 hosted owner application
 
-Status: offline owner foundation; private GitHub browser synchronization is the
-next slice
+Status: offline owner editing and private GitHub browser synchronization
 
 ## What works now
 
@@ -21,12 +20,14 @@ of them:
 - the next fixed-width device sequence.
 
 The WASM boundary also accepts a set of remote immutable envelopes in one Loro
-session and reports any causally deferred indices. That path is ready for the
-browser GitHub adapter but is not exposed as owner authentication in this slice.
+session and reports any causally deferred indices. The browser GitHub adapter
+discovers exact protocol blobs, validates immutable genesis, applies unseen
+envelopes through this boundary, serializes Contents API creates, and pulls once
+more after uploads or branch-head races.
 
 ## Browser persistence
 
-IndexedDB database `researchpocket-v2`, version 1, contains only these stores:
+IndexedDB database `researchpocket-v2`, version 2, contains only these stores:
 
 | Store | Contents |
 | --- | --- |
@@ -37,11 +38,14 @@ IndexedDB database `researchpocket-v2`, version 1, contains only these stores:
 | `outbox` | Pending local protocol paths, attempt count, sanitized error category |
 | `deferred` | Exact remote envelopes still missing a causal predecessor |
 | `remoteObservations` | Protocol path, Git blob identity, observation time |
+| `syncConfig` | Non-secret owner, repository, branch, and sanitized success/error times |
 
 There is no credential, token, authorization-header, repository secret, or
-generic settings store. A fine-grained PAT will remain in JavaScript memory by
-default when browser synchronization lands; optional tab-only retention will
-use `sessionStorage`, never IndexedDB or `localStorage`.
+generic settings store. The fine-grained PAT remains in JavaScript memory by
+default; explicit tab-only retention uses `sessionStorage`, never IndexedDB or
+`localStorage`. Authentication, authorization, protocol-integrity, or
+upgrade-required failures immediately forget both token copies while preserving
+the durable outbox.
 
 Writes serialize across tabs with the Web Locks API. Browsers without Web Locks
 can read an existing library but fail closed before writing, because an in-tab
@@ -62,9 +66,34 @@ for same-origin shell resources and WASM. It explicitly bypasses all GitHub API
 traffic, cross-origin traffic, and non-GET requests, so it cannot cache a token,
 private API response, or upload body.
 
-Clearing browser site data deletes this device-local replica. Until the browser
-GitHub adapter is connected, browser-only pending changes are not remotely
-recoverable. The UI says this explicitly rather than implying a cloud backup.
+Clearing browser site data deletes this device-local replica. Once a successful
+private sync has drained the outbox, another pristine browser or CLI device can
+restore the library from immutable repository genesis and operations. Unsynced
+changes remain only in the current browser, and the UI reports their pending
+count rather than implying they are already backed up.
+
+## Owner synchronization lifecycle
+
+The owner supplies `OWNER/REPOSITORY`, an optional branch, and an expiring
+fine-grained PAT restricted to that private repository with Contents read/write.
+Repository coordinates and sanitized timestamps persist; the PAT follows the
+memory/tab-only boundary above. The browser rejects public, archived, disabled,
+unavailable, read-only, mismatched-library, malformed, or unsupported remotes
+before uploading queued work.
+
+One browser upload loop runs under a Web Lock. A cycle validates immutable
+genesis, discovers the Git tree, downloads and applies every unseen operation,
+uploads unchanged outbox bytes one at a time, and pulls again. Existing identical
+paths acknowledge the outbox; byte-different paths stop as integrity failures.
+`409`, `422`, ambiguous transport errors, rate limits, and server failures leave
+the exact outbox intact for bounded or later retry. Visible owner tabs request a
+cycle after local changes, on startup, focus, network recovery, and every 60
+seconds.
+
+An edit form carries the note value it originally displayed. If synchronization
+or another tab changes that note before submission, the shared WASM mutation
+boundary rejects the stale replacement before creating an envelope; the owner
+reopens the form against the merged text instead of overwriting it.
 
 ## Build and Pages deployment
 
@@ -80,9 +109,9 @@ npm run build
 The build compiles `research-domain` to WASM, generates the local JavaScript
 bridge, runs strict TypeScript checking, and emits a relative-path static site
 to `web/dist/`. The Pages workflow performs the same build and deploys only
-that directory from the public ResearchPocket source repository. The future
-owner PAT will be scoped to a different private data repository and therefore
-cannot modify the application JavaScript it executes.
+that directory from the public ResearchPocket source repository. The owner PAT
+is scoped to a different private data repository and therefore cannot modify
+the application JavaScript it executes.
 
 The complete credential and publication boundary remains in
 [THREAT_MODEL.md](./THREAT_MODEL.md), and immutable replay behavior remains in

--- a/web/README.md
+++ b/web/README.md
@@ -1,6 +1,15 @@
 # ResearchPocket web owner
 
-This static app opens a private library from IndexedDB and keeps local actions usable offline. A local action is durable before the interface reports success; the header shows how many immutable updates still need to be synchronized. This slice never asks for or persists a GitHub token and does not pull or push remote data yet.
+This static app opens a private library from IndexedDB and keeps local actions
+usable offline. A local action is durable before the interface reports success;
+the header shows how many immutable updates still need to be synchronized. The
+Private sync panel pulls and appends those updates through a separate private
+GitHub repository without using Git history as application conflict resolution.
+
+Use an expiring fine-grained PAT limited to the private data repository with
+`Contents: read/write`. The app holds it in JavaScript memory by default. The
+explicit tab-only option uses `sessionStorage`; no token is written to IndexedDB,
+`localStorage`, an API URL, logs, or service-worker caches.
 
 Install the WASM target and the CLI version pinned by the Rust crate once:
 
@@ -15,7 +24,13 @@ npm test
 npm run dev
 ```
 
-`npm test` runs the single browser-persistence contract: a complete local commit
-survives reopen, while an interrupted replacement exposes none of its writes.
+`npm test` runs two focused contracts: a complete local commit and non-secret
+sync configuration survive reopen while an interrupted replacement exposes none
+of its writes; the GitHub adapter keeps credentials in headers and sends exact
+immutable bytes without a replacement SHA.
 
-`npm run build` first compiles `research-domain` for `wasm32-unknown-unknown`, runs the matching `wasm-bindgen` CLI, type-checks the app, and creates the relative-path Pages build in `dist/`. The service worker caches only same-origin application-shell resources and bypasses `api.github.com`.
+`npm run build` first compiles `research-domain` for
+`wasm32-unknown-unknown`, runs the matching `wasm-bindgen` CLI, type-checks the
+app, and creates the relative-path Pages build in `dist/`. The service worker
+caches only same-origin application-shell resources and bypasses
+`api.github.com`.

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
     "dev": "npm run wasm && vite",
     "wasm": "node ./scripts/build-wasm.mjs",
     "typecheck": "tsc --noEmit",
-    "test": "node --experimental-strip-types --test src/data/db.test.mjs",
+    "test": "node --experimental-strip-types --test src/data/*.test.mjs",
     "build": "npm run wasm && npm run typecheck && vite build",
     "preview": "vite preview"
   },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,10 @@ import {
   type LibraryState,
   libraryRepository,
 } from "./data/library.ts";
+import {
+  browserSync,
+  type BrowserSyncState,
+} from "./data/sync.ts";
 
 type AddInput = Parameters<typeof libraryRepository.add>[0];
 type EditInput = Parameters<typeof libraryRepository.edit>[1];
@@ -37,9 +41,19 @@ const EMPTY_LIBRARY_STATE: LibraryState = {
   status: "opening",
 };
 
+const EMPTY_SYNC_STATE: BrowserSyncState = {
+  configuration: null,
+  credentialAvailable: false,
+  syncing: false,
+  status: "Private sync is not connected",
+  error: null,
+  lastCycle: null,
+};
+
 export function App() {
   const [libraryState, setLibraryState] =
     useState<LibraryState>(EMPTY_LIBRARY_STATE);
+  const [syncState, setSyncState] = useState<BrowserSyncState>(EMPTY_SYNC_STATE);
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<LifecycleFilter>("active");
   const [editingItem, setEditingItem] = useState<LibraryItemView | null>(null);
@@ -55,10 +69,14 @@ export function App() {
         setLibraryState(nextState);
       }
     });
+    const unsubscribeSync = browserSync.subscribe((nextState) => {
+      if (active) setSyncState(nextState);
+    });
 
     return () => {
       active = false;
       unsubscribe();
+      unsubscribeSync();
     };
   }, []);
 
@@ -132,7 +150,10 @@ export function App() {
 
   async function saveEdit(item: LibraryItemView, input: EditInput) {
     const saved = await runAction("Update link", "Changes saved locally.", () =>
-      libraryRepository.edit(item.id, input),
+      libraryRepository.edit(item.id, {
+        ...input,
+        expectedNote: item.note ?? null,
+      }),
     );
     if (saved) {
       closeEditor();
@@ -200,6 +221,8 @@ export function App() {
       </header>
 
       <main>
+        <SyncPanel state={syncState} />
+
         <section aria-labelledby="capture-heading" className="capture-section">
           <div className="section-intro">
             <p className="eyebrow">Capture</p>
@@ -353,6 +376,184 @@ function Welcome({
         </p>
       </section>
     </main>
+  );
+}
+
+function SyncPanel({ state }: { state: BrowserSyncState }) {
+  const [repository, setRepository] = useState("");
+  const [branch, setBranch] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+
+  async function connect(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const credential = readSyncCredential(form);
+    setFormError(null);
+    try {
+      await browserSync.connect({ repository, branch, ...credential });
+      form.reset();
+    } catch (error) {
+      setFormError(readError(error));
+    } finally {
+      clearCredentialInput(form);
+    }
+  }
+
+  async function unlock(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const credential = readSyncCredential(form);
+    setFormError(null);
+    try {
+      await browserSync.unlock(credential);
+      form.reset();
+    } catch (error) {
+      setFormError(readError(error));
+    } finally {
+      clearCredentialInput(form);
+    }
+  }
+
+  async function syncNow() {
+    setFormError(null);
+    try {
+      await browserSync.syncNow();
+    } catch (error) {
+      setFormError(readError(error));
+    }
+  }
+
+  const error = formError ?? state.error;
+  const remote = state.configuration;
+
+  return (
+    <section aria-labelledby="sync-heading" className="sync-section">
+      <div className="sync-copy">
+        <p className="eyebrow">Private sync</p>
+        <h1 id="sync-heading">Your library, wherever you open it.</h1>
+        <p>
+          ResearchPocket exchanges immutable application updates through a private
+          GitHub repository. Git commits never decide which save or note wins.
+        </p>
+        <div className="sync-state" role="status">
+          <span aria-hidden="true" className="status-dot" />
+          <span>{state.status}</span>
+        </div>
+        {remote ? (
+          <p className="sync-remote">
+            <strong>{remote.owner}/{remote.repository}</strong>
+            <span>Branch {remote.branch}</span>
+          </p>
+        ) : null}
+      </div>
+
+      {!remote ? (
+        <form className="sync-form" onSubmit={(event) => void connect(event)}>
+          <label className="field">
+            <span>Private data repository</span>
+            <input
+              autoCapitalize="none"
+              autoComplete="off"
+              onChange={(event) => setRepository(event.target.value)}
+              placeholder="owner/private-repository"
+              required
+              spellCheck={false}
+              value={repository}
+            />
+          </label>
+          <label className="field">
+            <span>Branch <small>default branch when blank</small></span>
+            <input
+              autoCapitalize="none"
+              autoComplete="off"
+              onChange={(event) => setBranch(event.target.value)}
+              placeholder="main"
+              spellCheck={false}
+              value={branch}
+            />
+          </label>
+          <TokenFields />
+          {error ? <p className="sync-error" role="alert">{error}</p> : null}
+          <button className="primary-button" disabled={state.syncing} type="submit">
+            {state.syncing ? "Connecting…" : "Connect private sync"}
+          </button>
+        </form>
+      ) : !state.credentialAvailable ? (
+        <form className="sync-form" onSubmit={(event) => void unlock(event)}>
+          <p>
+            Repository details stay on this device, but the credential does not.
+            Enter it again to pull and push queued changes.
+          </p>
+          <TokenFields />
+          {error ? <p className="sync-error" role="alert">{error}</p> : null}
+          <button className="primary-button" disabled={state.syncing} type="submit">
+            {state.syncing ? "Synchronizing…" : "Unlock and sync"}
+          </button>
+        </form>
+      ) : (
+        <div className="sync-controls">
+          <p>
+            Your credential is active only in this browser context and never enters
+            the library, an API URL, or the service-worker cache.
+          </p>
+          {state.lastCycle ? (
+            <dl className="sync-counts">
+              <div><dt>Downloaded</dt><dd>{state.lastCycle.downloaded}</dd></div>
+              <div><dt>Uploaded</dt><dd>{state.lastCycle.uploaded}</dd></div>
+              <div><dt>Pending</dt><dd>{state.lastCycle.pending}</dd></div>
+            </dl>
+          ) : null}
+          {error ? <p className="sync-error" role="alert">{error}</p> : null}
+          <div className="sync-actions">
+            <button
+              className="primary-button"
+              disabled={state.syncing}
+              onClick={() => void syncNow()}
+              type="button"
+            >
+              {state.syncing ? "Synchronizing…" : "Sync now"}
+            </button>
+            <button
+              className="secondary-button"
+              disabled={state.syncing}
+              onClick={() => browserSync.forgetCredential()}
+              type="button"
+            >
+              Forget token
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function TokenFields() {
+  return (
+    <>
+      <label className="field sync-token-field">
+        <span>Fine-grained GitHub token</span>
+        <input
+          autoCapitalize="none"
+          autoComplete="off"
+          name="github-token"
+          required
+          spellCheck={false}
+          type="password"
+        />
+      </label>
+      <label className="check-field sync-session-choice">
+        <input
+          name="remember-for-tab"
+          type="checkbox"
+        />
+        <span>Keep the token only for this tab session</span>
+      </label>
+      <p className="sync-help">
+        Use an expiring fine-grained token limited to this private repository with
+        Contents read and write access. Leave the box off to keep it in memory only.
+      </p>
+    </>
   );
 }
 
@@ -784,6 +985,23 @@ function parseTags(value: string) {
         .filter(Boolean),
     ),
   );
+}
+
+function readSyncCredential(form: HTMLFormElement) {
+  const data = new FormData(form);
+  const token = data.get("github-token");
+  if (typeof token !== "string") {
+    throw new Error("Enter a fine-grained GitHub token.");
+  }
+  return {
+    token,
+    rememberForTab: data.get("remember-for-tab") === "on",
+  };
+}
+
+function clearCredentialInput(form: HTMLFormElement) {
+  const input = form.elements.namedItem("github-token");
+  if (input instanceof HTMLInputElement) input.value = "";
 }
 
 function optionalText(value: string) {

--- a/web/src/data/db.test.mjs
+++ b/web/src/data/db.test.mjs
@@ -53,9 +53,19 @@ test("a browser library commit survives reopen and an interrupted replacement ro
     attempts: 0,
     lastErrorKind: null,
   };
+  const syncConfig = {
+    key: "github",
+    owner: "owner",
+    repository: "private-library",
+    branch: "main",
+    connectedAt: "2026-07-11T00:00:02.000Z",
+    lastSuccessAt: null,
+    lastErrorKind: null,
+    lastErrorAt: null,
+  };
 
   const commit = database.transaction(
-    ["meta", "state", "items", "batches", "outbox"],
+    ["meta", "state", "items", "batches", "outbox", "syncConfig"],
     "readwrite",
   );
   await commit.objectStore("meta").add(meta);
@@ -63,6 +73,7 @@ test("a browser library commit survives reopen and an interrupted replacement ro
   await commit.objectStore("items").add(item);
   await commit.objectStore("batches").add(batch);
   await commit.objectStore("outbox").add(outbox);
+  await commit.objectStore("syncConfig").add(syncConfig);
   await commit.done;
 
   database.close();
@@ -72,9 +83,11 @@ test("a browser library commit survives reopen and an interrupted replacement ro
   assert.deepEqual(await database.get("items", item.id), item);
   assert.deepEqual(await database.get("batches", path), batch);
   assert.deepEqual(await database.get("outbox", path), outbox);
+  assert.deepEqual(await database.get("syncConfig", "github"), syncConfig);
+  assert.equal(JSON.stringify(syncConfig).includes("token"), false);
 
   const interrupted = database.transaction(
-    ["meta", "state", "items", "outbox"],
+    ["meta", "state", "items", "outbox", "syncConfig"],
     "readwrite",
   );
   void interrupted.objectStore("meta").put({
@@ -87,6 +100,10 @@ test("a browser library commit survives reopen and an interrupted replacement ro
   }).catch(() => undefined);
   void interrupted.objectStore("items").clear().catch(() => undefined);
   void interrupted.objectStore("outbox").delete(path).catch(() => undefined);
+  void interrupted.objectStore("syncConfig").put({
+    ...syncConfig,
+    lastErrorKind: "transport",
+  }).catch(() => undefined);
   interrupted.abort();
   await assert.rejects(interrupted.done);
 
@@ -96,6 +113,7 @@ test("a browser library commit survives reopen and an interrupted replacement ro
   assert.deepEqual(await database.get("state", "canonical"), snapshot);
   assert.deepEqual(await database.get("items", item.id), item);
   assert.deepEqual(await database.get("outbox", path), outbox);
+  assert.deepEqual(await database.get("syncConfig", "github"), syncConfig);
 
   database.close();
   await deleteDB(databaseName);

--- a/web/src/data/db.ts
+++ b/web/src/data/db.ts
@@ -58,6 +58,17 @@ export interface RemoteObservation {
   observedAt: string;
 }
 
+export interface PersistedSyncConfiguration {
+  key: "github";
+  owner: string;
+  repository: string;
+  branch: string;
+  connectedAt: string;
+  lastSuccessAt: string | null;
+  lastErrorKind: string | null;
+  lastErrorAt: string | null;
+}
+
 interface ResearchPocketBrowserDb extends DBSchema {
   meta: {
     key: "library";
@@ -93,6 +104,10 @@ interface ResearchPocketBrowserDb extends DBSchema {
     key: string;
     value: RemoteObservation;
   };
+  syncConfig: {
+    key: "github";
+    value: PersistedSyncConfiguration;
+  };
 }
 
 let databasePromise: Promise<IDBPDatabase<ResearchPocketBrowserDb>> | undefined;
@@ -105,21 +120,26 @@ export function browserDatabase(): Promise<IDBPDatabase<ResearchPocketBrowserDb>
 export function openBrowserDatabase(
   name: string,
 ): Promise<IDBPDatabase<ResearchPocketBrowserDb>> {
-  return openDB<ResearchPocketBrowserDb>(name, 1, {
-    upgrade(database) {
-      database.createObjectStore("meta", { keyPath: "key" });
-      database.createObjectStore("state", { keyPath: "key" });
+  return openDB<ResearchPocketBrowserDb>(name, 2, {
+    upgrade(database, oldVersion) {
+      if (oldVersion < 1) {
+        database.createObjectStore("meta", { keyPath: "key" });
+        database.createObjectStore("state", { keyPath: "key" });
 
-      const items = database.createObjectStore("items", { keyPath: "id" });
-      items.createIndex("by-saved-at", ["savedAtUnix", "id"]);
+        const items = database.createObjectStore("items", { keyPath: "id" });
+        items.createIndex("by-saved-at", ["savedAtUnix", "id"]);
 
-      const batches = database.createObjectStore("batches", { keyPath: "path" });
-      batches.createIndex("by-device-sequence", ["deviceId", "sequence"], {
-        unique: true,
-      });
-      database.createObjectStore("outbox", { keyPath: "path" });
-      database.createObjectStore("deferred", { keyPath: "path" });
-      database.createObjectStore("remoteObservations", { keyPath: "path" });
+        const batches = database.createObjectStore("batches", { keyPath: "path" });
+        batches.createIndex("by-device-sequence", ["deviceId", "sequence"], {
+          unique: true,
+        });
+        database.createObjectStore("outbox", { keyPath: "path" });
+        database.createObjectStore("deferred", { keyPath: "path" });
+        database.createObjectStore("remoteObservations", { keyPath: "path" });
+      }
+      if (oldVersion < 2) {
+        database.createObjectStore("syncConfig", { keyPath: "key" });
+      }
     },
     blocked() {
       if (typeof window !== "undefined") {

--- a/web/src/data/github.test.mjs
+++ b/web/src/data/github.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GitHubClient } from "./github.ts";
+
+test("the browser GitHub adapter keeps credentials in headers and exact bytes in immutable writes", async () => {
+  const token = "github-test-credential";
+  const blobSha = "a".repeat(40);
+  const envelope = "{\"exact\":true}";
+  const requests = [];
+  const fetcher = async (input, init) => {
+    const url = input instanceof URL ? input : new URL(input.toString());
+    requests.push({ url, init });
+
+    if (url.pathname === "/repos/owner/private-library") {
+      return Response.json({
+        private: true,
+        archived: false,
+        disabled: false,
+        default_branch: "main",
+        size: 1,
+        permissions: { push: true },
+      });
+    }
+    if (url.pathname.endsWith("/git/trees/main")) {
+      return Response.json({
+        sha: "b".repeat(40),
+        truncated: false,
+        tree: [
+          {
+            path: "sync/v1/ops/00000000-0000-7000-8000-000000000002/00000000000000000001.json",
+            mode: "100644",
+            type: "blob",
+            sha: blobSha,
+          },
+        ],
+      });
+    }
+    if (url.pathname.endsWith(`/git/blobs/${blobSha}`)) {
+      return Response.json({
+        content: Buffer.from(envelope).toString("base64"),
+        encoding: "base64",
+        sha: blobSha,
+        size: Buffer.byteLength(envelope),
+      });
+    }
+    if (init?.method === "PUT") return new Response(null, { status: 409 });
+    throw new Error(`Unexpected request ${url}`);
+  };
+
+  const client = new GitHubClient(token, fetcher);
+  const remote = { owner: "owner", repository: "private-library", branch: "main" };
+  assert.deepEqual(await client.inspectRepository(remote.owner, remote.repository), {
+    defaultBranch: "main",
+    empty: false,
+  });
+  const tree = await client.discover(remote);
+  assert.equal(tree.blobs.size, 1);
+  assert.equal(await client.downloadText(remote, blobSha), envelope);
+  assert.deepEqual(
+    await client.putNew(remote, [...tree.blobs.keys()][0], envelope, remote.branch),
+    { type: "race" },
+  );
+
+  for (const { url, init } of requests) {
+    assert.equal(url.href.includes(token), false);
+    assert.equal(JSON.stringify(init?.body ?? "").includes(token), false);
+    assert.equal(new Headers(init?.headers).get("Authorization"), `Bearer ${token}`);
+    assert.equal(init?.cache, "no-store");
+    assert.equal(init?.credentials, "omit");
+    assert.equal(init?.redirect, "error");
+  }
+  const write = requests.find(({ init }) => init?.method === "PUT");
+  assert.ok(write);
+  const body = JSON.parse(write.init.body);
+  assert.equal(Buffer.from(body.content, "base64").toString(), envelope);
+  assert.equal("sha" in body, false);
+});

--- a/web/src/data/github.ts
+++ b/web/src/data/github.ts
@@ -1,0 +1,458 @@
+const API_ROOT = "https://api.github.com";
+const API_VERSION = "2026-03-10";
+
+export const GENESIS_PATH = "sync/v1/library.json";
+export const OPS_PREFIX = "sync/v1/ops/";
+
+export interface GitHubRemote {
+  owner: string;
+  repository: string;
+  branch: string;
+}
+
+export interface RepositoryInfo {
+  defaultBranch: string;
+  empty: boolean;
+}
+
+export interface ProtocolTree {
+  blobs: Map<string, string>;
+}
+
+export type PutResult =
+  | { type: "created"; blobSha: string }
+  | { type: "race" }
+  | { type: "ambiguous"; kind: "transport" | "server" };
+
+interface RepositoryResponse {
+  private: boolean;
+  archived: boolean;
+  disabled: boolean;
+  default_branch: string;
+  size: number;
+  permissions?: {
+    push?: boolean;
+  };
+}
+
+interface TreeResponse {
+  sha: string;
+  tree: TreeEntry[];
+  truncated: boolean;
+}
+
+interface TreeEntry {
+  path: string;
+  mode: string;
+  type: string;
+  sha: string;
+}
+
+interface BlobResponse {
+  content: string;
+  encoding: string;
+  sha: string;
+  size: number;
+}
+
+interface PutContentResponse {
+  content?: {
+    sha?: string;
+  } | null;
+}
+
+export class GitHubSyncError extends Error {
+  readonly kind: string;
+  readonly retryAfterSeconds: number | null;
+
+  constructor(message: string, kind: string, retryAfterSeconds: number | null = null) {
+    super(message);
+    this.name = "GitHubSyncError";
+    this.kind = kind;
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+
+  get retryable(): boolean {
+    return ["transport", "rate_limited", "server", "contention"].includes(
+      this.kind,
+    );
+  }
+}
+
+export class GitHubClient {
+  private readonly headers: Headers;
+  private readonly fetcher: typeof fetch;
+
+  constructor(
+    token: string,
+    fetcher: typeof fetch = globalThis.fetch.bind(globalThis),
+  ) {
+    if (token.trim().length === 0 || /[\r\n]/.test(token)) {
+      throw new GitHubSyncError(
+        "Enter a valid fine-grained GitHub personal access token.",
+        "authentication",
+      );
+    }
+    this.headers = new Headers({
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": API_VERSION,
+    });
+    this.fetcher = fetcher;
+  }
+
+  async inspectRepository(owner: string, repository: string): Promise<RepositoryInfo> {
+    const response = await this.getJson<RepositoryResponse>(
+      repositoryUrl(owner, repository),
+    );
+    if (!response.private) {
+      throw new GitHubSyncError(
+        "Choose a private repository for your complete personal library.",
+        "repository_policy",
+      );
+    }
+    if (response.archived || response.disabled) {
+      throw new GitHubSyncError(
+        "That repository is archived or unavailable for synchronization.",
+        "repository_policy",
+      );
+    }
+    if (response.permissions?.push !== true) {
+      throw new GitHubSyncError(
+        "This token does not have read and write access to the selected repository.",
+        "authorization",
+      );
+    }
+    if (response.default_branch.trim().length === 0) {
+      throw new GitHubSyncError(
+        "GitHub did not report a usable default branch.",
+        "configuration",
+      );
+    }
+    return {
+      defaultBranch: response.default_branch,
+      empty: response.size === 0,
+    };
+  }
+
+  async discover(remote: GitHubRemote): Promise<ProtocolTree> {
+    let recursive: TreeResponse;
+    try {
+      recursive = await this.fetchTree(remote, remote.branch, true);
+    } catch (error) {
+      if (error instanceof GitHubSyncError && error.kind === "not_found") {
+        throw new GitHubSyncError(
+          "The selected branch does not exist in that repository.",
+          "configuration",
+        );
+      }
+      throw error;
+    }
+    if (!recursive.truncated) return collectProtocolEntries(recursive.tree, "");
+
+    const protocol: ProtocolTree = { blobs: new Map() };
+    const stack: Array<[string, string]> = [[recursive.sha, ""]];
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (!current) break;
+      const [treeSha, prefix] = current;
+      const tree = await this.fetchTree(remote, treeSha, false);
+      for (const entry of tree.tree) {
+        const path = joinPath(prefix, entry.path);
+        validateReservedDirectory(path, entry);
+        if (entry.type === "tree" && protocolTreeRelevant(path)) {
+          stack.push([entry.sha, path]);
+        } else if (path.startsWith("sync/v1/")) {
+          insertProtocolBlob(protocol, path, entry);
+        }
+      }
+    }
+    return protocol;
+  }
+
+  async downloadText(remote: GitHubRemote, sha: string): Promise<string> {
+    const bytes = await this.downloadBlob(remote, sha);
+    try {
+      return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    } catch {
+      throw new GitHubSyncError(
+        "A remote synchronization file is not valid UTF-8.",
+        "integrity",
+      );
+    }
+  }
+
+  async putNew(
+    remote: GitHubRemote,
+    path: string,
+    text: string,
+    branch: string | null,
+  ): Promise<PutResult> {
+    const body = {
+      message: `researchpocket: append ${path}`,
+      content: bytesToBase64(new TextEncoder().encode(text)),
+      ...(branch === null ? {} : { branch }),
+    };
+    const headers = new Headers(this.headers);
+    headers.set("Content-Type", "application/json");
+    let response: Response;
+    try {
+      response = await this.fetcher(contentsUrl(remote, path), {
+        method: "PUT",
+        headers,
+        body: JSON.stringify(body),
+        cache: "no-store",
+        credentials: "omit",
+        redirect: "error",
+        referrerPolicy: "no-referrer",
+      });
+    } catch {
+      return { type: "ambiguous", kind: "transport" };
+    }
+
+    if (response.status === 201) {
+      const created = (await responseJson(response)) as PutContentResponse;
+      const sha = created.content?.sha;
+      if (typeof sha !== "string") {
+        throw new GitHubSyncError(
+          "GitHub did not return the immutable blob identity it created.",
+          "integrity",
+        );
+      }
+      validateGitSha(sha);
+      return { type: "created", blobSha: sha };
+    }
+    if (response.status === 409 || response.status === 422) {
+      return { type: "race" };
+    }
+    if (response.status >= 500) {
+      return { type: "ambiguous", kind: "server" };
+    }
+    if (response.status === 200) {
+      throw new GitHubSyncError(
+        "GitHub reported replacing an immutable synchronization path.",
+        "integrity",
+      );
+    }
+    throw apiError(response);
+  }
+
+  private async fetchTree(
+    remote: GitHubRemote,
+    treeSha: string,
+    recursive: boolean,
+  ): Promise<TreeResponse> {
+    const url = repositoryUrl(remote.owner, remote.repository, "git", "trees", treeSha);
+    if (recursive) url.searchParams.set("recursive", "1");
+    return this.getJson<TreeResponse>(url);
+  }
+
+  private async downloadBlob(remote: GitHubRemote, sha: string): Promise<Uint8Array> {
+    validateGitSha(sha);
+    const blob = await this.getJson<BlobResponse>(
+      repositoryUrl(remote.owner, remote.repository, "git", "blobs", sha),
+    );
+    if (blob.sha !== sha || blob.encoding !== "base64") {
+      throw new GitHubSyncError(
+        "GitHub returned a synchronization blob with the wrong identity or encoding.",
+        "integrity",
+      );
+    }
+    const bytes = base64ToBytes(blob.content.replace(/\s/g, ""));
+    if (!Number.isSafeInteger(blob.size) || blob.size !== bytes.byteLength) {
+      throw new GitHubSyncError(
+        "GitHub returned a synchronization blob with an invalid size.",
+        "integrity",
+      );
+    }
+    return bytes;
+  }
+
+  private async getJson<T>(url: URL): Promise<T> {
+    let response: Response;
+    try {
+      response = await this.fetcher(url, {
+        method: "GET",
+        headers: this.headers,
+        cache: "no-store",
+        credentials: "omit",
+        redirect: "error",
+        referrerPolicy: "no-referrer",
+      });
+    } catch {
+      throw new GitHubSyncError(
+        "GitHub could not be reached. Your queued changes remain safely stored here.",
+        "transport",
+      );
+    }
+    if (!response.ok) throw apiError(response);
+    return (await responseJson(response)) as T;
+  }
+}
+
+export function parseRepository(value: string): [string, string] {
+  const parts = value.trim().split("/");
+  const safe = (part: string | undefined) =>
+    typeof part === "string" &&
+    part.length > 0 &&
+    part.length <= 100 &&
+    /^[A-Za-z0-9._-]+$/.test(part);
+  if (parts.length !== 2 || !safe(parts[0]) || !safe(parts[1])) {
+    throw new GitHubSyncError(
+      "Write the private repository as OWNER/NAME.",
+      "configuration",
+    );
+  }
+  return [parts[0]!, parts[1]!];
+}
+
+function repositoryUrl(owner: string, repository: string, ...suffix: string[]): URL {
+  const segments = ["repos", owner, repository, ...suffix].map(encodeURIComponent);
+  return new URL(`/${segments.join("/")}`, API_ROOT);
+}
+
+function contentsUrl(remote: GitHubRemote, path: string): URL {
+  return repositoryUrl(
+    remote.owner,
+    remote.repository,
+    "contents",
+    ...path.split("/"),
+  );
+}
+
+function collectProtocolEntries(entries: TreeEntry[], prefix: string): ProtocolTree {
+  const protocol: ProtocolTree = { blobs: new Map() };
+  for (const entry of entries) {
+    const path = joinPath(prefix, entry.path);
+    validateReservedDirectory(path, entry);
+    if (path.startsWith("sync/v1/") && entry.type !== "tree") {
+      insertProtocolBlob(protocol, path, entry);
+    }
+  }
+  return protocol;
+}
+
+function insertProtocolBlob(
+  protocol: ProtocolTree,
+  path: string,
+  entry: TreeEntry,
+): void {
+  if (entry.type !== "blob" || entry.mode !== "100644") {
+    throw new GitHubSyncError(
+      "A synchronization entry is not an ordinary immutable file.",
+      "integrity",
+    );
+  }
+  validateGitSha(entry.sha);
+  if (protocol.blobs.has(path)) {
+    throw new GitHubSyncError(
+      "A synchronization path appears more than once in the repository.",
+      "integrity",
+    );
+  }
+  protocol.blobs.set(path, entry.sha);
+}
+
+function validateReservedDirectory(path: string, entry: TreeEntry): void {
+  if ((path === "sync" || path === "sync/v1") && entry.type !== "tree") {
+    throw new GitHubSyncError(
+      "The reserved synchronization path is not a directory.",
+      "integrity",
+    );
+  }
+}
+
+function protocolTreeRelevant(path: string): boolean {
+  return path === "sync" || path === "sync/v1" || path.startsWith("sync/v1/");
+}
+
+function joinPath(prefix: string, path: string): string {
+  return prefix.length === 0 ? path : `${prefix}/${path}`;
+}
+
+function validateGitSha(sha: string): void {
+  if (!/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(sha)) {
+    throw new GitHubSyncError(
+      "GitHub returned an invalid object identity.",
+      "integrity",
+    );
+  }
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  let decoded: string;
+  try {
+    decoded = atob(value);
+  } catch {
+    throw new GitHubSyncError(
+      "GitHub returned invalid Base64 synchronization data.",
+      "integrity",
+    );
+  }
+  return Uint8Array.from(decoded, (character) => character.charCodeAt(0));
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunkSize = 32_768;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return btoa(binary);
+}
+
+async function responseJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    throw new GitHubSyncError(
+      "GitHub returned a malformed API response.",
+      "github_api",
+    );
+  }
+}
+
+function apiError(response: Response): GitHubSyncError {
+  const status = response.status;
+  const rateLimited =
+    status === 429 ||
+    (status === 403 &&
+      (response.headers.get("x-ratelimit-remaining") === "0" ||
+        response.headers.has("retry-after")));
+  const kind =
+    status === 401
+      ? "authentication"
+      : rateLimited
+        ? "rate_limited"
+        : status === 403
+          ? "authorization"
+          : status === 404
+            ? "not_found"
+            : status >= 500
+              ? "server"
+              : "github_api";
+  const message =
+    kind === "authentication"
+      ? "GitHub rejected this token. Your queued changes remain safely stored here."
+      : kind === "authorization"
+        ? "This token cannot read and write the selected private repository."
+        : kind === "rate_limited"
+          ? "GitHub rate-limited synchronization. Your queued changes will retry later."
+          : kind === "not_found"
+            ? "GitHub could not find that repository or branch for this token."
+            : kind === "server"
+              ? "GitHub is temporarily unavailable. Your queued changes remain stored here."
+              : `GitHub rejected the synchronization request (HTTP ${status}).`;
+  return new GitHubSyncError(message, kind, retryAfterSeconds(response));
+}
+
+function retryAfterSeconds(response: Response): number | null {
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter && /^\d+$/.test(retryAfter)) return Number.parseInt(retryAfter, 10);
+  const reset = response.headers.get("x-ratelimit-reset");
+  if (reset && /^\d+$/.test(reset)) {
+    const resetSeconds = Number.parseInt(reset, 10);
+    return Math.max(0, resetSeconds - Math.floor(Date.now() / 1_000));
+  }
+  return null;
+}

--- a/web/src/data/library.ts
+++ b/web/src/data/library.ts
@@ -14,6 +14,8 @@ import {
   type PersistedLibraryMeta,
   type PersistedOutbox,
   type PersistedSnapshot,
+  type PersistedSyncConfiguration,
+  type RemoteObservation,
 } from "./db";
 
 export type LibraryItem = PersistedItem;
@@ -45,12 +47,27 @@ export interface EditItemInput {
   favorite?: boolean;
   language?: string | null;
   tags?: string[];
+  expectedNote?: string | null;
 }
 
 export interface RemoteEnvelopeInput {
   path: string;
   blobSha: string;
   envelopeJson: string;
+}
+
+export type SyncConfiguration = PersistedSyncConfiguration;
+
+export interface PendingSyncBatch {
+  path: string;
+  envelopeJson: string;
+  attempts: number;
+}
+
+export interface BrowserSyncIdentity {
+  libraryId: string;
+  deviceId: string;
+  createdAt: string;
 }
 
 interface RawProjection {
@@ -203,7 +220,10 @@ class LibraryRepository {
     if (input.url !== undefined) mutation.url = input.url;
     if (input.title !== undefined) mutation.title = textUpdate(input.title);
     if (input.excerpt !== undefined) mutation.excerpt = textUpdate(input.excerpt);
-    if (input.note !== undefined) mutation.note = textUpdate(input.note);
+    if (input.note !== undefined) {
+      mutation.note = textUpdate(input.note);
+      if (input.expectedNote !== undefined) mutation.expected_note = input.expectedNote;
+    }
     if (input.favorite !== undefined) mutation.favorite = input.favorite;
     if (input.language !== undefined) mutation.language = textUpdate(input.language);
     if (input.tags !== undefined) {
@@ -222,6 +242,161 @@ class LibraryRepository {
 
   async restore(itemId: string): Promise<void> {
     await this.commitMutation({ type: "restore", item_id: itemId });
+  }
+
+  async syncIdentity(): Promise<BrowserSyncIdentity> {
+    const database = await browserDatabase();
+    const meta = await database.get("meta", "library");
+    if (!meta) throw new Error("Create the browser library before connecting sync.");
+    return {
+      libraryId: meta.libraryId,
+      deviceId: meta.deviceId,
+      createdAt: meta.createdAt,
+    };
+  }
+
+  async syncConfiguration(): Promise<SyncConfiguration | null> {
+    return (await (await browserDatabase()).get("syncConfig", "github")) ?? null;
+  }
+
+  async configureSync(
+    owner: string,
+    repository: string,
+    branch: string,
+  ): Promise<SyncConfiguration> {
+    let configured: SyncConfiguration | undefined;
+    await this.write(async (database) => {
+      const existing = await database.get("syncConfig", "github");
+      if (
+        existing &&
+        (existing.owner !== owner ||
+          existing.repository !== repository ||
+          existing.branch !== branch)
+      ) {
+        throw new Error(
+          "This browser library is already connected to another synchronization repository.",
+        );
+      }
+      configured =
+        existing ??
+        {
+          key: "github",
+          owner,
+          repository,
+          branch,
+          connectedAt: new Date().toISOString(),
+          lastSuccessAt: null,
+          lastErrorKind: null,
+          lastErrorAt: null,
+        };
+      await database.put("syncConfig", configured);
+    });
+    if (!configured) throw new Error("The synchronization configuration was not saved.");
+    return configured;
+  }
+
+  async adoptRemoteLibraryIfPristine(libraryId: string): Promise<boolean> {
+    let adopted = false;
+    await this.write(async (database) => {
+      const transaction = database.transaction(
+        ["meta", "items", "batches", "outbox", "deferred", "remoteObservations"],
+        "readwrite",
+      );
+      try {
+        const metaStore = transaction.objectStore("meta");
+        const meta = await metaStore.get("library");
+        if (!meta) throw new Error("The browser library is not initialized.");
+        if (meta.libraryId === libraryId) {
+          await transaction.done;
+          return;
+        }
+        const counts = await Promise.all([
+          transaction.objectStore("items").count(),
+          transaction.objectStore("batches").count(),
+          transaction.objectStore("outbox").count(),
+          transaction.objectStore("deferred").count(),
+          transaction.objectStore("remoteObservations").count(),
+        ]);
+        if (
+          meta.nextSequence !== "00000000000000000001" ||
+          counts.some((count) => count !== 0)
+        ) {
+          throw new Error(
+            "This browser already contains a different library. Open a fresh browser profile or clear this site's local library before restoring another one.",
+          );
+        }
+        await metaStore.put({ ...meta, libraryId });
+        await transaction.done;
+        adopted = true;
+      } catch (error) {
+        abortTransaction(transaction);
+        throw error;
+      }
+    });
+    if (adopted) this.channel.postMessage({ type: "changed" });
+    return adopted;
+  }
+
+  async pendingSyncBatches(): Promise<PendingSyncBatch[]> {
+    const database = await browserDatabase();
+    const outbox = await database.getAll("outbox");
+    const pending = await Promise.all(
+      outbox.map(async (entry) => {
+        const batch = await database.get("batches", entry.path);
+        if (!batch) {
+          throw new Error("A queued synchronization update is missing its immutable batch.");
+        }
+        return {
+          path: entry.path,
+          envelopeJson: batch.envelopeJson,
+          attempts: entry.attempts,
+        };
+      }),
+    );
+    return pending.sort((left, right) => left.path.localeCompare(right.path));
+  }
+
+  async remoteObservation(path: string): Promise<RemoteObservation | null> {
+    return (await (await browserDatabase()).get("remoteObservations", path)) ?? null;
+  }
+
+  async recordRemoteObservation(path: string, blobSha: string): Promise<void> {
+    validateBlobSha(blobSha);
+    await this.write(async (database) => {
+      const existing = await database.get("remoteObservations", path);
+      if (existing && existing.blobSha !== blobSha) {
+        throw new Error("An immutable remote path changed its Git object identity.");
+      }
+      await database.put("remoteObservations", {
+        path,
+        blobSha,
+        observedAt: new Date().toISOString(),
+      });
+    });
+  }
+
+  async recordOutboxAttempt(path: string, errorKind: string | null): Promise<void> {
+    await this.write(async (database) => {
+      const entry = await database.get("outbox", path);
+      if (!entry) return;
+      await database.put("outbox", {
+        ...entry,
+        attempts: entry.attempts + 1,
+        lastErrorKind: errorKind,
+      });
+    });
+  }
+
+  async deferredSyncCount(): Promise<number> {
+    return (await browserDatabase()).count("deferred");
+  }
+
+  async recordSyncSuccess(): Promise<void> {
+    await this.recordSyncResult(null);
+  }
+
+  async recordSyncFailure(kind: string): Promise<void> {
+    await this.recordSyncResult(kind);
   }
 
   async applyRemote(inputs: RemoteEnvelopeInput[]): Promise<void> {
@@ -373,6 +548,20 @@ class LibraryRepository {
       }
     });
     await this.afterCommit("Saved offline — queued for synchronization");
+  }
+
+  private async recordSyncResult(errorKind: string | null): Promise<void> {
+    await this.write(async (database) => {
+      const configuration = await database.get("syncConfig", "github");
+      if (!configuration) return;
+      const now = new Date().toISOString();
+      await database.put("syncConfig", {
+        ...configuration,
+        lastSuccessAt: errorKind === null ? now : configuration.lastSuccessAt,
+        lastErrorKind: errorKind,
+        lastErrorAt: errorKind === null ? null : now,
+      });
+    });
   }
 
   private async load(): Promise<void> {

--- a/web/src/data/sync.ts
+++ b/web/src/data/sync.ts
@@ -1,0 +1,625 @@
+import initWasm, {
+  createSyncGenesis,
+  validateSyncGenesis,
+} from "../generated/research_domain";
+
+import {
+  GENESIS_PATH,
+  GitHubClient,
+  GitHubSyncError,
+  OPS_PREFIX,
+  parseRepository,
+  type GitHubRemote,
+  type ProtocolTree,
+  type RepositoryInfo,
+} from "./github.ts";
+import {
+  libraryRepository,
+  type PendingSyncBatch,
+  type RemoteEnvelopeInput,
+  type SyncConfiguration,
+} from "./library.ts";
+
+export interface BrowserSyncState {
+  configuration: SyncConfiguration | null;
+  credentialAvailable: boolean;
+  syncing: boolean;
+  status: string;
+  error: string | null;
+  lastCycle: SyncCycleResult | null;
+}
+
+export interface ConnectSyncInput {
+  repository: string;
+  branch?: string;
+  token: string;
+  rememberForTab: boolean;
+}
+
+export interface UnlockSyncInput {
+  token: string;
+  rememberForTab: boolean;
+}
+
+export interface SyncCycleResult {
+  remoteSeen: number;
+  downloaded: number;
+  applied: number;
+  acknowledged: number;
+  uploaded: number;
+  pending: number;
+}
+
+interface PullStats {
+  remoteSeen: number;
+  downloaded: number;
+  applied: number;
+  acknowledged: number;
+}
+
+const SYNC_LOCK = "researchpocket-v2-github-sync";
+const LIBRARY_CHANNEL = "researchpocket-v2-state";
+const SESSION_TOKEN_KEY = "researchpocket-v2-github-token";
+const MAX_UPLOAD_ATTEMPTS = 4;
+const PERIODIC_SYNC_MS = 60_000;
+
+let wasmPromise: Promise<unknown> | undefined;
+
+function ensureWasm(): Promise<unknown> {
+  wasmPromise ??= initWasm();
+  return wasmPromise;
+}
+
+class BrowserSyncService {
+  private state: BrowserSyncState = {
+    configuration: null,
+    credentialAvailable: false,
+    syncing: false,
+    status: "Private sync is not connected",
+    error: null,
+    lastCycle: null,
+  };
+
+  #token: string | null = readSessionToken();
+  private retryNotBefore = 0;
+  private running: Promise<void> | null = null;
+  private readonly listeners = new Set<(state: BrowserSyncState) => void>();
+  private readonly channel = new BroadcastChannel(LIBRARY_CHANNEL);
+
+  constructor() {
+    this.channel.addEventListener("message", () => {
+      if (this.#token && this.state.configuration && document.visibilityState === "visible") {
+        void this.requestSync("local change");
+      }
+    });
+    window.addEventListener("focus", () => void this.requestSync("window focus"));
+    window.addEventListener("online", () => void this.requestSync("network restored"));
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "visible") {
+        void this.requestSync("window visible");
+      }
+    });
+    window.setInterval(() => {
+      if (document.visibilityState === "visible") {
+        void this.requestSync("periodic refresh");
+      }
+    }, PERIODIC_SYNC_MS);
+    void this.load().catch((error: unknown) => {
+      this.patch({
+        status: "Private sync could not open",
+        error: error instanceof Error ? error.message : "Could not read sync configuration.",
+      });
+    });
+  }
+
+  getState(): BrowserSyncState {
+    return this.state;
+  }
+
+  subscribe(listener: (state: BrowserSyncState) => void): () => void {
+    this.listeners.add(listener);
+    listener(this.state);
+    return () => this.listeners.delete(listener);
+  }
+
+  async connect(input: ConnectSyncInput): Promise<void> {
+    const [owner, repository] = parseRepository(input.repository);
+    this.setCredential(input.token, input.rememberForTab);
+    this.patch({ syncing: true, status: "Checking your private repository…", error: null });
+    try {
+      if (this.running) await this.running;
+      await this.withSyncLock(
+        async () => {
+          const client = new GitHubClient(this.requireToken());
+          const repositoryInfo = await client.inspectRepository(owner, repository);
+          const branch = input.branch?.trim() || repositoryInfo.defaultBranch;
+          if (repositoryInfo.empty && branch !== repositoryInfo.defaultBranch) {
+            throw new GitHubSyncError(
+              "An empty repository must be initialized on its default branch.",
+              "configuration",
+            );
+          }
+          const remote = { owner, repository, branch };
+          await this.connectGenesis(client, remote, repositoryInfo);
+          const configuration = await libraryRepository.configureSync(
+            owner,
+            repository,
+            branch,
+          );
+          this.patch({ configuration });
+          await this.runConfigured(client, remote);
+        },
+        true,
+      );
+    } catch (error) {
+      await this.handleFailure(error);
+      throw error;
+    } finally {
+      this.patch({ syncing: false });
+    }
+  }
+
+  async unlock(input: UnlockSyncInput): Promise<void> {
+    if (!this.state.configuration) {
+      throw new Error("Connect a private synchronization repository first.");
+    }
+    this.setCredential(input.token, input.rememberForTab);
+    await this.syncNow();
+  }
+
+  async syncNow(): Promise<void> {
+    await this.requestSync("manual sync", true);
+  }
+
+  forgetCredential(): void {
+    this.#token = null;
+    removeSessionToken();
+    this.patch({
+      credentialAvailable: false,
+      status: this.state.configuration
+        ? "Repository connected — enter your token to synchronize"
+        : "Private sync is not connected",
+      error: null,
+    });
+  }
+
+  private async load(): Promise<void> {
+    const configuration = await libraryRepository.syncConfiguration();
+    this.patch({
+      configuration,
+      credentialAvailable: this.#token !== null,
+      status: configuration
+        ? this.#token
+          ? "Private sync ready"
+          : "Repository connected — enter your token to synchronize"
+        : "Private sync is not connected",
+    });
+    if (configuration && this.#token) void this.requestSync("startup");
+  }
+
+  private async requestSync(reason: string, force = false): Promise<void> {
+    if (this.running) return this.running;
+    if (!this.#token || !this.state.configuration) return;
+    if (!navigator.onLine) {
+      const error = new GitHubSyncError(
+        "You are offline. Your queued changes remain stored here and will retry when the network returns.",
+        "transport",
+      );
+      if (force) {
+        await this.handleFailure(error);
+        throw error;
+      }
+      return;
+    }
+    if (Date.now() < this.retryNotBefore) {
+      if (force) {
+        const seconds = Math.ceil((this.retryNotBefore - Date.now()) / 1_000);
+        const error = new GitHubSyncError(
+          `GitHub asked this browser to wait ${seconds} more seconds before retrying.`,
+          "rate_limited",
+          seconds,
+        );
+        this.patch({ status: "Private sync is waiting to retry", error: error.message });
+        throw error;
+      }
+      return;
+    }
+    this.running = this.withSyncLock(async () => {
+      const configuration = await libraryRepository.syncConfiguration();
+      if (!configuration || !this.#token) return;
+      this.patch({
+        configuration,
+        syncing: true,
+        status: reason === "manual sync" ? "Synchronizing now…" : "Synchronizing private changes…",
+        error: null,
+      });
+      const client = new GitHubClient(this.requireToken());
+      await this.runConfigured(client, remoteFrom(configuration));
+    }, force)
+      .catch(async (error: unknown) => {
+        await this.handleFailure(error);
+        if (force) throw error;
+      })
+      .finally(() => {
+        this.patch({ syncing: false });
+        this.running = null;
+      });
+    return this.running;
+  }
+
+  private async withSyncLock(
+    operation: () => Promise<void>,
+    waitForLock: boolean,
+  ): Promise<void> {
+    if (!navigator.locks) {
+      throw new Error("Safe synchronization requires a browser with Web Locks support.");
+    }
+    if (waitForLock) {
+      await navigator.locks.request(SYNC_LOCK, operation);
+    } else {
+      await navigator.locks.request(
+        SYNC_LOCK,
+        { ifAvailable: true },
+        async (lock) => {
+          if (lock) await operation();
+        },
+      );
+    }
+  }
+
+  private async connectGenesis(
+    client: GitHubClient,
+    remote: GitHubRemote,
+    repositoryInfo: RepositoryInfo,
+  ): Promise<void> {
+    let emptyBootstrap = repositoryInfo.empty;
+    for (let attempt = 0; attempt < MAX_UPLOAD_ATTEMPTS; attempt += 1) {
+      const tree = emptyBootstrap ? emptyProtocolTree() : await client.discover(remote);
+      const remoteGenesisSha = tree.blobs.get(GENESIS_PATH);
+      if (remoteGenesisSha) {
+        const genesisJson = await client.downloadText(remote, remoteGenesisSha);
+        await ensureWasm();
+        const remoteLibraryId = validatedGenesisLibraryId(genesisJson);
+        await libraryRepository.adoptRemoteLibraryIfPristine(remoteLibraryId);
+        await libraryRepository.recordRemoteObservation(GENESIS_PATH, remoteGenesisSha);
+        return;
+      }
+      if (
+        [...tree.blobs.keys()].some(
+          (path) => path.startsWith(OPS_PREFIX) || path.startsWith("sync/v1/checkpoints/"),
+        )
+      ) {
+        throw new GitHubSyncError(
+          "The repository contains synchronization updates without immutable library genesis.",
+          "integrity",
+        );
+      }
+
+      const identity = await libraryRepository.syncIdentity();
+      await ensureWasm();
+      const genesisJson = createSyncGenesis(identity.libraryId, identity.createdAt);
+      const put = await client.putNew(
+        remote,
+        GENESIS_PATH,
+        genesisJson,
+        emptyBootstrap ? null : remote.branch,
+      );
+      if (put.type === "created") {
+        await libraryRepository.recordRemoteObservation(GENESIS_PATH, put.blobSha);
+        return;
+      }
+      emptyBootstrap = false;
+      await retryDelay(GENESIS_PATH, attempt);
+    }
+    throw new GitHubSyncError(
+      "Repository initialization remained contended after safe retries.",
+      "contention",
+    );
+  }
+
+  private async runConfigured(client: GitHubClient, remote: GitHubRemote): Promise<void> {
+    await client.inspectRepository(remote.owner, remote.repository);
+    let pull = await this.pullRemote(client, remote);
+    let uploaded = 0;
+    for (const batch of await libraryRepository.pendingSyncBatches()) {
+      const upload = await this.ensureUploaded(client, remote, batch);
+      uploaded += upload.created ? 1 : 0;
+      pull = addPullStats(pull, upload.pull);
+    }
+    pull = addPullStats(pull, await this.pullRemote(client, remote));
+    const pending = (await libraryRepository.pendingSyncBatches()).length;
+    const result: SyncCycleResult = {
+      ...pull,
+      uploaded,
+      pending,
+    };
+    await libraryRepository.recordSyncSuccess();
+    this.retryNotBefore = 0;
+    this.patch({
+      configuration: await libraryRepository.syncConfiguration(),
+      lastCycle: result,
+      status:
+        pending === 0
+          ? "Private library synchronized"
+          : `${pending} change${pending === 1 ? "" : "s"} still queued`,
+      error: null,
+    });
+  }
+
+  private async pullRemote(client: GitHubClient, remote: GitHubRemote): Promise<PullStats> {
+    const tree = await client.discover(remote);
+    await this.validateRemoteGenesis(client, remote, tree);
+    const operations = [...tree.blobs.entries()]
+      .filter(([path]) => path.startsWith(OPS_PREFIX))
+      .sort(([left], [right]) => left.localeCompare(right));
+    const inputs: RemoteEnvelopeInput[] = [];
+    for (const [path, blobSha] of operations) {
+      const observation = await libraryRepository.remoteObservation(path);
+      if (observation) {
+        if (observation.blobSha !== blobSha) {
+          throw new GitHubSyncError(
+            "An immutable remote update changed after it was observed.",
+            "integrity",
+          );
+        }
+        continue;
+      }
+      inputs.push({
+        path,
+        blobSha,
+        envelopeJson: await client.downloadText(remote, blobSha),
+      });
+    }
+    const pendingBefore = (await libraryRepository.pendingSyncBatches()).length;
+    await this.applyRemoteUpdates(inputs);
+    if ((await libraryRepository.deferredSyncCount()) > 0) {
+      throw new GitHubSyncError(
+        "Remote updates are missing a causal predecessor. No local changes were uploaded.",
+        "integrity",
+      );
+    }
+    const pendingAfter = (await libraryRepository.pendingSyncBatches()).length;
+    return {
+      remoteSeen: operations.length,
+      downloaded: inputs.length,
+      applied: inputs.length,
+      acknowledged: Math.max(0, pendingBefore - pendingAfter),
+    };
+  }
+
+  private async validateRemoteGenesis(
+    client: GitHubClient,
+    remote: GitHubRemote,
+    tree: ProtocolTree,
+  ): Promise<void> {
+    const sha = tree.blobs.get(GENESIS_PATH);
+    if (!sha) {
+      throw new GitHubSyncError(
+        "The configured repository has no immutable library genesis.",
+        "integrity",
+      );
+    }
+    const observation = await libraryRepository.remoteObservation(GENESIS_PATH);
+    if (observation?.blobSha !== undefined && observation.blobSha !== sha) {
+      throw new GitHubSyncError(
+        "The immutable library genesis changed after it was observed.",
+        "integrity",
+      );
+    }
+    if (!observation) {
+      const genesisJson = await client.downloadText(remote, sha);
+      await ensureWasm();
+      const remoteLibraryId = validatedGenesisLibraryId(genesisJson);
+      const local = await libraryRepository.syncIdentity();
+      if (remoteLibraryId !== local.libraryId) {
+        throw new GitHubSyncError(
+          "The remote repository belongs to a different ResearchPocket library.",
+          "library_mismatch",
+        );
+      }
+      await libraryRepository.recordRemoteObservation(GENESIS_PATH, sha);
+    }
+  }
+
+  private async ensureUploaded(
+    client: GitHubClient,
+    remote: GitHubRemote,
+    batch: PendingSyncBatch,
+  ): Promise<{ created: boolean; pull: PullStats }> {
+    let racePull = emptyPullStats();
+    for (let attempt = 0; attempt < MAX_UPLOAD_ATTEMPTS; attempt += 1) {
+      const tree = await client.discover(remote);
+      const existingSha = tree.blobs.get(batch.path);
+      if (existingSha) {
+        await this.applyRemoteUpdates([
+          {
+            path: batch.path,
+            blobSha: existingSha,
+            envelopeJson: await client.downloadText(remote, existingSha),
+          },
+        ]);
+        return { created: false, pull: racePull };
+      }
+
+      const put = await client.putNew(
+        remote,
+        batch.path,
+        batch.envelopeJson,
+        remote.branch,
+      );
+      if (put.type === "created") {
+        await libraryRepository.recordOutboxAttempt(batch.path, null);
+        await this.applyRemoteUpdates([
+          {
+            path: batch.path,
+            blobSha: put.blobSha,
+            envelopeJson: batch.envelopeJson,
+          },
+        ]);
+        return { created: true, pull: racePull };
+      }
+      await libraryRepository.recordOutboxAttempt(batch.path, put.type === "race" ? "contention" : put.kind);
+      racePull = addPullStats(racePull, await this.pullRemote(client, remote));
+      await retryDelay(batch.path, attempt);
+    }
+    throw new GitHubSyncError(
+      "Synchronization remained contended after safe retries.",
+      "contention",
+    );
+  }
+
+  private async applyRemoteUpdates(inputs: RemoteEnvelopeInput[]): Promise<void> {
+    try {
+      await libraryRepository.applyRemote(inputs);
+    } catch (error) {
+      if (error instanceof DOMException) throw error;
+      throw new GitHubSyncError(
+        "A remote immutable update failed shared protocol or convergence validation.",
+        "integrity",
+      );
+    }
+  }
+
+  private setCredential(token: string, rememberForTab: boolean): void {
+    const normalizedToken = token.trim();
+    const client = new GitHubClient(normalizedToken);
+    void client;
+    this.#token = normalizedToken;
+    try {
+      if (rememberForTab) writeSessionToken(normalizedToken);
+      else removeSessionToken();
+    } catch (error) {
+      this.#token = null;
+      throw error;
+    }
+    this.patch({ credentialAvailable: true, error: null });
+  }
+
+  private requireToken(): string {
+    if (!this.#token) {
+      throw new GitHubSyncError(
+        "Enter your repository-scoped GitHub token to synchronize.",
+        "authentication",
+      );
+    }
+    return this.#token;
+  }
+
+  private async handleFailure(error: unknown): Promise<void> {
+    const syncError = normalizeError(error);
+    if (this.state.configuration) {
+      await libraryRepository.recordSyncFailure(syncError.kind).catch(() => undefined);
+      this.patch({ configuration: await libraryRepository.syncConfiguration() });
+    }
+    if (
+      [
+        "authentication",
+        "authorization",
+        "integrity",
+        "library_mismatch",
+        "upgrade_required",
+      ].includes(syncError.kind)
+    ) {
+      this.forgetCredential();
+    }
+    if (syncError.retryAfterSeconds !== null) {
+      this.retryNotBefore = Date.now() + syncError.retryAfterSeconds * 1_000;
+    }
+    this.patch({ status: "Private sync needs attention", error: syncError.message });
+  }
+
+  private patch(patch: Partial<BrowserSyncState>): void {
+    this.state = { ...this.state, ...patch };
+    for (const listener of this.listeners) listener(this.state);
+  }
+}
+
+function remoteFrom(configuration: SyncConfiguration): GitHubRemote {
+  return {
+    owner: configuration.owner,
+    repository: configuration.repository,
+    branch: configuration.branch,
+  };
+}
+
+function emptyProtocolTree(): ProtocolTree {
+  return { blobs: new Map() };
+}
+
+function emptyPullStats(): PullStats {
+  return { remoteSeen: 0, downloaded: 0, applied: 0, acknowledged: 0 };
+}
+
+function addPullStats(left: PullStats, right: PullStats): PullStats {
+  return {
+    remoteSeen: left.remoteSeen + right.remoteSeen,
+    downloaded: left.downloaded + right.downloaded,
+    applied: left.applied + right.applied,
+    acknowledged: left.acknowledged + right.acknowledged,
+  };
+}
+
+function normalizeError(error: unknown): GitHubSyncError {
+  if (error instanceof GitHubSyncError) return error;
+  return new GitHubSyncError(
+    error instanceof Error
+      ? error.message
+      : "Private synchronization could not finish. Your local changes remain queued.",
+    "local_state",
+  );
+}
+
+function validatedGenesisLibraryId(genesisJson: string): string {
+  try {
+    return validateSyncGenesis(genesisJson);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const upgradeRequired = /unsupported (?:protocol|domain schema|Loro codec|feature)/i.test(
+      message,
+    );
+    throw new GitHubSyncError(
+      upgradeRequired
+        ? "This private library uses a newer synchronization format. Upgrade ResearchPocket before syncing."
+        : "The repository's immutable library genesis is malformed or incompatible.",
+      upgradeRequired ? "upgrade_required" : "integrity",
+    );
+  }
+}
+
+async function retryDelay(path: string, attempt: number): Promise<void> {
+  let state = 0;
+  for (const character of path) state = (Math.imul(state, 33) ^ character.charCodeAt(0)) >>> 0;
+  const jitter = state % 173;
+  const base = 200 * 2 ** Math.min(attempt, 4);
+  await new Promise((resolve) => window.setTimeout(resolve, base + jitter));
+}
+
+function readSessionToken(): string | null {
+  try {
+    const token = sessionStorage.getItem(SESSION_TOKEN_KEY);
+    return token?.trim() ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeSessionToken(token: string): void {
+  try {
+    sessionStorage.setItem(SESSION_TOKEN_KEY, token);
+  } catch {
+    throw new GitHubSyncError(
+      "This browser blocked tab-only token storage. Leave the option off to keep it in memory.",
+      "local_state",
+    );
+  }
+}
+
+function removeSessionToken(): void {
+  try {
+    sessionStorage.removeItem(SESSION_TOKEN_KEY);
+  } catch {
+    // The in-memory token is still forgotten even if storage is unavailable.
+  }
+}
+
+export const browserSync = new BrowserSyncService();

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -174,6 +174,140 @@ a {
   opacity: 0.55;
 }
 
+.sync-section {
+  align-items: start;
+  background: var(--ink);
+  border-radius: 20px;
+  color: var(--surface);
+  display: grid;
+  gap: clamp(28px, 5vw, 72px);
+  grid-template-columns: minmax(240px, 0.8fr) minmax(360px, 1.2fr);
+  margin-top: clamp(28px, 5vw, 56px);
+  padding: clamp(24px, 5vw, 48px);
+}
+
+.sync-copy h1 {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(2rem, 4vw, 3.8rem);
+  font-weight: 500;
+  letter-spacing: -0.045em;
+  line-height: 1;
+  margin: 12px 0 18px;
+  text-wrap: balance;
+}
+
+.sync-copy > p:not(.eyebrow, .sync-remote) {
+  color: #d8ddd8;
+  line-height: 1.62;
+  max-width: 52ch;
+}
+
+.sync-section .eyebrow {
+  color: #9bc8ae;
+}
+
+.sync-state {
+  align-items: center;
+  background: rgb(255 255 255 / 9%);
+  border: 1px solid rgb(255 255 255 / 18%);
+  border-radius: 10px;
+  display: flex;
+  font-size: 0.82rem;
+  font-weight: 700;
+  gap: 10px;
+  margin-top: 22px;
+  min-height: 44px;
+  padding: 10px 13px;
+}
+
+.sync-state .status-dot {
+  background: #9bc8ae;
+}
+
+.sync-remote {
+  display: grid;
+  gap: 3px;
+  margin: 16px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.sync-remote span {
+  color: #b9c1ba;
+  font-size: 0.75rem;
+}
+
+.sync-form,
+.sync-controls {
+  background: var(--surface);
+  border-radius: 14px;
+  color: var(--ink);
+  display: grid;
+  gap: 16px;
+  padding: clamp(20px, 4vw, 32px);
+}
+
+.sync-form > p,
+.sync-controls > p,
+.sync-help {
+  color: var(--ink-muted);
+  font-size: 0.84rem;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.sync-session-choice {
+  align-items: start;
+}
+
+.sync-help {
+  margin-top: -8px;
+}
+
+.sync-error {
+  background: var(--warm-soft);
+  border-left: 3px solid var(--warm);
+  border-radius: 0 8px 8px 0;
+  color: #6b2b20;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  margin: 0;
+  padding: 11px 13px;
+}
+
+.sync-counts {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(3, 1fr);
+  margin: 0;
+}
+
+.sync-counts div {
+  background: var(--surface-muted);
+  border-radius: 9px;
+  display: grid;
+  gap: 3px;
+  padding: 12px;
+}
+
+.sync-counts dt {
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.sync-counts dd {
+  font-size: 1.2rem;
+  font-weight: 800;
+  margin: 0;
+}
+
+.sync-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
 .capture-section {
   align-items: start;
   display: grid;
@@ -808,6 +942,10 @@ footer p {
 }
 
 @media (max-width: 900px) {
+  .sync-section {
+    grid-template-columns: 1fr;
+  }
+
   .capture-section {
     grid-template-columns: 1fr;
   }
@@ -856,6 +994,20 @@ footer p {
   .capture-section {
     gap: 28px;
     padding: 48px 0 58px;
+  }
+
+  .sync-section {
+    border-radius: 14px;
+    margin-top: 20px;
+    padding: 20px;
+  }
+
+  .sync-counts {
+    grid-template-columns: 1fr;
+  }
+
+  .sync-actions {
+    display: grid;
   }
 
   .section-intro h1 {


### PR DESCRIPTION
Closes #24

## User outcome

The hosted owner app can now restore and synchronize a complete private library through a separate private GitHub repository while remaining fully usable offline. Browser and CLI edits converge through immutable Loro envelopes; Git history never selects application values.

## What changed

- adds repository/PAT onboarding, manual sync, startup/focus/online/local-change triggers, and a visible-tab 60-second loop
- persists only non-secret repository coordinates and sanitized sync status in IndexedDB v2
- keeps the PAT in module-private memory by default, with explicit tab-only sessionStorage retention and immediate forgetting on auth, authorization, integrity, mismatch, or upgrade failures
- mirrors native Git Trees/Blobs discovery and serialized Contents creates with exact-byte idempotency, bounded 409/422/ambiguous retry, and pull-apply-push-pull ordering
- validates genesis and every remote operation through the shared Rust/WASM domain boundary
- rejects stale browser note forms before they can replace text changed by sync or another tab
- refreshes uuid and zmij to their latest compatible patch releases

## Verification

- cargo fmt --all -- --check
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- cargo test --locked --workspace --all-targets --all-features
- cargo audit --deny warnings
- cargo build --locked --release
- cargo update --dry-run --verbose (zero compatible updates)
- web npm test (two focused durability/transport contracts)
- web npm run build
- web npm audit --omit=dev
- web npm outdated --json (empty)
- live GitHub CORS preflight for Authorization, X-GitHub-Api-Version, GET, and PUT

## UI evidence

The production static bundle and responsive styles build successfully. The in-app browser preview was unavailable in this session, so visual/keyboard acceptance is intentionally left to the deployed PR artifact review rather than claimed here.

## Privacy and recovery

No token field exists in IndexedDB. API traffic uses no-store, omits credentials/referrers, never puts the PAT in a URL or body, and is bypassed by the service worker. Every failure path preserves exact outbox bytes; clearing browser site data still removes any changes that have not successfully synchronized.