### PR TITLE
Make mobile save tags scrollable

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1261,8 +1261,6 @@ function LibraryItem({
 }) {
   const label = item.title?.trim() || item.url;
   const preview = item.note?.trim() || item.excerpt?.trim();
-  const visibleTags = item.tags.slice(0, 3);
-  const hiddenTags = item.tags.slice(visibleTags.length);
 
   return (
     <li>
@@ -1300,13 +1298,13 @@ function LibraryItem({
             <span>{readHostname(item.url)}</span>
             <span aria-hidden="true">·</span>
             <span>{item.deleted ? "Deleted" : "Saved"} {formatDate(item.savedAt)}</span>
-            {visibleTags.length > 0 ? (
+            {item.tags.length > 0 ? (
               <span
                 aria-label={`Tags for ${label}`}
                 className="item-inline-tags"
                 role="group"
               >
-                {visibleTags.map((tag) => {
+                {item.tags.map((tag) => {
                   const selected = selectedTags.includes(tag);
                   return (
                     <button
@@ -1323,11 +1321,6 @@ function LibraryItem({
                     </button>
                   );
                 })}
-                {hiddenTags.length > 0 ? (
-                  <span aria-label={`More tags: ${hiddenTags.join(", ")}`}>
-                    +{hiddenTags.length}
-                  </span>
-                ) : null}
               </span>
             ) : null}
           </p>

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1142,10 +1142,14 @@ footer,
   align-items: center;
   color: var(--color-accent-strong);
   display: inline-flex;
+  flex: 1 1 auto;
   gap: var(--space-1);
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  overscroll-behavior-inline: contain;
+  overflow-x: auto;
+  overflow-y: hidden;
+  pointer-events: auto;
+  scrollbar-width: thin;
 }
 
 .item-inline-tag {
@@ -1153,6 +1157,7 @@ footer,
   background: transparent;
   border: 0;
   color: var(--color-accent-strong);
+  flex: 0 0 auto;
   font-size: inherit;
   min-height: 1.75rem;
   padding: 0 var(--space-1);
@@ -1653,6 +1658,15 @@ footer {
 
   .item-card {
     gap: var(--space-2);
+  }
+
+  .item-meta {
+    flex-wrap: wrap;
+  }
+
+  .item-inline-tags {
+    flex-basis: 100%;
+    width: 100%;
   }
 
   .error-banner {


### PR DESCRIPTION
Closes #63

## Summary

- render every save-row tag instead of collapsing the remainder into a count
- make the inline tag region independently horizontally scrollable
- give the tag strip a full-width mobile row so metadata and actions remain fixed

## Verification

- npm run build
- git diff --check
- Chrome mobile emulation at 320x800 with seven tags
- confirmed internal scroll width exceeds its viewport and the last tag is fully reachable
- confirmed selecting the last tag filters the library without opening the edit modal
- confirmed document scroll width equals the 320px viewport
- browser console: no messages