### PR TITLE
Show pending browser sync changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ credential-free GitHub Pages shell. Its
 Private sync panel connects a separate private data repository with an expiring,
 repository-scoped fine-grained PAT. The browser pulls on startup, focus, network
 recovery, and every 60 seconds while visible; local changes also request a sync.
+The Sync view lists every durable outgoing browser change until GitHub
+acknowledges its immutable update; older queued entries remain visible with a
+generic label when detailed local summaries are unavailable.
 The token stays in JavaScript memory unless the owner explicitly chooses
 tab-only `sessionStorage`, and it never enters IndexedDB, URLs, logs, or the
 service-worker cache.

--- a/docs/v2/WEB.md
+++ b/docs/v2/WEB.md
@@ -27,6 +27,12 @@ of them:
 - one durable outbox row; and
 - the next fixed-width device sequence.
 
+New outbox rows also carry a versioned, local-only presentation summary of the
+accepted mutation. The Sync view uses it to list every pending add, edit,
+favorite or tag change, delete, and restore without decoding the opaque Loro
+payload or duplicating note and excerpt values. Older queued rows without a
+summary remain visible as earlier local changes until acknowledged.
+
 The WASM boundary also accepts a set of remote immutable envelopes in one Loro
 session and reports any causally deferred indices. The browser GitHub adapter
 discovers exact protocol blobs, validates immutable genesis, applies unseen
@@ -43,7 +49,7 @@ IndexedDB database `researchpocket-v2`, version 2, contains only these stores:
 | `state` | Canonical Base64 snapshot and local update time |
 | `items` | Rebuildable materialized private items for rendering/search |
 | `batches` | Exact accepted immutable envelopes and origin |
-| `outbox` | Pending local protocol paths, attempt count, sanitized error category |
+| `outbox` | Pending local protocol paths, attempt count, sanitized error category, optional local-only change summary |
 | `deferred` | Exact remote envelopes still missing a causal predecessor |
 | `remoteObservations` | Protocol path, Git blob identity, observation time |
 | `syncConfig` | Non-secret owner, repository, branch, and sanitized success/error times |

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import {
   type LibraryState,
+  type PendingSyncChange,
   libraryRepository,
 } from "./data/library.ts";
 import {
@@ -44,6 +45,7 @@ const EMPTY_LIBRARY_STATE: LibraryState = {
   initialized: false,
   items: [],
   loading: true,
+  pendingChanges: [],
   pendingCount: 0,
   status: "opening",
 };
@@ -349,7 +351,11 @@ export function App() {
       <main id="workspace" tabIndex={-1}>
         <h1 className="sr-only">ResearchPocket owner library</h1>
 
-        <SyncPanel hidden={view !== "sync"} state={syncState} />
+        <SyncPanel
+          hidden={view !== "sync"}
+          pendingChanges={libraryState.pendingChanges}
+          state={syncState}
+        />
 
         <section
           aria-busy={searchPending}
@@ -727,9 +733,11 @@ function Welcome({
 
 function SyncPanel({
   hidden,
+  pendingChanges,
   state,
 }: {
   hidden: boolean;
+  pendingChanges: PendingSyncChange[];
   state: BrowserSyncState;
 }) {
   const [repository, setRepository] = useState("");
@@ -803,86 +811,141 @@ function SyncPanel({
         ) : null}
       </div>
 
-      {!remote ? (
-        <form className="sync-form" onSubmit={(event) => void connect(event)}>
-          <label className="field">
-            <span>Private data repository</span>
-            <input
-              autoCapitalize="none"
-              autoComplete="off"
-              id="sync-repository"
-              name="repository"
-              onChange={(event) => setRepository(event.target.value)}
-              placeholder="owner/private-repository"
-              required
-              spellCheck={false}
-              value={repository}
-            />
-          </label>
-          <label className="field">
-            <span>Branch <small>default branch when blank</small></span>
-            <input
-              autoCapitalize="none"
-              autoComplete="off"
-              id="sync-branch"
-              name="branch"
-              onChange={(event) => setBranch(event.target.value)}
-              placeholder="main"
-              spellCheck={false}
-              value={branch}
-            />
-          </label>
-          <TokenFields />
-          {error ? <p className="sync-error" role="alert">{error}</p> : null}
-          <button className="primary-button" disabled={state.syncing} type="submit">
-            {state.syncing ? "Connecting…" : "Connect private sync"}
-          </button>
-        </form>
-      ) : !state.credentialAvailable ? (
-        <form className="sync-form" onSubmit={(event) => void unlock(event)}>
-          <p>
-            Repository details stay on this device, but the credential does not.
-            Enter it again to pull and push queued changes.
-          </p>
-          <TokenFields />
-          {error ? <p className="sync-error" role="alert">{error}</p> : null}
-          <button className="primary-button" disabled={state.syncing} type="submit">
-            {state.syncing ? "Synchronizing…" : "Unlock and sync"}
-          </button>
-        </form>
-      ) : (
-        <div className="sync-controls">
-          <p>
-            Your credential is active only in this browser context and never enters
-            the library, an API URL, or the service-worker cache.
-          </p>
-          {state.lastCycle ? (
-            <dl className="sync-counts">
-              <div><dt>Downloaded</dt><dd>{state.lastCycle.downloaded}</dd></div>
-              <div><dt>Uploaded</dt><dd>{state.lastCycle.uploaded}</dd></div>
-              <div><dt>Pending</dt><dd>{state.lastCycle.pending}</dd></div>
-            </dl>
-          ) : null}
-          {error ? <p className="sync-error" role="alert">{error}</p> : null}
-          <div className="sync-actions">
-            <button
-              className="primary-button"
-              disabled={state.syncing}
-              onClick={() => void syncNow()}
-              type="button"
-            >
-              {state.syncing ? "Synchronizing…" : "Sync now"}
+      <div className="sync-content">
+        <PendingSyncChanges
+          changes={pendingChanges}
+          hasSynced={Boolean(remote?.lastSuccessAt)}
+          syncing={state.syncing}
+        />
+
+        {!remote ? (
+          <form className="sync-form" onSubmit={(event) => void connect(event)}>
+            <label className="field">
+              <span>Private data repository</span>
+              <input
+                autoCapitalize="none"
+                autoComplete="off"
+                id="sync-repository"
+                name="repository"
+                onChange={(event) => setRepository(event.target.value)}
+                placeholder="owner/private-repository"
+                required
+                spellCheck={false}
+                value={repository}
+              />
+            </label>
+            <label className="field">
+              <span>Branch <small>default branch when blank</small></span>
+              <input
+                autoCapitalize="none"
+                autoComplete="off"
+                id="sync-branch"
+                name="branch"
+                onChange={(event) => setBranch(event.target.value)}
+                placeholder="main"
+                spellCheck={false}
+                value={branch}
+              />
+            </label>
+            <TokenFields />
+            {error ? <p className="sync-error" role="alert">{error}</p> : null}
+            <button className="primary-button" disabled={state.syncing} type="submit">
+              {state.syncing ? "Connecting…" : "Connect private sync"}
             </button>
-            <button
-              className="secondary-button"
-              disabled={state.syncing}
-              onClick={() => browserSync.forgetCredential()}
-              type="button"
-            >
-              Forget token
+          </form>
+        ) : !state.credentialAvailable ? (
+          <form className="sync-form" onSubmit={(event) => void unlock(event)}>
+            <p>
+              Repository details stay on this device, but the credential does not.
+              Enter it again to pull and push queued changes.
+            </p>
+            <TokenFields />
+            {error ? <p className="sync-error" role="alert">{error}</p> : null}
+            <button className="primary-button" disabled={state.syncing} type="submit">
+              {state.syncing ? "Synchronizing…" : "Unlock and sync"}
             </button>
+          </form>
+        ) : (
+          <div className="sync-controls">
+            <p>
+              Your credential is active only in this browser context and never enters
+              the library, an API URL, or the service-worker cache.
+            </p>
+            {state.lastCycle ? (
+              <dl className="sync-counts">
+                <div><dt>Downloaded</dt><dd>{state.lastCycle.downloaded}</dd></div>
+                <div><dt>Uploaded</dt><dd>{state.lastCycle.uploaded}</dd></div>
+              </dl>
+            ) : null}
+            {error ? <p className="sync-error" role="alert">{error}</p> : null}
+            <div className="sync-actions">
+              <button
+                className="primary-button"
+                disabled={state.syncing}
+                onClick={() => void syncNow()}
+                type="button"
+              >
+                {state.syncing ? "Synchronizing…" : "Sync now"}
+              </button>
+              <button
+                className="secondary-button"
+                disabled={state.syncing}
+                onClick={() => browserSync.forgetCredential()}
+                type="button"
+              >
+                Forget token
+              </button>
+            </div>
           </div>
-        </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function PendingSyncChanges({
+  changes,
+  hasSynced,
+  syncing,
+}: {
+  changes: PendingSyncChange[];
+  hasSynced: boolean;
+  syncing: boolean;
+}) {
+  return (
+    <section
+      aria-busy={syncing}
+      aria-labelledby="sync-pending-heading"
+      className="sync-pending"
+    >
+      <div className="sync-pending-heading">
+        <h3 id="sync-pending-heading">Local changes waiting</h3>
+        <span>{pluralize(changes.length, "change")}</span>
+      </div>
+      <p className="sync-pending-help">
+        Outgoing changes stay on this device until GitHub confirms them. Incoming
+        changes are discovered during sync.
+      </p>
+
+      {changes.length > 0 ? (
+        <ol className="sync-change-list">
+          {changes.map((change) => (
+            <li className="sync-change" key={change.path}>
+              <span className="sync-change-kind">{pendingChangeAction(change.kind)}</span>
+              <div className="sync-change-copy">
+                <p>{change.label}</p>
+                <p>{pendingChangeDetails(change)}</p>
+              </div>
+              <time dateTime={change.enqueuedAt}>{formatDateTime(change.enqueuedAt)}</time>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className="sync-pending-empty">
+          {hasSynced
+            ? "Everything from this browser is synced."
+            : "No local changes are waiting to sync."}
+        </p>
       )}
     </section>
   );
@@ -1615,6 +1678,67 @@ function readHostname(value: string) {
   }
 }
 
+function pendingChangeAction(kind: PendingSyncChange["kind"]) {
+  switch (kind) {
+    case "create":
+      return "Added";
+    case "edit":
+      return "Edited";
+    case "delete":
+      return "Deleted";
+    case "restore":
+      return "Restored";
+    default:
+      return "Queued";
+  }
+}
+
+function pendingChangeDetails(change: PendingSyncChange) {
+  if (change.kind === "queued") {
+    return "Stored before detailed change labels were available.";
+  }
+  if (change.kind === "delete") {
+    return "Will move this save to deleted items.";
+  }
+  if (change.kind === "restore") {
+    return "Will return this save to active items.";
+  }
+
+  const details: string[] = [];
+  if (change.fields.length > 0) {
+    const fields = change.fields.map(pendingFieldLabel).join(", ");
+    details.push(change.kind === "create" ? `Includes ${fields}` : `Changed ${fields}`);
+  }
+  if (change.favorite !== null) {
+    details.push(
+      change.favorite
+        ? change.kind === "create"
+          ? "Favorite"
+          : "Added to favorites"
+        : "Removed from favorites",
+    );
+  }
+  if (change.addedTags.length > 0) {
+    const tags = change.addedTags.map((tag) => `#${tag}`).join(", ");
+    details.push(change.kind === "create" ? `Tags ${tags}` : `Added ${tags}`);
+  }
+  if (change.removedTags.length > 0) {
+    details.push(`Removed ${change.removedTags.map((tag) => `#${tag}`).join(", ")}`);
+  }
+  return details.join(" · ") || "Local library edit.";
+}
+
+function pendingFieldLabel(field: PendingSyncChange["fields"][number]) {
+  switch (field) {
+    case "url":
+      return "URL";
+    case "note":
+      return "private note";
+    default:
+      return field;
+  }
+}
+
 function formatDate(value: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
@@ -1623,6 +1747,17 @@ function formatDate(value: string) {
 
   return new Intl.DateTimeFormat(undefined, {
     dateStyle: "medium",
+  }).format(date);
+}
+
+function formatDateTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Recently";
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
   }).format(date);
 }
 

--- a/web/src/data/db.test.mjs
+++ b/web/src/data/db.test.mjs
@@ -52,6 +52,15 @@ test("a browser library commit survives reopen and an interrupted replacement ro
     enqueuedAt: "2026-07-11T00:00:01.000Z",
     attempts: 0,
     lastErrorKind: null,
+    summary: {
+      version: 1,
+      kind: "create",
+      itemId: item.id,
+      fields: ["url", "title", "note"],
+      favorite: true,
+      addedTags: ["reference"],
+      removedTags: [],
+    },
   };
   const syncConfig = {
     key: "github",

--- a/web/src/data/db.ts
+++ b/web/src/data/db.ts
@@ -40,11 +40,31 @@ export interface PersistedBatch {
   appliedAt: string;
 }
 
+export type PersistedChangeKind = "create" | "edit" | "delete" | "restore";
+
+export type PersistedChangeField =
+  | "url"
+  | "title"
+  | "excerpt"
+  | "note"
+  | "language";
+
+export interface PersistedChangeSummary {
+  version: 1;
+  kind: PersistedChangeKind;
+  itemId: string;
+  fields: PersistedChangeField[];
+  favorite: boolean | null;
+  addedTags: string[];
+  removedTags: string[];
+}
+
 export interface PersistedOutbox {
   path: string;
   enqueuedAt: string;
   attempts: number;
   lastErrorKind: string | null;
+  summary?: PersistedChangeSummary;
 }
 
 export interface PersistedDeferred {

--- a/web/src/data/library.ts
+++ b/web/src/data/library.ts
@@ -9,6 +9,9 @@ import {
   browserDatabase,
   type BrowserDatabase,
   type PersistedBatch,
+  type PersistedChangeField,
+  type PersistedChangeKind,
+  type PersistedChangeSummary,
   type PersistedDeferred,
   type PersistedItem,
   type PersistedLibraryMeta,
@@ -24,9 +27,24 @@ export interface LibraryState {
   initialized: boolean;
   loading: boolean;
   items: LibraryItem[];
+  pendingChanges: PendingSyncChange[];
   pendingCount: number;
   status: string;
   error: string | null;
+}
+
+export interface PendingSyncChange {
+  path: string;
+  enqueuedAt: string;
+  attempts: number;
+  lastErrorKind: string | null;
+  kind: PersistedChangeKind | "queued";
+  itemId: string | null;
+  label: string;
+  fields: PersistedChangeField[];
+  favorite: boolean | null;
+  addedTags: string[];
+  removedTags: string[];
 }
 
 export interface AddItemInput {
@@ -125,6 +143,7 @@ class LibraryRepository {
     initialized: false,
     loading: true,
     items: [],
+    pendingChanges: [],
     pendingCount: 0,
     status: "Opening your private library…",
     error: null,
@@ -211,11 +230,6 @@ class LibraryRepository {
   }
 
   async edit(itemId: string, input: EditItemInput): Promise<void> {
-    const database = await browserDatabase();
-    const current = await database.get("items", itemId);
-    if (!current) {
-      throw new Error("That save no longer exists in this browser library.");
-    }
     const mutation: Record<string, unknown> = { type: "edit", item_id: itemId };
     if (input.url !== undefined) mutation.url = input.url;
     if (input.title !== undefined) mutation.title = textUpdate(input.title);
@@ -226,14 +240,10 @@ class LibraryRepository {
     }
     if (input.favorite !== undefined) mutation.favorite = input.favorite;
     if (input.language !== undefined) mutation.language = textUpdate(input.language);
-    if (input.tags !== undefined) {
-      const nextTags = exactTags(input.tags);
-      const currentTags = new Set(current.tags);
-      const requestedTags = new Set(nextTags);
-      mutation.add_tags = nextTags.filter((tag) => !currentTags.has(tag));
-      mutation.remove_tags = current.tags.filter((tag) => !requestedTags.has(tag));
-    }
-    await this.commitMutation(mutation);
+    await this.commitMutation(
+      mutation,
+      input.tags === undefined ? undefined : exactTags(input.tags),
+    );
   }
 
   async remove(itemId: string): Promise<void> {
@@ -490,9 +500,17 @@ class LibraryRepository {
     await this.afterCommit("Remote changes applied");
   }
 
-  private async commitMutation(mutation: Record<string, unknown>): Promise<void> {
+  private async commitMutation(
+    mutation: Record<string, unknown>,
+    targetTags?: string[],
+  ): Promise<void> {
+    let committed = false;
     await this.write(async (database) => {
       const persisted = await readPersisted(database);
+      const itemId = mutationItemId(mutation);
+      const beforeItem = await database.get("items", itemId);
+      const normalizedMutation = normalizeMutation(mutation, beforeItem, targetTags);
+      if (!normalizedMutation) return;
       await ensureWasm();
       const now = new Date().toISOString();
       const result = JSON.parse(
@@ -503,7 +521,7 @@ class LibraryRepository {
           persisted.meta.deviceId,
           persisted.meta.nextSequence,
           now,
-          JSON.stringify(mutation),
+          JSON.stringify(normalizedMutation),
         ),
       ) as MutationResult;
       const identity = parseEnvelope(result.envelope);
@@ -520,12 +538,15 @@ class LibraryRepository {
         nextSequence: incrementSequence(persisted.meta.nextSequence),
       };
       const items = materializeProjection(result.projection);
+      const afterItem = items.find((item) => item.id === itemId);
+      const summary = summarizeMutation(normalizedMutation, beforeItem, afterItem);
       const batch = batchRecord(path, result.envelope, identity, "local", now);
       const outbox: PersistedOutbox = {
         path,
         enqueuedAt: now,
         attempts: 0,
         lastErrorKind: null,
+        summary,
       };
       const transaction = database.transaction(
         ["meta", "state", "items", "batches", "outbox"],
@@ -542,12 +563,15 @@ class LibraryRepository {
         await transaction.objectStore("batches").add(batch);
         await transaction.objectStore("outbox").add(outbox);
         await transaction.done;
+        committed = true;
       } catch (error) {
         abortTransaction(transaction);
         throw error;
       }
     });
-    await this.afterCommit("Saved offline — queued for synchronization");
+    if (committed) {
+      await this.afterCommit("Saved offline — queued for synchronization");
+    }
   }
 
   private async recordSyncResult(errorKind: string | null): Promise<void> {
@@ -573,6 +597,7 @@ class LibraryRepository {
           initialized: false,
           loading: false,
           items: [],
+          pendingChanges: [],
           pendingCount: 0,
           status: "Create an offline library to begin",
           error: null,
@@ -580,15 +605,18 @@ class LibraryRepository {
         this.emit();
         return;
       }
-      const [items, pendingCount] = await Promise.all([
+      const [items, outbox] = await Promise.all([
         database.getAll("items"),
-        database.count("outbox"),
+        database.getAll("outbox"),
       ]);
       items.sort(compareItems);
+      const pendingChanges = materializePendingChanges(outbox, items);
+      const pendingCount = pendingChanges.length;
       this.state = {
         initialized: true,
         loading: false,
         items,
+        pendingChanges,
         pendingCount,
         status: pendingCount === 0 ? "All changes are stored locally" : `${pendingCount} change${pendingCount === 1 ? "" : "s"} waiting to sync`,
         error: null,
@@ -731,6 +759,207 @@ function materializeItem(item: RawProjection["items"][number]): PersistedItem {
     tags: [...item.tags],
     deleted: item.state === "deleted",
   };
+}
+
+function mutationItemId(mutation: Record<string, unknown>): string {
+  const itemId = mutation.item_id;
+  if (typeof itemId !== "string" || itemId.length === 0) {
+    throw new Error("A browser mutation is missing its item identity.");
+  }
+  return itemId;
+}
+
+function mutationKind(mutation: Record<string, unknown>): PersistedChangeKind {
+  const kind = mutation.type;
+  if (kind === "create" || kind === "edit" || kind === "delete" || kind === "restore") {
+    return kind;
+  }
+  throw new Error("A browser mutation has an unsupported change type.");
+}
+
+function normalizeMutation(
+  mutation: Record<string, unknown>,
+  beforeItem: PersistedItem | undefined,
+  targetTags?: string[],
+): Record<string, unknown> | null {
+  const kind = mutationKind(mutation);
+  if (kind !== "edit") return mutation;
+  if (!beforeItem) {
+    throw new Error("That save no longer exists in this browser library.");
+  }
+
+  const normalized = { ...mutation };
+  if (normalized.url === beforeItem.url) delete normalized.url;
+  removeUnchangedTextUpdate(normalized, "title", beforeItem.title);
+  removeUnchangedTextUpdate(normalized, "excerpt", beforeItem.excerpt);
+  removeUnchangedTextUpdate(normalized, "note", beforeItem.note);
+  removeUnchangedTextUpdate(normalized, "language", beforeItem.language);
+  if (normalized.favorite === beforeItem.favorite) delete normalized.favorite;
+
+  if (!("note" in normalized)) delete normalized.expected_note;
+
+  if (targetTags !== undefined) {
+    const currentTags = new Set(beforeItem.tags);
+    const requestedTags = new Set(targetTags);
+    const addedTags = targetTags.filter((tag) => !currentTags.has(tag));
+    const removedTags = beforeItem.tags.filter((tag) => !requestedTags.has(tag));
+    if (addedTags.length > 0) normalized.add_tags = addedTags;
+    else delete normalized.add_tags;
+    if (removedTags.length > 0) normalized.remove_tags = removedTags;
+    else delete normalized.remove_tags;
+  }
+
+  const hasChange = Object.keys(normalized).some(
+    (key) => key !== "type" && key !== "item_id",
+  );
+  return hasChange ? normalized : null;
+}
+
+function removeUnchangedTextUpdate(
+  mutation: Record<string, unknown>,
+  field: "title" | "excerpt" | "note" | "language",
+  current: string | null,
+): void {
+  if (!(field in mutation)) return;
+  if (textUpdateValue(mutation[field]) === current) delete mutation[field];
+}
+
+function textUpdateValue(value: unknown): string | null {
+  if (typeof value !== "object" || value === null || !("type" in value)) {
+    throw new Error("A browser text change is malformed.");
+  }
+  const update = value as Partial<TextUpdate>;
+  if (update.type === "clear") return null;
+  if (update.type === "set" && typeof update.value === "string") return update.value;
+  throw new Error("A browser text change is malformed.");
+}
+
+function summarizeMutation(
+  mutation: Record<string, unknown>,
+  beforeItem: PersistedItem | undefined,
+  afterItem: PersistedItem | undefined,
+): PersistedChangeSummary {
+  const kind = mutationKind(mutation);
+  const itemId = mutationItemId(mutation);
+  if (!afterItem) {
+    throw new Error("The domain core omitted the changed item from its projection.");
+  }
+
+  const fields: PersistedChangeField[] = [];
+  let favorite: boolean | null = null;
+  let addedTags: string[] = [];
+  let removedTags: string[] = [];
+
+  if (kind === "create") {
+    fields.push("url");
+    if (afterItem.title) fields.push("title");
+    if (afterItem.excerpt) fields.push("excerpt");
+    if (afterItem.note) fields.push("note");
+    if (afterItem.language) fields.push("language");
+    favorite = afterItem.favorite ? true : null;
+    addedTags = [...afterItem.tags];
+  } else if (kind === "edit") {
+    if (!beforeItem) {
+      throw new Error("The edited item is missing its previous projection.");
+    }
+    for (const field of ["url", "title", "excerpt", "note", "language"] as const) {
+      if (beforeItem[field] !== afterItem[field]) fields.push(field);
+    }
+    if (beforeItem.favorite !== afterItem.favorite) favorite = afterItem.favorite;
+    addedTags = afterItem.tags.filter((tag) => !beforeItem.tags.includes(tag));
+    removedTags = beforeItem.tags.filter((tag) => !afterItem.tags.includes(tag));
+  }
+
+  return {
+    version: 1,
+    kind,
+    itemId,
+    fields,
+    favorite,
+    addedTags,
+    removedTags,
+  };
+}
+
+function materializePendingChanges(
+  outbox: PersistedOutbox[],
+  items: PersistedItem[],
+): PendingSyncChange[] {
+  const itemsById = new Map(items.map((item) => [item.id, item]));
+  return [...outbox]
+    .sort(
+      (left, right) =>
+        left.enqueuedAt.localeCompare(right.enqueuedAt) || left.path.localeCompare(right.path),
+    )
+    .map((entry) => {
+      const summary = isPersistedChangeSummary(entry.summary) ? entry.summary : null;
+      if (!summary) {
+        return {
+          path: entry.path,
+          enqueuedAt: entry.enqueuedAt,
+          attempts: entry.attempts,
+          lastErrorKind: entry.lastErrorKind,
+          kind: "queued",
+          itemId: null,
+          label: "Earlier local change",
+          fields: [],
+          favorite: null,
+          addedTags: [],
+          removedTags: [],
+        };
+      }
+      const item = itemsById.get(summary.itemId);
+      return {
+        path: entry.path,
+        enqueuedAt: entry.enqueuedAt,
+        attempts: entry.attempts,
+        lastErrorKind: entry.lastErrorKind,
+        kind: summary.kind,
+        itemId: summary.itemId,
+        label: pendingItemLabel(item),
+        fields: [...summary.fields],
+        favorite: summary.favorite,
+        addedTags: [...summary.addedTags],
+        removedTags: [...summary.removedTags],
+      };
+    });
+}
+
+function isPersistedChangeSummary(value: unknown): value is PersistedChangeSummary {
+  if (typeof value !== "object" || value === null) return false;
+  const summary = value as Partial<PersistedChangeSummary>;
+  const kinds: PersistedChangeKind[] = ["create", "edit", "delete", "restore"];
+  const fields: PersistedChangeField[] = [
+    "url",
+    "title",
+    "excerpt",
+    "note",
+    "language",
+  ];
+  return (
+    summary.version === 1 &&
+    kinds.includes(summary.kind as PersistedChangeKind) &&
+    typeof summary.itemId === "string" &&
+    summary.itemId.length > 0 &&
+    Array.isArray(summary.fields) &&
+    summary.fields.every((field) => fields.includes(field)) &&
+    (summary.favorite === null || typeof summary.favorite === "boolean") &&
+    Array.isArray(summary.addedTags) &&
+    summary.addedTags.every((tag) => typeof tag === "string") &&
+    Array.isArray(summary.removedTags) &&
+    summary.removedTags.every((tag) => typeof tag === "string")
+  );
+}
+
+function pendingItemLabel(item: PersistedItem | undefined): string {
+  const title = item?.title?.trim();
+  if (title) return title;
+  if (!item) return "Saved link";
+  try {
+    return new URL(item.url).hostname.replace(/^www\./, "");
+  } catch {
+    return "Saved link";
+  }
 }
 
 function parseProjection(json: string): RawProjection {

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -508,6 +508,13 @@
   max-width: 56rem;
 }
 
+.sync-content {
+  display: grid;
+  gap: var(--space-6);
+  max-width: 56rem;
+  min-width: 0;
+}
+
 .sync-form .field,
 .capture-form .field {
   align-items: start;
@@ -551,7 +558,7 @@
 
 .sync-counts {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   margin: 0;
 }
 
@@ -574,6 +581,93 @@
   font-size: var(--font-size-lg);
   font-weight: 800;
   margin: 0;
+}
+
+.sync-pending {
+  border-top: var(--rule) solid var(--color-border-strong);
+  min-width: 0;
+  padding-top: var(--space-3);
+}
+
+.sync-pending-heading {
+  align-items: baseline;
+  display: flex;
+  gap: var(--space-3);
+  justify-content: space-between;
+}
+
+.sync-pending-heading h3 {
+  font-size: var(--font-size-md);
+  margin: 0;
+}
+
+.sync-pending-heading > span,
+.sync-pending-help,
+.sync-pending-empty,
+.sync-change-kind,
+.sync-change-copy > p:last-child,
+.sync-change time {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.sync-pending-heading > span {
+  flex: 0 0 auto;
+}
+
+.sync-pending-help {
+  margin: var(--space-1) 0 var(--space-3);
+}
+
+.sync-pending-empty {
+  border-bottom: var(--rule) solid var(--color-border);
+  border-top: var(--rule) solid var(--color-border);
+  margin: 0;
+  padding: var(--space-3) 0;
+}
+
+.sync-change-list {
+  border-top: var(--rule) solid var(--color-border-strong);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sync-change {
+  align-items: start;
+  border-bottom: var(--rule) solid var(--color-border);
+  display: grid;
+  gap: var(--space-2) var(--space-4);
+  grid-template-columns: 5rem minmax(0, 1fr) max-content;
+  padding: var(--space-3) 0;
+}
+
+.sync-change-kind {
+  font-weight: 750;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.sync-change-copy {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.sync-change-copy > p {
+  margin: 0;
+}
+
+.sync-change-copy > p:first-child {
+  font-size: var(--font-size-sm);
+  font-weight: 750;
+}
+
+.sync-change-copy > p:last-child {
+  margin-top: var(--space-1);
+}
+
+.sync-change time {
+  white-space: nowrap;
 }
 
 .sync-actions {
@@ -1494,6 +1588,25 @@ footer {
 
   .sync-section {
     grid-template-columns: 1fr;
+  }
+
+  .sync-change {
+    grid-template-columns: minmax(0, 1fr) max-content;
+  }
+
+  .sync-change-kind {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .sync-change time {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .sync-change-copy {
+    grid-column: 1 / -1;
+    grid-row: 2;
   }
 
   .library-section {


### PR DESCRIPTION
Closes #61

## Summary

- attach versioned local-only semantic summaries to new durable outbox entries
- show every pending create, edit, favorite or tag change, delete, and restore in the Sync view
- normalize browser edits under the writer lock and preserve a generic fallback for older queued rows

## Protocol and privacy impact

- immutable sync envelopes and GitHub repository layout are unchanged
- summaries remain local in IndexedDB and contain field names plus tags, never raw note or excerpt values
- existing outbox entries remain compatible without a database migration

## Verification

- npm run verify
- npm run typecheck
- git diff --check
- browser smoke: create, exact no-op edit, favorite-only edit, title/note/tag edit, delete, restore
- Chrome mobile emulation at 320x800: no horizontal overflow; sticky workspace chrome remains at top
- browser console: no messages

The existing atomic IndexedDB contract test was extended; no duplicate test suite was added.