### PR TITLE
Repair preview release archive validation

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -136,7 +136,9 @@ jobs:
           tar -C package -czf "$archive" "$package_name"
 
           tar -tzf "$archive" >/dev/null
-          tar -tvzf "$archive" | grep -Eq '^-rwxr-xr-x .*\/research$'
+          listing="$RUNNER_TEMP/$package_name.contents"
+          tar -tvzf "$archive" > "$listing"
+          grep -Eq '^-rwxr-xr-x .*\/research$' "$listing"
 
       - name: Package Windows archive
         if: matrix.package == 'zip'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "research"
-version = "2.0.0-preview.1"
+version = "2.0.0-preview.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research"
-version = "2.0.0-preview.1"
+version = "2.0.0-preview.2"
 edition = "2024"
 rust-version = "1.94"
 keywords = ["bookmarks", "reading-list", "local-first", "knowledge", "cli"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ rather than a conflict resolver.
 
 This is a preview release, not V2 GA. The available workflows and remaining
 boundaries are listed below and in the
-[preview release guide](docs/releases/v2.0.0-preview.1.md).
+[preview release guide](docs/releases/v2.0.0-preview.2.md).
 
 ## Current V2 CLI
 
@@ -42,7 +42,7 @@ data compatibility lives only in the read-only importer.
 
 ## Install the V2 preview
 
-The `v2.0.0-preview.1` release provides archives for Apple Silicon and Intel
+The `v2.0.0-preview.2` release provides archives for Apple Silicon and Intel
 macOS, Linux amd64, and Windows amd64, plus `SHA256SUMS`. Download the archive
 for your platform from the [release page](https://github.com/ResearchPocket/ResearchPocket/releases),
 verify it, place `research` (or `research.exe`) somewhere stable on your `PATH`,
@@ -57,7 +57,7 @@ research status
 On macOS, native capture binds the current executable location into its local
 application bridge, so install the binary at its long-term path before running
 `research capture install`. The complete archive names and setup sequence are in
-the [release guide](docs/releases/v2.0.0-preview.1.md).
+the [release guide](docs/releases/v2.0.0-preview.2.md).
 
 ## Build from this repository
 

--- a/docs/releases/v2.0.0-preview.2.md
+++ b/docs/releases/v2.0.0-preview.2.md
@@ -1,9 +1,9 @@
-# ResearchPocket v2.0.0-preview.1
+# ResearchPocket v2.0.0-preview.2
 
-> This tag was not published. Linux archive validation exposed a workflow pipe
-> failure after the binary smoke test passed. Use
-> [`v2.0.0-preview.2`](./v2.0.0-preview.2.md), which contains the corrected
-> release gate and the same reviewed V2 launch.
+> `v2.0.0-preview.1` was not published. Its binaries passed their smoke tests,
+> but Linux archive validation exposed a release-workflow pipe failure. This
+> preview carries the corrected archive gate and otherwise ships the reviewed
+> V2 launch described below.
 
 This is the first installable preview of the V2 local-first product. It is meant
 for real personal-library use and recovery testing, but it is not a general
@@ -39,10 +39,10 @@ Download `SHA256SUMS` and the archive for the computer that will run the CLI:
 
 | Platform | Release asset |
 | --- | --- |
-| Linux GNU/glibc x86-64 (glibc 2.35 or newer) | `research-v2.0.0-preview.1-linux-amd64.tar.gz` |
-| Windows x86-64 | `research-v2.0.0-preview.1-windows-amd64.zip` |
-| macOS Intel | `research-v2.0.0-preview.1-macos-amd64.tar.gz` |
-| macOS Apple Silicon | `research-v2.0.0-preview.1-macos-arm64.tar.gz` |
+| Linux GNU/glibc x86-64 (glibc 2.35 or newer) | `research-v2.0.0-preview.2-linux-amd64.tar.gz` |
+| Windows x86-64 | `research-v2.0.0-preview.2-windows-amd64.zip` |
+| macOS Intel | `research-v2.0.0-preview.2-macos-amd64.tar.gz` |
+| macOS Apple Silicon | `research-v2.0.0-preview.2-macos-arm64.tar.gz` |
 
 On Linux, verify the downloaded archive with:
 
@@ -60,17 +60,17 @@ On Windows, compare the displayed hash with the matching line in
 `SHA256SUMS`:
 
 ```powershell
-Get-FileHash .\research-v2.0.0-preview.1-windows-amd64.zip -Algorithm SHA256
+Get-FileHash .\research-v2.0.0-preview.2-windows-amd64.zip -Algorithm SHA256
 ```
 
 The Unix archives preserve the executable bit. Extract an archive and place the
 binary in a directory on `PATH`, for example:
 
 ```sh
-tar -xzf research-v2.0.0-preview.1-linux-amd64.tar.gz
+tar -xzf research-v2.0.0-preview.2-linux-amd64.tar.gz
 mkdir -p "$HOME/.local/bin"
 install -m 0755 \
-  research-v2.0.0-preview.1-linux-amd64/research \
+  research-v2.0.0-preview.2-linux-amd64/research \
   "$HOME/.local/bin/research"
 research --version
 ```
@@ -84,7 +84,7 @@ operating system does not accept it, build the tagged source with the pinned
 Rust toolchain rather than weakening system-wide security settings:
 
 ```sh
-git clone --branch v2.0.0-preview.1 \
+git clone --branch v2.0.0-preview.2 \
   https://github.com/ResearchPocket/ResearchPocket.git
 cd ResearchPocket
 cargo build --locked --release

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "research-pocket-web",
-  "version": "2.0.0-preview.1",
+  "version": "2.0.0-preview.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "research-pocket-web",
-      "version": "2.0.0-preview.1",
+      "version": "2.0.0-preview.2",
       "dependencies": {
         "idb": "8.0.3",
         "react": "19.2.7",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "research-pocket-web",
   "private": true,
-  "version": "2.0.0-preview.1",
+  "version": "2.0.0-preview.2",
   "type": "module",
   "scripts": {
     "dev": "npm run wasm && vite",


### PR DESCRIPTION
## Summary

The unpublished `v2.0.0-preview.1` run built and smoke-tested its Linux binary, then failed while validating the archive mode. Under Bash `pipefail`, GNU tar received `SIGPIPE` when `grep -q` exited after the first match and reported a write error. macOS tar did not expose the same behavior.

This change:

- writes the verbose tar listing to a temporary file before checking the executable bit
- advances the unreleased package version to `2.0.0-preview.2` because release tags are immutable
- adds honest preview.1/preview.2 notes and updates the README release guide

No preview.1 GitHub release was created or published. The website remains deployed from the already reviewed V2 launch commit.

## Verification

- reproduced the corrected archive/listing/mode assertion locally without a pipeline
- `npm --prefix web run verify`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo audit --deny warnings`
- `cargo build --locked --release`
- exact `research 2.0.0-preview.2` version check
- Actionlint 1.7.12
- `git diff --check`

Continues #56.
