### PR TITLE
Batch sync updates into immutable operation packs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,14 @@ Store update batches at:
 sync/v1/ops/<device-uuid>/<zero-padded-sequence>.json
 ```
 
+When a sync flush contains multiple queued batches, clients may transport their
+exact bytes in one immutable content-addressed pack at
+`sync/v1/ops/packs/<device-uuid>/<pack-sha256>.json`. Packing must preserve every
+logical envelope identity, receipt, outbox acknowledgement, and exact retry
+byte. It must not recompute domain state, append to a mutable log, or use Git
+history as compaction. Pack-unaware clients must fail closed rather than ignore
+a recognized packed operation.
+
 Each envelope includes the protocol version, library ID, device ID, durable
 device sequence, causal frontier, creation timestamp, base64 CRDT update, and
 payload hash. Never rewrite an operation file. If a target path already exists,
@@ -217,9 +225,10 @@ documented repository-history rewrite or migration to a new data repository.
 
 Sync must be safe after every local mutation, on application start/exit, through
 `research sync`, and through optional platform scheduling. Pull before push,
-apply all unseen batches, upload queued unique batches, and pull once more after
-a remote race. Never drop queued changes on timeout, rate limit, token expiry,
-process interruption, or browser reload.
+apply all unseen batches, pack the starting outbox into bounded immutable
+transport objects, upload them, and pull once more after a remote race. Never
+drop queued changes on timeout, rate limit, token expiry, process interruption,
+or browser reload.
 
 ## Hosted Editing, Privacy, and Publishing
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "research"
-version = "2.0.0-preview.3"
+version = "2.0.0-preview.4"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research"
-version = "2.0.0-preview.3"
+version = "2.0.0-preview.4"
 edition = "2024"
 rust-version = "1.94"
 keywords = ["bookmarks", "reading-list", "local-first", "knowledge", "cli"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ rather than a conflict resolver.
 
 This is a preview release, not V2 GA. The available workflows and remaining
 boundaries are listed below and in the
-[preview release guide](docs/releases/v2.0.0-preview.3.md).
+[preview release guide](docs/releases/v2.0.0-preview.4.md).
 
 ## Current V2 CLI
 
@@ -44,7 +44,7 @@ data compatibility lives only in the read-only importer.
 
 ## Install the V2 preview
 
-The `v2.0.0-preview.3` release provides archives for Apple Silicon and Intel
+The `v2.0.0-preview.4` release provides archives for Apple Silicon and Intel
 macOS, Linux amd64, and Windows amd64, plus `SHA256SUMS`. Download the archive
 for your platform from the [release page](https://github.com/ResearchPocket/researchpocket.github.io/releases),
 verify it, place `research` (or `research.exe`) somewhere stable on your `PATH`,
@@ -59,7 +59,7 @@ research status
 On macOS, native capture binds the current executable location into its local
 application bridge, so install the binary at its long-term path before running
 `research capture install`. The complete archive names and setup sequence are in
-the [release guide](docs/releases/v2.0.0-preview.3.md).
+the [release guide](docs/releases/v2.0.0-preview.4.md).
 
 ## Build from this repository
 

--- a/crates/research-domain/src/document.rs
+++ b/crates/research-domain/src/document.rs
@@ -48,6 +48,8 @@ pub enum DomainError {
     UnsupportedCodec(String),
     #[error("unsupported required protocol feature {0}")]
     UnsupportedFeature(String),
+    #[error("unsupported operation pack version {0}")]
+    UnsupportedOperationPackVersion(u8),
     #[error("integrity failure at {path}: expected {expected}, got {actual}")]
     Integrity {
         path: String,

--- a/crates/research-domain/src/lib.rs
+++ b/crates/research-domain/src/lib.rs
@@ -7,6 +7,7 @@ mod document;
 mod envelope;
 mod genesis;
 mod identity;
+mod pack;
 mod projection;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
@@ -14,6 +15,11 @@ mod wasm;
 pub use document::{DomainError, DomainResult, ItemSeed, Library, validate_item_url};
 pub use envelope::{DOMAIN_SCHEMA_VERSION, LORO_CODEC, PROTOCOL_VERSION, UpdateEnvelope};
 pub use genesis::{LibraryGenesis, SYNC_FORMAT};
+pub use pack::{
+    MAX_OPERATION_PACK_BYTES, MAX_OPERATION_PACK_MEMBERS, OPERATION_PACK_FEATURE,
+    OPERATION_PACK_FORMAT, OPERATION_PACK_VERSION, OperationPack, OperationPackArtifact,
+    create_operation_pack, unpack_operation_pack,
+};
 pub use projection::{
     CanonicalItem, CanonicalProjection, LifecycleRevision, LifecycleState, LifecycleView,
     ScalarRevision, ScalarView,

--- a/crates/research-domain/src/pack.rs
+++ b/crates/research-domain/src/pack.rs
@@ -1,0 +1,316 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    DomainError, DomainResult, PROTOCOL_VERSION, UpdateEnvelope, identity::validate_uuid_v7,
+};
+
+pub const OPERATION_PACK_FORMAT: &str = "researchpocket-operation-pack";
+pub const OPERATION_PACK_VERSION: u8 = 1;
+pub const OPERATION_PACK_FEATURE: &str = "operation-packs-v1";
+pub const MAX_OPERATION_PACK_MEMBERS: usize = 1_000;
+pub const MAX_OPERATION_PACK_BYTES: usize = 20 * 1024 * 1024;
+
+/// Immutable collection of exact update-envelope JSON documents.
+///
+/// Member strings are standard-base64 encodings of the exact UTF-8 envelope
+/// bytes. This lets a receiver recover and validate the original immutable
+/// envelope without reserializing it.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OperationPack {
+    pub format: String,
+    pub protocol_version: u8,
+    pub pack_version: u8,
+    pub required_features: Vec<String>,
+    pub extensions: BTreeMap<String, serde_json::Value>,
+    pub library_id: String,
+    pub device_id: String,
+    pub envelopes: Vec<String>,
+}
+
+/// Complete immutable artifact returned by both native and WASM codecs.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct OperationPackArtifact {
+    pub path: String,
+    pub json: String,
+    pub member_envelopes: Vec<String>,
+}
+
+/// Build one deterministic pack from two or more exact envelope JSON strings.
+///
+/// A single envelope intentionally remains in the legacy one-file form. Packs
+/// are bounded to 1,000 members and 20 MiB of exact serialized pack JSON.
+pub fn create_operation_pack(envelope_jsons: &[String]) -> DomainResult<OperationPackArtifact> {
+    validate_member_count(envelope_jsons.len())?;
+    let exact_member_bytes = envelope_jsons.iter().try_fold(0usize, |total, json| {
+        total.checked_add(json.len()).ok_or_else(|| {
+            DomainError::InvalidState("operation pack member size overflow".into())
+        })
+    })?;
+    validate_pack_size(exact_member_bytes)?;
+
+    let mut members = envelope_jsons
+        .iter()
+        .map(|json| validate_envelope_json(json).map(|envelope| (envelope, json.clone())))
+        .collect::<DomainResult<Vec<_>>>()?;
+    members.sort_by(|(left, _), (right, _)| left.sequence.cmp(&right.sequence));
+
+    let first = members
+        .first()
+        .ok_or_else(|| DomainError::InvalidState("operation pack has no members".into()))?;
+    validate_member_set(&members, &first.0.library_id, &first.0.device_id, true)?;
+    let library_id = first.0.library_id.clone();
+    let device_id = first.0.device_id.clone();
+
+    let member_envelopes = members
+        .into_iter()
+        .map(|(_, json)| json)
+        .collect::<Vec<_>>();
+    let pack = OperationPack {
+        format: OPERATION_PACK_FORMAT.to_owned(),
+        protocol_version: PROTOCOL_VERSION,
+        pack_version: OPERATION_PACK_VERSION,
+        required_features: vec![OPERATION_PACK_FEATURE.to_owned()],
+        extensions: BTreeMap::new(),
+        library_id,
+        device_id,
+        envelopes: member_envelopes
+            .iter()
+            .map(|json| STANDARD.encode(json.as_bytes()))
+            .collect(),
+    };
+    let json = serde_json::to_string(&pack)?;
+    validate_pack_size(json.len())?;
+    let path = pack_path(&pack.device_id, json.as_bytes());
+
+    Ok(OperationPackArtifact {
+        path,
+        json,
+        member_envelopes,
+    })
+}
+
+/// Validate and unpack one immutable operation pack.
+///
+/// The path hash is checked against the exact supplied JSON bytes. Returned
+/// member strings are the same UTF-8 bytes that were encoded in the pack.
+pub fn unpack_operation_pack(
+    path: &str,
+    pack_json: &str,
+) -> DomainResult<OperationPackArtifact> {
+    validate_pack_size(pack_json.len())?;
+    let pack: OperationPack = serde_json::from_str(pack_json)?;
+    validate_pack_metadata(&pack)?;
+
+    let expected_path = pack_path(&pack.device_id, pack_json.as_bytes());
+    if path != expected_path {
+        return Err(DomainError::Integrity {
+            path: path.to_owned(),
+            expected: expected_path,
+            actual: path.to_owned(),
+        });
+    }
+
+    validate_member_count(pack.envelopes.len())?;
+    let mut members = Vec::with_capacity(pack.envelopes.len());
+    for encoded in &pack.envelopes {
+        let bytes = STANDARD.decode(encoded)?;
+        if STANDARD.encode(&bytes) != *encoded {
+            return Err(DomainError::InvalidState(
+                "operation pack member is not canonical standard base64".into(),
+            ));
+        }
+        let json = String::from_utf8(bytes).map_err(|_| {
+            DomainError::InvalidState("operation pack member is not UTF-8 JSON".into())
+        })?;
+        let envelope = validate_envelope_json(&json)?;
+        members.push((envelope, json));
+    }
+    validate_member_set(&members, &pack.library_id, &pack.device_id, true)?;
+
+    Ok(OperationPackArtifact {
+        path: path.to_owned(),
+        json: pack_json.to_owned(),
+        member_envelopes: members.into_iter().map(|(_, json)| json).collect(),
+    })
+}
+
+fn validate_pack_metadata(pack: &OperationPack) -> DomainResult<()> {
+    if pack.format != OPERATION_PACK_FORMAT {
+        return Err(DomainError::InvalidState(format!(
+            "unsupported operation pack format {:?}",
+            pack.format
+        )));
+    }
+    if pack.protocol_version != PROTOCOL_VERSION {
+        return Err(DomainError::UnsupportedProtocol(pack.protocol_version));
+    }
+    if pack.pack_version != OPERATION_PACK_VERSION {
+        return Err(DomainError::UnsupportedOperationPackVersion(
+            pack.pack_version,
+        ));
+    }
+    if pack.required_features != [OPERATION_PACK_FEATURE] {
+        if let Some(feature) = pack
+            .required_features
+            .iter()
+            .find(|feature| feature.as_str() != OPERATION_PACK_FEATURE)
+        {
+            return Err(DomainError::UnsupportedFeature(feature.clone()));
+        }
+        return Err(DomainError::InvalidState(
+            "operation pack required_features must contain only operation-packs-v1".into(),
+        ));
+    }
+    if !pack.extensions.is_empty() {
+        return Err(DomainError::InvalidState(
+            "operation pack extensions must be empty".into(),
+        ));
+    }
+    validate_uuid_v7(&pack.library_id, "operation pack library ID")?;
+    validate_uuid_v7(&pack.device_id, "operation pack device ID")?;
+    Ok(())
+}
+
+fn validate_envelope_json(json: &str) -> DomainResult<UpdateEnvelope> {
+    let envelope: UpdateEnvelope = serde_json::from_str(json)?;
+    let path = envelope.path();
+    envelope.validate_identity(&envelope.library_id, &path)?;
+    let payload = envelope.verified_payload()?;
+    if STANDARD.encode(payload) != envelope.payload {
+        return Err(DomainError::InvalidState(format!(
+            "envelope payload at {path} is not canonical standard base64"
+        )));
+    }
+    Ok(envelope)
+}
+
+fn validate_member_set(
+    members: &[(UpdateEnvelope, String)],
+    expected_library_id: &str,
+    expected_device_id: &str,
+    require_sorted: bool,
+) -> DomainResult<()> {
+    validate_uuid_v7(expected_library_id, "operation pack library ID")?;
+    validate_uuid_v7(expected_device_id, "operation pack device ID")?;
+
+    let mut identities = BTreeSet::new();
+    let mut previous_sequence: Option<&str> = None;
+    for (envelope, _) in members {
+        let path = envelope.path();
+        envelope.validate_identity(expected_library_id, &path)?;
+        if envelope.device_id != expected_device_id {
+            return Err(DomainError::Integrity {
+                path,
+                expected: expected_device_id.to_owned(),
+                actual: envelope.device_id.clone(),
+            });
+        }
+        if require_sorted
+            && previous_sequence.is_some_and(|previous| previous >= envelope.sequence.as_str())
+        {
+            return Err(DomainError::InvalidState(
+                "operation pack members are not in strictly increasing device sequence order"
+                    .into(),
+            ));
+        }
+        previous_sequence = Some(&envelope.sequence);
+        if !identities.insert(envelope.path()) {
+            return Err(DomainError::InvalidState(format!(
+                "duplicate operation pack member identity {}",
+                envelope.path()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_member_count(count: usize) -> DomainResult<()> {
+    if !(2..=MAX_OPERATION_PACK_MEMBERS).contains(&count) {
+        return Err(DomainError::InvalidState(format!(
+            "operation packs require 2 to {MAX_OPERATION_PACK_MEMBERS} members, got {count}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_pack_size(bytes: usize) -> DomainResult<()> {
+    if bytes > MAX_OPERATION_PACK_BYTES {
+        return Err(DomainError::InvalidState(format!(
+            "operation pack exceeds the {MAX_OPERATION_PACK_BYTES}-byte limit"
+        )));
+    }
+    Ok(())
+}
+
+fn pack_path(device_id: &str, json: &[u8]) -> String {
+    format!("sync/v1/ops/packs/{device_id}/{}.json", sha256_hex(json))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use loro::VersionVector;
+
+    use super::*;
+
+    const LIBRARY_ID: &str = "00000000-0000-7000-8000-000000000001";
+    const DEVICE_ID: &str = "00000000-0000-7000-8000-000000000101";
+
+    #[test]
+    fn deterministic_round_trip_rejects_inner_tampering() {
+        let frontier = VersionVector::default();
+        let first = UpdateEnvelope::new(
+            LIBRARY_ID,
+            DEVICE_ID,
+            1,
+            &frontier,
+            "2026-07-19T00:00:00Z",
+            b"first-update",
+        )
+        .expect("first envelope");
+        let second = UpdateEnvelope::new(
+            LIBRARY_ID,
+            DEVICE_ID,
+            2,
+            &frontier,
+            "2026-07-19T00:00:01Z",
+            b"second-update",
+        )
+        .expect("second envelope");
+        let first_json = serde_json::to_string(&first).expect("serialize first envelope");
+        let second_json = serde_json::to_string(&second).expect("serialize second envelope");
+
+        let forward = create_operation_pack(&[first_json.clone(), second_json.clone()])
+            .expect("build forward pack");
+        let reverse =
+            create_operation_pack(&[second_json, first_json]).expect("build reverse pack");
+        assert_eq!(forward, reverse);
+        assert_eq!(
+            unpack_operation_pack(&forward.path, &forward.json).expect("unpack valid pack"),
+            forward
+        );
+
+        let mut pack: OperationPack = serde_json::from_str(&forward.json).expect("parse pack");
+        let mut member: serde_json::Value = serde_json::from_slice(
+            &STANDARD.decode(&pack.envelopes[0]).expect("decode member"),
+        )
+        .expect("parse member");
+        member["payload"] = serde_json::Value::String(STANDARD.encode(b"tampered-update"));
+        pack.envelopes[0] =
+            STANDARD.encode(serde_json::to_vec(&member).expect("serialize tampered member"));
+        let tampered_json = serde_json::to_string(&pack).expect("serialize tampered pack");
+        let tampered_path = pack_path(DEVICE_ID, tampered_json.as_bytes());
+        assert!(unpack_operation_pack(&tampered_path, &tampered_json).is_err());
+    }
+}

--- a/crates/research-domain/src/wasm.rs
+++ b/crates/research-domain/src/wasm.rs
@@ -6,7 +6,9 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     CanonicalProjection, DomainError, DomainResult, ItemSeed, Library, LibraryGenesis,
-    LifecycleState, UpdateEnvelope, identity::validate_uuid_v7,
+    LifecycleState, UpdateEnvelope,
+    identity::validate_uuid_v7,
+    pack::{create_operation_pack, unpack_operation_pack},
 };
 
 #[derive(Serialize)]
@@ -197,6 +199,23 @@ pub fn validate_sync_genesis(genesis_json: &str) -> Result<String, JsValue> {
         .map_err(js_error)?;
     genesis.validate().map_err(js_error)?;
     Ok(genesis.library_id)
+}
+
+/// Build one deterministic immutable operation pack from envelope JSON strings.
+#[wasm_bindgen(js_name = createOperationPack)]
+pub fn create_operation_pack_wasm(envelope_json_array: &str) -> Result<String, JsValue> {
+    let envelopes: Vec<String> = serde_json::from_str(envelope_json_array)
+        .map_err(DomainError::from)
+        .map_err(js_error)?;
+    let artifact = create_operation_pack(&envelopes).map_err(js_error)?;
+    serde_json::to_string(&artifact).map_err(|error| js_error(error.into()))
+}
+
+/// Validate and unpack one immutable operation pack into exact envelope JSON strings.
+#[wasm_bindgen(js_name = unpackOperationPack)]
+pub fn unpack_operation_pack_wasm(path: &str, pack_json: &str) -> Result<String, JsValue> {
+    let artifact = unpack_operation_pack(path, pack_json).map_err(js_error)?;
+    serde_json::to_string(&artifact).map_err(|error| js_error(error.into()))
 }
 
 fn initialize(peer_id: &str) -> DomainResult<String> {

--- a/crates/research-store/src/lib.rs
+++ b/crates/research-store/src/lib.rs
@@ -14,8 +14,8 @@ pub use model::{
     CreateItemRequest, EditItemRequest, EnrichmentApplyResult, EnrichmentCandidates,
     EnrichmentClaim, EnrichmentJob, EnrichmentProvider, EnrichmentQueueCounts,
     EnrichmentStatus, ImportRejection, ImportResult, ListPage, ListQuery, ListResult,
-    OptionalTextUpdate, PendingBatch, RemoteBatchDisposition, RemoteBatchResult, SearchQuery,
-    SearchResult, SourceBundleReceipt, SourceFileReceipt, StoreStatus, StoredItem,
-    SyncConfiguration, SyncIdentity,
+    OptionalTextUpdate, PendingBatch, RemoteBatchDisposition, RemoteBatchResult,
+    RemotePackResult, SearchQuery, SearchResult, SourceBundleReceipt, SourceFileReceipt,
+    StoreStatus, StoredItem, SyncConfiguration, SyncIdentity,
 };
 pub use store::V2Store;

--- a/crates/research-store/src/model.rs
+++ b/crates/research-store/src/model.rs
@@ -204,6 +204,7 @@ pub struct SyncIdentity {
     pub pristine: bool,
 }
 
+#[derive(Clone, Debug)]
 pub struct PendingBatch {
     pub device_id: String,
     pub sequence: String,
@@ -223,6 +224,14 @@ pub enum RemoteBatchDisposition {
 pub struct RemoteBatchResult {
     pub disposition: RemoteBatchDisposition,
     pub acknowledged_outbox: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RemotePackResult {
+    pub member_count: u64,
+    pub applied: u64,
+    pub already_applied: u64,
+    pub acknowledged_outbox: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/research-store/src/sync.rs
+++ b/crates/research-store/src/sync.rs
@@ -1,12 +1,12 @@
 use chrono::{DateTime, FixedOffset};
-use research_domain::{Library, LibraryGenesis, UpdateEnvelope};
+use research_domain::{Library, LibraryGenesis, UpdateEnvelope, unpack_operation_pack};
 use sqlx::{Row, SqliteConnection};
 
 use crate::import::persist_projection;
 use crate::store::{fresh_peer_id, now_rfc3339, sha256_hex};
 use crate::{
-    PendingBatch, RemoteBatchDisposition, RemoteBatchResult, StoreError, StoreResult,
-    SyncConfiguration, SyncIdentity, V2Store,
+    PendingBatch, RemoteBatchDisposition, RemoteBatchResult, RemotePackResult, StoreError,
+    StoreResult, SyncConfiguration, SyncIdentity, V2Store,
 };
 
 impl V2Store {
@@ -198,8 +198,75 @@ impl V2Store {
         sqlx::query("BEGIN IMMEDIATE")
             .execute(&mut *connection)
             .await?;
-        let result =
-            apply_remote_batch(&mut connection, path, blob_sha, envelope_json, &envelope).await;
+        let result = async {
+            let result =
+                apply_remote_batch(&mut connection, path, envelope_json, &envelope).await?;
+            observe_remote(&mut connection, path, blob_sha).await?;
+            Ok(result)
+        }
+        .await;
+        match result {
+            Ok(result) => {
+                sqlx::query("COMMIT").execute(&mut *connection).await?;
+                Ok(result)
+            }
+            Err(error) => {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *connection).await;
+                Err(error)
+            }
+        }
+    }
+
+    pub async fn receive_remote_pack(
+        &self,
+        path: &str,
+        blob_sha: &str,
+        bytes: &[u8],
+    ) -> StoreResult<RemotePackResult> {
+        validate_blob_sha(blob_sha)?;
+        let pack_json = std::str::from_utf8(bytes)
+            .map_err(|_| StoreError::SyncIntegrity(format!("{path} is not UTF-8 JSON")))?;
+        let artifact = unpack_operation_pack(path, pack_json)?;
+        let expected_library_id = self.meta("library_id").await?;
+        let mut members = Vec::with_capacity(artifact.member_envelopes.len());
+        for envelope_json in artifact.member_envelopes {
+            let envelope: UpdateEnvelope = serde_json::from_str(&envelope_json)?;
+            let member_path = envelope.path();
+            envelope.validate_identity(&expected_library_id, &member_path)?;
+            validate_timestamp(&envelope.created_at, "operation creation time")?;
+            members.push((member_path, envelope_json, envelope));
+        }
+
+        let mut connection = self.pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *connection)
+            .await?;
+        let result = async {
+            let mut applied = 0_u64;
+            let mut already_applied = 0_u64;
+            let mut acknowledged_outbox = 0_u64;
+            for (member_path, envelope_json, envelope) in &members {
+                let member =
+                    apply_remote_batch(&mut connection, member_path, envelope_json, envelope)
+                        .await?;
+                match member.disposition {
+                    RemoteBatchDisposition::Applied => applied += 1,
+                    RemoteBatchDisposition::AlreadyApplied => already_applied += 1,
+                }
+                if member.acknowledged_outbox {
+                    acknowledged_outbox += 1;
+                }
+            }
+            observe_remote(&mut connection, path, blob_sha).await?;
+            Ok(RemotePackResult {
+                member_count: u64::try_from(members.len())
+                    .map_err(|_| StoreError::NumericRange("operation pack member count"))?,
+                applied,
+                already_applied,
+                acknowledged_outbox,
+            })
+        }
+        .await;
         match result {
             Ok(result) => {
                 sqlx::query("COMMIT").execute(&mut *connection).await?;
@@ -230,6 +297,46 @@ impl V2Store {
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    pub async fn record_outbox_attempts(
+        &self,
+        paths: &[String],
+        error_kind: Option<&str>,
+    ) -> StoreResult<()> {
+        if let Some(kind) = error_kind {
+            validate_error_kind(kind)?;
+        }
+        let mut connection = self.pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *connection)
+            .await?;
+        let result = async {
+            for path in paths {
+                sqlx::query(
+                    "UPDATE outbox SET attempts = attempts + 1, last_error = ? \
+                     WHERE EXISTS (SELECT 1 FROM batches b \
+                     WHERE b.device_id = outbox.device_id \
+                     AND b.sequence = outbox.sequence AND b.path = ?)",
+                )
+                .bind(error_kind)
+                .bind(path)
+                .execute(&mut *connection)
+                .await?;
+            }
+            StoreResult::Ok(())
+        }
+        .await;
+        match result {
+            Ok(()) => {
+                sqlx::query("COMMIT").execute(&mut *connection).await?;
+                Ok(())
+            }
+            Err(error) => {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *connection).await;
+                Err(error)
+            }
+        }
     }
 
     pub async fn record_sync_success(&self) -> StoreResult<()> {
@@ -308,7 +415,6 @@ async fn adopt_library_id(
 async fn apply_remote_batch(
     connection: &mut SqliteConnection,
     path: &str,
-    blob_sha: &str,
     envelope_json: &str,
     envelope: &UpdateEnvelope,
 ) -> StoreResult<RemoteBatchResult> {
@@ -330,7 +436,6 @@ async fn apply_remote_batch(
                 "batch identity collision at {path}"
             )));
         }
-        observe_remote(connection, path, blob_sha).await?;
         let acknowledged_outbox = remove_outbox(connection, envelope).await?;
         return Ok(RemoteBatchResult {
             disposition: RemoteBatchDisposition::AlreadyApplied,
@@ -412,7 +517,6 @@ async fn apply_remote_batch(
             .execute(&mut *connection)
             .await?;
     }
-    observe_remote(connection, path, blob_sha).await?;
     Ok(RemoteBatchResult {
         disposition: RemoteBatchDisposition::Applied,
         acknowledged_outbox: false,
@@ -425,15 +529,24 @@ async fn observe_remote(
     blob_sha: &str,
 ) -> StoreResult<()> {
     sqlx::query(
-        "INSERT INTO remote_observations (path, blob_sha, observed_at) VALUES (?, ?, ?) \
-         ON CONFLICT(path) DO UPDATE SET blob_sha = excluded.blob_sha, \
-         observed_at = excluded.observed_at",
+        "INSERT OR IGNORE INTO remote_observations (path, blob_sha, observed_at) \
+         VALUES (?, ?, ?)",
     )
     .bind(path)
     .bind(blob_sha)
     .bind(now_rfc3339())
     .execute(&mut *connection)
     .await?;
+    let observed: String =
+        sqlx::query_scalar("SELECT blob_sha FROM remote_observations WHERE path = ?")
+            .bind(path)
+            .fetch_one(&mut *connection)
+            .await?;
+    if observed != blob_sha {
+        return Err(StoreError::SyncIntegrity(format!(
+            "immutable remote path {path} changed after it was observed"
+        )));
+    }
     Ok(())
 }
 

--- a/crates/research-store/tests/sync_contract.rs
+++ b/crates/research-store/tests/sync_contract.rs
@@ -1,7 +1,116 @@
+use research_domain::create_operation_pack;
 use research_store::{
     CreateItemRequest, EditItemRequest, ListQuery, OptionalTextUpdate, RemoteBatchDisposition,
     SearchQuery, StoreError, V2Store,
 };
+
+#[tokio::test]
+async fn one_operation_pack_applies_and_acknowledges_several_exact_updates() {
+    let root = tempfile::tempdir().expect("temporary test root");
+    let sender = V2Store::init(root.path().join("sender"))
+        .await
+        .expect("sender store");
+    let receiver = V2Store::init(root.path().join("receiver"))
+        .await
+        .expect("receiver store");
+    let identity = sender.sync_identity().await.expect("sender identity");
+    receiver
+        .adopt_library_id_if_pristine(&identity.library_id)
+        .await
+        .expect("receiver adopts library");
+
+    let item = sender
+        .create_item(CreateItemRequest {
+            url: "https://example.com/packed".into(),
+            title: Some("Before packing".into()),
+            excerpt: None,
+            favorite: false,
+            language: None,
+            saved_at: Some(1_700_000_000),
+            note: String::new(),
+            tags: vec![],
+        })
+        .await
+        .expect("create item");
+    sender
+        .edit_item(EditItemRequest {
+            item_id: item.id.clone(),
+            favorite: Some(true),
+            ..EditItemRequest::default()
+        })
+        .await
+        .expect("favorite item");
+    sender
+        .edit_item(EditItemRequest {
+            item_id: item.id,
+            title: Some(OptionalTextUpdate::Set("After packing".into())),
+            ..EditItemRequest::default()
+        })
+        .await
+        .expect("retitle item");
+
+    let pending = sender.pending_batches().await.expect("sender outbox");
+    assert_eq!(pending.len(), 3);
+    let artifact = create_operation_pack(
+        &pending
+            .iter()
+            .map(|batch| batch.envelope_json.clone())
+            .collect::<Vec<_>>(),
+    )
+    .expect("build operation pack");
+    let pack_blob_sha = "a".repeat(40);
+
+    let applied = receiver
+        .receive_remote_pack(&artifact.path, &pack_blob_sha, artifact.json.as_bytes())
+        .await
+        .expect("apply pack");
+    assert_eq!(applied.member_count, 3);
+    assert_eq!(applied.applied, 3);
+    assert_eq!(applied.already_applied, 0);
+    assert_eq!(applied.acknowledged_outbox, 0);
+    let received = receiver
+        .list(ListQuery::default())
+        .await
+        .expect("receiver projection");
+    assert_eq!(received.items.len(), 1);
+    assert!(received.items[0].favorite);
+    assert_eq!(received.items[0].title.as_deref(), Some("After packing"));
+
+    let acknowledged = sender
+        .receive_remote_pack(&artifact.path, &pack_blob_sha, artifact.json.as_bytes())
+        .await
+        .expect("acknowledge packed upload");
+    assert_eq!(acknowledged.already_applied, 3);
+    assert_eq!(acknowledged.acknowledged_outbox, 3);
+    assert!(
+        sender
+            .pending_batches()
+            .await
+            .expect("drained sender outbox")
+            .is_empty()
+    );
+
+    let before_tamper = receiver
+        .list(ListQuery::default())
+        .await
+        .expect("projection before tamper");
+    let mut tampered = artifact.json.into_bytes();
+    let last = tampered.last_mut().expect("non-empty pack");
+    *last = if *last == b'}' { b']' } else { b'}' };
+    assert!(
+        receiver
+            .receive_remote_pack(&artifact.path, &"b".repeat(40), &tampered)
+            .await
+            .is_err()
+    );
+    assert_eq!(
+        receiver
+            .list(ListQuery::default())
+            .await
+            .expect("projection after rejected tamper"),
+        before_tamper
+    );
+}
 
 #[tokio::test]
 async fn remote_replay_is_exact_idempotent_and_convergent() {

--- a/docs/releases/v2.0.0-preview.4.md
+++ b/docs/releases/v2.0.0-preview.4.md
@@ -1,0 +1,118 @@
+# ResearchPocket v2.0.0-preview.4
+
+This preview makes a normal multi-edit synchronization flush create one
+immutable GitHub operation-pack file and normally one commit, instead of one
+file and commit for every local edit. The change is application-level transport
+packing: Git history still has no role in choosing or merging library values.
+
+The release is suitable for personal-library use and migration testing, but it
+is not V2 general availability. Keep the private remote repository and local
+library under your control, and retain a verified backup of any V1 source.
+
+## What changed
+
+- Native and hosted-browser clients preserve every durable `UpdateEnvelope`
+  byte-for-byte, then place two or more queued envelopes in one immutable,
+  content-addressed operation pack at sync time.
+- A single queued edit keeps the original direct operation-file format. A
+  normal multi-edit flush adds one pack file and one GitHub Contents commit.
+- Packs are bounded to 1,000 logical envelopes and 20 MiB. An exceptional larger
+  queue is split deterministically instead of making an unbounded request.
+- Pack path/body hashes, schema, library/device identity, member ordering,
+  Base64, exact envelope bytes, payload hashes, protocol/schema/codec support,
+  and Loro updates are validated before the local transaction commits.
+- Applying a pack and acknowledging all of its member outbox rows is atomic.
+  A malformed member or changed immutable path preserves the complete local
+  queue and state.
+- Direct files and pack members deduplicate by logical device/sequence identity;
+  byte-identical delivery is idempotent and conflicting bytes stop sync.
+- Upload timeouts, rate limits, server failures, and branch-head races retain
+  every exact member for retry. No merge, rebase, force-push, mutable log, or Git
+  conflict workflow is used.
+- The hosted Sync tab continues to show every individual pending add, edit,
+  favorite/tag change, delete, and restore even when those changes will travel
+  in one pack.
+- Existing direct operation files and repositories remain readable and are not
+  rewritten or pruned.
+
+The domain/CRDT schema remains version 2 and the synchronization protocol remains
+version 1. `operation-packs-v1` is a new required transport feature asserted by
+each pack. The full decision and recovery rules are in
+[ADR 0003](../v2/ADR_0003_OPERATION_PACKS.md).
+
+## Required coordinated upgrade
+
+Upgrade every native and browser client for one private library before allowing
+the first preview 4 client to sync. Once an operation pack exists in the remote
+repository, preview 3 and older clients intentionally stop when they encounter
+the recognized unsupported object; they do not silently ignore packed saves or
+upload stale state.
+
+Recommended sequence:
+
+1. Close every ResearchPocket CLI, TUI, owner-app tab, and capture process.
+2. Make an offline filesystem backup of each native local data directory.
+3. Install the preview 4 CLI on every native device and confirm its version.
+4. Reload the hosted owner app so it receives the preview 4 shell.
+5. Run one sync from each upgraded device.
+
+```sh
+research --version
+research status
+research sync run
+```
+
+There is no SQLite migration in this release. Existing local envelopes and
+outbox rows remain unchanged. Do not delete existing operation files or squash
+repository history. To keep using an older client, restore a pre-pack private
+repository and matching local backup instead of editing protocol files by hand.
+
+On macOS, reinstall the native capture association after replacing the binary
+because the per-user application bridge contains its own copy:
+
+```sh
+research capture install
+research capture status
+```
+
+## Download and verify
+
+| Platform | Release asset |
+| --- | --- |
+| Linux GNU/glibc x86-64 (glibc 2.35 or newer) | `research-v2.0.0-preview.4-linux-amd64.tar.gz` |
+| Windows x86-64 | `research-v2.0.0-preview.4-windows-amd64.zip` |
+| macOS Intel | `research-v2.0.0-preview.4-macos-amd64.tar.gz` |
+| macOS Apple Silicon | `research-v2.0.0-preview.4-macos-arm64.tar.gz` |
+
+Verify `SHA256SUMS` and the selected archive before extraction. On Linux:
+
+```sh
+sha256sum --check --ignore-missing SHA256SUMS
+```
+
+On macOS:
+
+```sh
+shasum -a 256 --check --ignore-missing SHA256SUMS
+```
+
+On Windows, compare the matching checksum line with:
+
+```powershell
+Get-FileHash .\research-v2.0.0-preview.4-windows-amd64.zip -Algorithm SHA256
+```
+
+The preview binaries are not code-signed or notarized. If the operating system
+does not accept the archive, build the reviewed tag with the pinned toolchain
+instead of weakening system-wide security:
+
+```sh
+git clone --branch v2.0.0-preview.4 \
+  https://github.com/ResearchPocket/researchpocket.github.io.git ResearchPocket
+cd ResearchPocket
+cargo build --locked --release
+```
+
+Report defects with the command, platform, exact error, and redacted diagnostic
+output. Never attach a private database, GitHub or Firecrawl token, protocol
+update, operation pack, or unredacted library export to a public issue.

--- a/docs/v2/ADR_0003_OPERATION_PACKS.md
+++ b/docs/v2/ADR_0003_OPERATION_PACKS.md
@@ -1,0 +1,160 @@
+# ADR 0003: Pack exact synchronization envelopes per upload flush
+
+- Status: accepted
+- Date: 2026-07-19
+- Issue: [#68](https://github.com/ResearchPocket/researchpocket.github.io/issues/68)
+
+## Context
+
+ResearchPocket durably creates one immutable `UpdateEnvelope` for every local
+mutation. Native and browser synchronization currently upload each queued
+envelope with a separate GitHub Contents API request. GitHub consequently adds
+one repository file and one commit for every edit, even when one explicit sync
+flush contains many edits.
+
+Git commits cannot become the unit of application state or conflict resolution.
+Rebasing, squashing, force-pushing, replacing operation files, or asking the
+owner to resolve a Git conflict would violate the synchronization contract. A
+mutable rolling log would have the same race. Creating one Git commit containing
+many operation files would reduce commit noise but would not reduce file growth.
+
+An ordinary aggregate Loro envelope was also considered. It can be readable by
+older clients, but exporting from the oldest pending causal frontier may repeat
+an unbounded tail of already synchronized operations. It also replaces the
+durable identities that the outbox, receipts, audit trail, and checkpoint
+coverage currently use.
+
+## Decision
+
+### Local mutations remain independent
+
+Every accepted mutation continues to atomically persist its exact immutable
+envelope, projection, snapshot, sequence reservation, and outbox row. The Sync
+preview continues to show those logical changes independently. Packing is a
+transport step performed only after a complete pull has succeeded and no causal
+dependency remains deferred.
+
+If at least two envelopes are queued at the start of a flush, the client builds
+one immutable operation pack from their exact UTF-8 JSON bytes. A single queued
+envelope retains its existing direct operation file. New mutations arriving
+after preparation wait for the next flush.
+
+The pack path is:
+
+```text
+sync/v1/ops/packs/<device-uuid>/<sha256-of-exact-pack-bytes>.json
+```
+
+The body is strict UTF-8 JSON:
+
+```json
+{
+  "format": "researchpocket-operation-pack",
+  "protocol_version": 1,
+  "pack_version": 1,
+  "required_features": ["operation-packs-v1"],
+  "extensions": {},
+  "library_id": "019...",
+  "device_id": "019...",
+  "envelopes": [
+    "base64-of-exact-update-envelope-json",
+    "base64-of-exact-update-envelope-json"
+  ]
+}
+```
+
+The builder sorts members by device sequence. Every member must be a valid
+protocol-v1 envelope for the pack library and device, identities must be unique,
+and each Base64 value preserves the exact bytes already stored in the outbox.
+The pack has no timestamp because its members already contain audit timestamps.
+The lowercase SHA-256 in the path covers the exact serialized pack bytes.
+
+A pack contains at most 1,000 envelopes and 20 MiB of exact serialized pack
+bytes. An exceptional larger outbox is divided deterministically into bounded
+packs; ordinary flushes therefore create one file and one Contents commit, while
+the hard bound prevents an unbounded allocation or request.
+
+### Receipts stay logical; observations stay physical
+
+Pull validates the container path, byte hash, schema, required feature, library,
+device, order, bounds, and every embedded envelope before committing any state.
+The embedded envelopes then pass through the existing deterministic apply and
+receipt path in one local writer transaction. Duplicate logical identities are
+success only when their exact envelope bytes match, whether they arrived as a
+direct file, in one pack, or in several duplicate packs.
+
+The local `batches` and outbox tables continue to identify logical envelopes by
+`(device_id, sequence)`. Applying a confirmed pack acknowledges each matching
+member outbox row. `remote_observations` records the physical pack path and its
+Git blob identity; it does not invent Git blob identities for embedded logical
+paths. Attempt and retry state is applied to every member represented by an
+outgoing pack.
+
+An upload timeout or ambiguous server result retains every member row and the
+same exact source bytes. The content-addressed pack can be rebuilt
+deterministically. Discovery checks the pack path and exact bytes before retry.
+Concurrent branch movement triggers another application-level pull and retry;
+it never triggers a merge, rebase, force-push, or value choice based on Git.
+
+### Compatibility and migration
+
+Pack-aware clients accept both existing direct operation files and packs, so an
+existing repository needs no rewrite, branch migration, or new genesis. Packs
+live below the existing `sync/v1/ops/` prefix deliberately: a released client
+that does not understand `operation-packs-v1` encounters a recognized but
+unsupported operation and stops before uploading, instead of silently ignoring
+new saves. After the first pack-enabled sync, every native or browser client for
+that library must be upgraded before it can sync again.
+
+This is a transport feature inside protocol version 1. It does not alter the
+domain schema, Loro merge rules, item projection, or direct-envelope format.
+Logical receipts and checkpoint coverage count embedded envelopes rather than
+container files. Discovery/download counters continue to describe physical
+remote protocol objects; apply, acknowledgement, upload, and pending counters
+describe logical envelopes.
+
+### Recovery
+
+A fresh pack-aware client can rebuild the library from immutable genesis plus
+all direct operations and pack members, optionally accelerated by a checkpoint.
+If a pack path/hash, member byte hash, identity, version, feature, or payload is
+invalid, the complete pack transaction rolls back and local state/outbox data is
+preserved. Existing repository history is never compacted or deleted. Secure
+erasure still requires the separate repository-replacement procedure.
+
+## Alternatives considered
+
+### Squash or rewrite Git commits
+
+Rejected. Commit topology is transport audit metadata, not application state.
+History rewriting does not safely reduce live protocol objects and introduces
+the exact source-control conflict workflow ResearchPocket excludes.
+
+### Create one Git commit with many operation files
+
+Rejected for this goal. Git's tree/commit APIs could reduce commit count, but
+the repository would still gain one file for every edit and the branch-head API
+surface would become larger.
+
+### Export one aggregate Loro update
+
+Rejected. It can duplicate an unbounded causal tail and obscures the relationship
+between durable local envelope identities, remote receipts, and checkpoint
+coverage. Exact-envelope packs achieve the repository reduction without
+changing the semantic operation set.
+
+### Append to one mutable log file
+
+Rejected. Competing clients would replace the same path, making branch order or
+manual Git conflict handling part of convergence.
+
+## Consequences
+
+- A normal multi-edit sync adds one immutable repository file and normally one
+  GitHub commit while preserving every logical update and Sync preview row.
+- Retries and duplicate delivery remain byte-exact and idempotent.
+- Native and browser clients need one shared pack codec and transactional pack
+  application path.
+- Pack-enabled repositories require pack-aware clients; older preview clients
+  fail closed until upgraded.
+- Existing operation files and commits remain valid and are not rewritten.

--- a/docs/v2/MIGRATION.md
+++ b/docs/v2/MIGRATION.md
@@ -118,3 +118,11 @@ separate private data repository. A pristine CLI or browser device can then
 adopt the repository's library identity and restore all saves. Never synchronize
 `library.sqlite3` through Git; Git merge behavior does not resolve library
 changes.
+
+Pack-aware releases group multiple exact queued envelopes into one immutable
+operation pack during a normal sync flush. Existing direct operation files need
+no migration or rewrite. After any pack has been uploaded, upgrade every CLI and
+hosted browser client for that library before its next sync; older preview
+clients intentionally fail closed on the unsupported packed object. A fresh
+pack-aware client restores both direct files and pack members through the same
+logical receipts.

--- a/docs/v2/SYNC_PROTOCOL.md
+++ b/docs/v2/SYNC_PROTOCOL.md
@@ -1,6 +1,6 @@
 # ResearchPocket synchronization protocol v1
 
-Status: protocol decision for issue #33
+Status: protocol decisions for issues #33 and #68
 
 Protocol version: 1  
 Domain schema version: 2  
@@ -42,6 +42,8 @@ publication rules in the [privacy threat model](./THREAT_MODEL.md).
    before application and preserves local state for an upgraded client.
 10. Synchronization and public publication use separate repositories and
     credentials.
+11. Transport packing may group exact immutable operation bytes, but it never
+    combines, replaces, or changes their logical identities.
 
 ## Identities
 
@@ -52,6 +54,7 @@ publication rules in the [privacy threat model](./THREAT_MODEL.md).
 | Item | Canonical lowercase UUIDv7. Equal URLs do not imply equal items. |
 | Device sequence | Decimal integer `1..=u64::MAX`, encoded as exactly 20 digits with leading zeroes. Gaps are allowed; reuse is forbidden. |
 | Batch | Tuple `(library_id, device_id, sequence)`. The repository path contains device and sequence. |
+| Operation pack | Lowercase SHA-256 of the exact serialized pack bytes, scoped to one library and device. |
 | Loro peer | Unsigned 64-bit Loro identifier. It is causal metadata, not a device or user identity. |
 | Checkpoint | Lowercase SHA-256 of the decoded full Loro snapshot payload. |
 | Collection | Canonical lowercase UUIDv7 when the collections feature is introduced. Names are mutable labels, not identity. |
@@ -70,6 +73,9 @@ sync/
     ops/
       <device-uuid>/
         <20-digit-sequence>.json
+      packs/
+        <device-uuid>/
+          <pack-sha256>.json
     checkpoints/
       <snapshot-sha256>.json
 ```
@@ -152,6 +158,61 @@ Protocol-v1 readers interpret those omissions as schema 2, codec 1.13.6, and
 empty feature/extension sets. No other missing required field receives a
 default.
 
+## Operation pack
+
+When two or more local envelopes are queued at the start of an upload flush, a
+client normally transports their exact stored bytes in one immutable operation
+pack. Packing is not a domain merge or Git squash: every embedded envelope keeps
+its original identity, causal frontier, payload, hash, timestamp, receipt, and
+outbox acknowledgement.
+
+The strict UTF-8 JSON body at
+`sync/v1/ops/packs/<device>/<pack-sha256>.json` is:
+
+```json
+{
+  "format": "researchpocket-operation-pack",
+  "protocol_version": 1,
+  "pack_version": 1,
+  "required_features": ["operation-packs-v1"],
+  "extensions": {},
+  "library_id": "019...",
+  "device_id": "019...",
+  "envelopes": [
+    "standard-padded-base64-of-exact-envelope-json",
+    "standard-padded-base64-of-exact-envelope-json"
+  ]
+}
+```
+
+Validation is performed before applying any member:
+
+1. the path matches the pack path grammar and contains canonical device and
+   lowercase 64-character SHA-256 identities;
+2. the SHA-256 of the exact pack bytes equals the path identity;
+3. the document has exactly the specified fields and versions, the sole
+   `operation-packs-v1` required feature, and an empty extensions object;
+4. the pack library and device are canonical UUIDv7 values and the path device
+   equals the body device;
+5. the pack contains between 2 and 1,000 members and its exact bytes are no more
+   than 20 MiB;
+6. members use padded standard Base64 and decode to valid UTF-8 exact envelope
+   JSON;
+7. every member passes the ordinary envelope validation for the same library
+   and device; and
+8. members are unique and sorted by fixed-width device sequence.
+
+The pack contains no timestamp. The exact bytes are canonical retry input and
+the member timestamps remain audit metadata. A pack-aware client accepts both
+legacy direct operation files and packs. Duplicate batch identities across
+direct files or packs require byte-identical envelope JSON; another value is an
+integrity error.
+
+Logical receipts and checkpoint coverage record each embedded batch. Physical
+remote observations record the pack path and Git blob identity. Applying a pack
+and acknowledging every matching member outbox row is one local transaction.
+An invalid member rolls back the entire pack.
+
 ## Domain convergence rules
 
 The payload is an opaque Loro update. Git and the transport do not inspect or
@@ -232,21 +293,29 @@ The browser uses `cache: "no-store"`; service workers bypass all API traffic.
 Native clients do not place authorization headers, response bodies, private
 paths, or item fields in logs.
 
-Clients sort discovered operation identities by `(device_id, sequence)` for
-repeatable diagnostics, but correctness is independent of that processing
-order. An update may arrive before its causal predecessor; the client retains
-its exact deferred envelope and convergence is checked after the complete
+Clients classify direct operation and pack paths, process physical paths in
+lowercase path order for repeatable diagnostics, and require each pack's members
+to be sorted by device sequence. Correctness is independent of container or
+processing order. An update may arrive before its causal predecessor; the client
+retains its exact deferred envelope and convergence is checked after the complete
 discovered set is applied.
 
 ## Upload, idempotency, and branch races
 
-Clients upload one outbox file at a time through
-`PUT /repos/{owner}/{repo}/contents/{path}` with Contents write permission. The
-body contains the exact operation-file bytes encoded once more as Base64 for the
-API. The commit message may identify the protocol path for audit, but no client
-reads it as state.
+Clients prepare the logical outbox present at the start of a flush after pulling
+and resolving every deferred update. One queued envelope is uploaded directly.
+Two or more envelopes from one device are sorted and placed in a bounded pack;
+an exceptional outbox larger than the pack limits is divided deterministically.
+New local mutations wait for the next flush.
 
-Before upload, the client refreshes discovery. For each batch:
+Each direct file or pack is uploaded through
+`PUT /repos/{owner}/{repo}/contents/{path}` with Contents write permission. The
+body contains the exact operation or pack bytes encoded once more as Base64 for
+the API. The commit message may identify the protocol path for audit, but no
+client reads it as state. A normal multi-edit flush therefore creates one
+immutable repository file and one Contents commit.
+
+Before upload, the client refreshes discovery. For each direct file or pack:
 
 - absent path: attempt create without a `sha` replacement parameter;
 - existing path with identical bytes: mark uploaded (idempotent success);
@@ -254,9 +323,9 @@ Before upload, the client refreshes discovery. For each batch:
 - `409`, `422`, timeout, or ambiguous connection loss: refresh the tree/blob,
   perform the same equality check, and retry the unchanged outbox bytes with
   bounded jitter;
-- `401`: require a new credential and preserve the outbox;
-- `403`/`429`: honor rate-limit/reset/retry headers and preserve the outbox;
-- `5xx` or offline: exponential backoff with jitter and preserve the outbox.
+- `401`: require a new credential and preserve every member outbox row;
+- `403`/`429`: honor rate-limit/reset/retry headers and preserve every member;
+- `5xx` or offline: exponential backoff with jitter and preserve every member.
 
 Contents writes are serialized because GitHub documents conflicts for
 concurrent content mutations. A branch-head race is transport contention, not an
@@ -272,10 +341,10 @@ An explicit or scheduled sync performs:
 
 ```text
 validate configuration and immutable library genesis
-discover remote operation and checkpoint blobs
+discover remote direct-operation, operation-pack, and checkpoint blobs
 select/validate an optional compatible checkpoint
-download and atomically apply every unseen valid operation
-upload queued local operations serially and idempotently
+download and atomically apply every unseen valid logical operation
+pack the starting local outbox and upload each bounded transport object serially
 discover/download/apply once more
 report local pending count, remote observations, and any retry state
 ```
@@ -340,6 +409,14 @@ Loro codecs: {1.13.6}
 required features: {}
 ```
 
+Pack-aware clients additionally support the transport feature
+`operation-packs-v1`. Because immutable genesis predates this optional transport
+feature, it is asserted and validated by each pack. A pack-unaware protocol-v1
+client discovers the recognized `sync/v1/ops/` object and must stop before
+application or upload; it must never silently ignore the file. After a pack is
+first uploaded, every client for that library must be upgraded to a pack-aware
+release before synchronizing.
+
 Genesis, checkpoint, and every operation must fit that tuple. Protocol v1 does
 not perform best-effort partial application. On an unsupported value, the client:
 
@@ -364,7 +441,9 @@ unknown required features. CI runs it natively and in a headless browser.
 ## Browser, publisher, and CLI consumption
 
 - **CLI/native:** SQLite holds canonical snapshot, projection, applied receipts,
-  immutable batches, and outbox. Credentials live outside SQLite.
+  immutable logical batches, and outbox. Packs are deterministic transport
+  containers and need no second semantic state store. Credentials live outside
+  SQLite.
 - **Browser owner mode:** IndexedDB holds the equivalent private state and
   outbox. The PAT follows the threat-model lifecycle and never enters IndexedDB
   or service-worker/cache state.
@@ -377,7 +456,10 @@ unknown required features. CI runs it natively and in a headless browser.
 ## Recovery and integrity failures
 
 - Missing local SQLite/IndexedDB state is recoverable from genesis plus all valid
-  operations, optionally accelerated by a checkpoint.
+  direct operations and pack members, optionally accelerated by a checkpoint.
+- A malformed pack, changed content-addressed pack path, invalid member, or
+  unsupported pack feature rolls back the complete pack application and retains
+  local/outbox data.
 - Missing remote operation paths, path/body mismatches, hash mismatch, sequence
   collision, incompatible versions, invalid Loro bytes, or a checkpoint claiming
   invalid coverage stop sync and retain local/outbox data.
@@ -391,6 +473,7 @@ unknown required features. CI runs it natively and in a headless browser.
 
 - Git merge semantics, shared mutable state files, last-push-wins, or manual
   source-control conflict resolution;
+- Git history rewriting or retroactive deletion of existing operation files;
 - a continuously running ResearchPocket backend;
 - multi-user collaboration or authorization within a library;
 - end-to-end encryption of the private repository;

--- a/docs/v2/THREAT_MODEL.md
+++ b/docs/v2/THREAT_MODEL.md
@@ -212,7 +212,7 @@ flowchart LR
     V --> I[IndexedDB state and applied receipts]
     E[Owner edit] --> I
     I --> Q[Durable browser outbox]
-    Q -->|serialized immutable upload| A
+    Q -->|exact envelopes in immutable bounded pack| A
     M -. never persisted .-> I
 ```
 
@@ -360,8 +360,8 @@ Activating a new shell version removes old caches.
 | Malicious Pages update captures credentials | Owner PAT cannot write the application repository; keep source, Pages workflow, releases, and protected `main` and `v*` tags in the same reviewed repository with required checks and pinned deployment inputs | A compromised maintainer or hosting account can publish malicious first-party code. |
 | Private data leaks through publication | Separate repositories; explicit collection and field allowlists; notes off by default; unresolved visibility private; negative artifact scans | Previously published Git history remains until rewritten. |
 | Service worker retains a token or API response | Never pass tokens to the worker; bypass Authorization/cross-origin traffic; cache shell allowlist only | Browser implementation defects remain possible. |
-| Git race loses or overwrites an edit | Immutable unique paths, pull-before-push, serialized upload, hash equality for idempotency, retry unchanged outbox | GitHub outage delays sync but does not discard local edits. |
-| Corrupt/replayed remote update changes state | Envelope schema/version checks, library identity, payload SHA-256, immutable device sequence/path, applied receipt | A repository writer can delete history; clients must detect missing/inconsistent data. |
+| Git race loses or overwrites an edit | Immutable unique direct/pack paths, pull-before-push, serialized upload, hash equality for idempotency, retry unchanged exact envelope bytes | GitHub outage delays sync but does not discard local edits. |
+| Corrupt/replayed remote update changes state | Pack path/body SHA-256 and bounds, exact member-envelope validation, library identity, payload SHA-256, immutable device sequence/path, applied receipt, all-or-nothing pack transaction | A repository writer can delete history; clients must detect missing/inconsistent data. |
 | Token appears in logs or URLs | Authorization header only; redacted errors; no analytics; no token interpolation; production console off | User-installed debugging tools may capture traffic. |
 | Untrusted page invokes native capture | Browser external-protocol confirmation; exact route/version; bounded append-only field allowlist; no read, edit, delete, sync, or publication action | Remembered site permission can permit unwanted save spam. |
 | Capture URI injects a command or selects private state | Direct argument handling without shell evaluation; reject unknown fields, paths, credentials, provider names, user information, fragments, and non-HTTP(S) targets | Browser, OS diagnostics, or same-user processes may observe accepted URL/title/description/language data. |

--- a/docs/v2/WEB.md
+++ b/docs/v2/WEB.md
@@ -33,11 +33,12 @@ favorite or tag change, delete, and restore without decoding the opaque Loro
 payload or duplicating note and excerpt values. Older queued rows without a
 summary remain visible as earlier local changes until acknowledged.
 
-The WASM boundary also accepts a set of remote immutable envelopes in one Loro
-session and reports any causally deferred indices. The browser GitHub adapter
-discovers exact protocol blobs, validates immutable genesis, applies unseen
-envelopes through this boundary, serializes Contents API creates, and pulls once
-more after uploads or branch-head races.
+The WASM boundary also validates immutable operation packs and accepts their
+exact embedded envelopes in one Loro session, reporting any causally deferred
+indices. The browser GitHub adapter discovers exact protocol blobs, validates
+immutable genesis and containers, applies unseen envelopes through this
+boundary, serializes Contents API creates, and pulls once more after uploads or
+branch-head races.
 
 ## Browser persistence
 
@@ -113,13 +114,24 @@ unavailable, read-only, mismatched-library, malformed, or unsupported remotes
 before uploading queued work.
 
 One browser upload loop runs under a Web Lock. A cycle validates immutable
-genesis, discovers the Git tree, downloads and applies every unseen operation,
-uploads unchanged outbox bytes one at a time, and pulls again. Existing identical
-paths acknowledge the outbox; byte-different paths stop as integrity failures.
-`409`, `422`, ambiguous transport errors, rate limits, and server failures leave
-the exact outbox intact for bounded or later retry. Visible owner tabs request a
-cycle after local changes, on startup, focus, network recovery, and every 60
-seconds.
+genesis, discovers the Git tree, downloads and applies every unseen direct or
+packed operation, groups the exact starting outbox bytes into one bounded
+content-addressed pack when more than one change is waiting, uploads it, and
+pulls again. A single pending envelope remains a direct operation file. Existing
+identical paths acknowledge every represented outbox row; byte-different paths
+stop as integrity failures. `409`, `422`, ambiguous transport errors, rate
+limits, and server failures leave the exact outbox intact for bounded or later
+retry. Changes created after pack preparation wait for the next cycle. Visible
+owner tabs coalesce local-change notifications through a five-second quiet
+window so a normal curation burst shares one pack. Manual sync, startup, focus,
+and network recovery remain immediate, and visible tabs still refresh every 60
+seconds. A local change arriving during a running cycle guarantees a follow-up
+flush instead of waiting for the periodic timer.
+
+Once a pack-enabled client has uploaded the first operation pack, every browser
+and native client for that private library must run a pack-aware release. Older
+preview clients encounter the recognized unsupported object and stop rather
+than silently miss changes.
 
 An edit form carries the note value it originally displayed. If synchronization
 or another tab changes that note before submission, the shared WASM mutation

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -6,7 +6,10 @@ use base64::{Engine as _, engine::general_purpose::STANDARD};
 use chrono::{DateTime, FixedOffset};
 use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
 use reqwest::{Client, Response, StatusCode, Url};
-use research_domain::{DomainError, LibraryGenesis};
+use research_domain::{
+    DomainError, LibraryGenesis, MAX_OPERATION_PACK_BYTES, MAX_OPERATION_PACK_MEMBERS,
+    OperationPackArtifact, create_operation_pack,
+};
 use research_store::{
     PendingBatch, RemoteBatchDisposition, StoreError, SyncConfiguration, V2Store,
 };
@@ -18,7 +21,9 @@ const API_ROOT: &str = "https://api.github.com/";
 const API_VERSION: &str = "2026-03-10";
 const GENESIS_PATH: &str = "sync/v1/library.json";
 const OPS_PREFIX: &str = "sync/v1/ops/";
+const PACKS_PREFIX: &str = "sync/v1/ops/packs/";
 const MAX_UPLOAD_ATTEMPTS: usize = 4;
+const PACK_JSON_OVERHEAD_ALLOWANCE: usize = 1_024;
 
 #[derive(Debug, Error)]
 pub enum SyncError {
@@ -200,6 +205,82 @@ enum PutResult {
     Ambiguous(&'static str),
 }
 
+enum PendingUpload {
+    Direct(PendingBatch),
+    Pack {
+        artifact: OperationPackArtifact,
+        members: Vec<PendingBatch>,
+    },
+}
+
+impl PendingUpload {
+    fn path(&self) -> &str {
+        match self {
+            Self::Direct(batch) => &batch.path,
+            Self::Pack { artifact, .. } => &artifact.path,
+        }
+    }
+
+    fn bytes(&self) -> &[u8] {
+        match self {
+            Self::Direct(batch) => batch.envelope_json.as_bytes(),
+            Self::Pack { artifact, .. } => artifact.json.as_bytes(),
+        }
+    }
+
+    fn member_paths(&self) -> Vec<String> {
+        match self {
+            Self::Direct(batch) => vec![batch.path.clone()],
+            Self::Pack { members, .. } => {
+                members.iter().map(|batch| batch.path.clone()).collect()
+            }
+        }
+    }
+
+    fn logical_count(&self) -> Result<u64, SyncError> {
+        let count = match self {
+            Self::Direct(_) => 1,
+            Self::Pack { members, .. } => members.len(),
+        };
+        u64::try_from(count)
+            .map_err(|_| StoreError::NumericRange("pending upload member count").into())
+    }
+
+    async fn confirm(
+        &self,
+        store: &V2Store,
+        blob_sha: &str,
+        bytes: &[u8],
+    ) -> Result<PullStats, SyncError> {
+        let mut stats = PullStats::default();
+        match self {
+            Self::Direct(batch) => {
+                let result = store
+                    .receive_remote_batch(&batch.path, blob_sha, bytes)
+                    .await?;
+                stats.downloaded = 1;
+                match result.disposition {
+                    RemoteBatchDisposition::Applied => stats.applied = 1,
+                    RemoteBatchDisposition::AlreadyApplied => stats.already_applied = 1,
+                }
+                if result.acknowledged_outbox {
+                    stats.acknowledged = 1;
+                }
+            }
+            Self::Pack { artifact, .. } => {
+                let result = store
+                    .receive_remote_pack(&artifact.path, blob_sha, bytes)
+                    .await?;
+                stats.downloaded = result.member_count;
+                stats.applied = result.applied;
+                stats.already_applied = result.already_applied;
+                stats.acknowledged = result.acknowledged_outbox;
+            }
+        }
+        Ok(stats)
+    }
+}
+
 #[derive(Default)]
 struct PullStats {
     seen: u64,
@@ -366,12 +447,12 @@ async fn run_configured(
         .inspect_repository(&remote.owner, &remote.repository)
         .await?;
     let mut pull = pull_remote(store, client, remote).await?;
-    let pending = store.pending_batches().await?;
+    let pending = prepare_uploads(store.pending_batches().await?)?;
     let mut uploaded = 0_u64;
-    for batch in pending {
-        let (created, race_pull) = ensure_uploaded(store, client, remote, &batch).await?;
+    for upload in pending {
+        let (created, race_pull) = ensure_uploaded(store, client, remote, &upload).await?;
         if created {
-            uploaded += 1;
+            uploaded += upload.logical_count()?;
         }
         pull.add(race_pull);
     }
@@ -402,24 +483,29 @@ async fn pull_remote(
         .iter()
         .filter(|(path, _)| path.starts_with(OPS_PREFIX))
         .collect::<Vec<_>>();
-    let mut stats = PullStats {
-        seen: u64::try_from(operations.len())
-            .map_err(|_| StoreError::NumericRange("remote batch count"))?,
-        ..PullStats::default()
-    };
+    let mut stats = PullStats::default();
     for (path, sha) in operations {
+        stats.seen += 1;
         if store.remote_blob_is_current(path, sha).await? {
             continue;
         }
         let bytes = client.download_blob(remote, sha).await?;
-        let result = store.receive_remote_batch(path, sha, &bytes).await?;
-        stats.downloaded += 1;
-        match result.disposition {
-            RemoteBatchDisposition::Applied => stats.applied += 1,
-            RemoteBatchDisposition::AlreadyApplied => stats.already_applied += 1,
-        }
-        if result.acknowledged_outbox {
-            stats.acknowledged += 1;
+        if path.starts_with(PACKS_PREFIX) {
+            let result = store.receive_remote_pack(path, sha, &bytes).await?;
+            stats.downloaded += 1;
+            stats.applied += result.applied;
+            stats.already_applied += result.already_applied;
+            stats.acknowledged += result.acknowledged_outbox;
+        } else {
+            let result = store.receive_remote_batch(path, sha, &bytes).await?;
+            stats.downloaded += 1;
+            match result.disposition {
+                RemoteBatchDisposition::Applied => stats.applied += 1,
+                RemoteBatchDisposition::AlreadyApplied => stats.already_applied += 1,
+            }
+            if result.acknowledged_outbox {
+                stats.acknowledged += 1;
+            }
         }
     }
     if store.status().await?.deferred_updates > 0 {
@@ -464,56 +550,92 @@ async fn ensure_uploaded(
     store: &V2Store,
     client: &GitHubClient,
     remote: &Remote,
-    batch: &PendingBatch,
+    upload: &PendingUpload,
 ) -> Result<(bool, PullStats), SyncError> {
     let mut race_pull = PullStats::default();
+    let member_paths = upload.member_paths();
     for attempt in 0..MAX_UPLOAD_ATTEMPTS {
         let tree = client.discover(remote).await?;
-        if let Some(sha) = tree.blobs.get(&batch.path) {
-            if !store.remote_blob_is_current(&batch.path, sha).await? {
+        if let Some(sha) = tree.blobs.get(upload.path()) {
+            if !store.remote_blob_is_current(upload.path(), sha).await? {
                 let bytes = client.download_blob(remote, sha).await?;
-                store.receive_remote_batch(&batch.path, sha, &bytes).await?;
+                race_pull.add(upload.confirm(store, sha, &bytes).await?);
             }
             return Ok((false, race_pull));
         }
 
         let put = client
-            .put_new(
-                remote,
-                &batch.path,
-                batch.envelope_json.as_bytes(),
-                Some(&remote.branch),
-            )
+            .put_new(remote, upload.path(), upload.bytes(), Some(&remote.branch))
             .await;
         match put {
             Ok(PutResult::Created(sha)) => {
-                store.record_outbox_attempt(&batch.path, None).await?;
-                store
-                    .receive_remote_batch(&batch.path, &sha, batch.envelope_json.as_bytes())
-                    .await?;
+                store.record_outbox_attempts(&member_paths, None).await?;
+                race_pull.add(upload.confirm(store, &sha, upload.bytes()).await?);
                 return Ok((true, race_pull));
             }
             Ok(PutResult::Race) => {
                 store
-                    .record_outbox_attempt(&batch.path, Some("contention"))
+                    .record_outbox_attempts(&member_paths, Some("contention"))
                     .await?;
                 race_pull.add(pull_remote(store, client, remote).await?);
-                retry_delay(&batch.path, attempt).await;
+                retry_delay(upload.path(), attempt).await;
             }
             Ok(PutResult::Ambiguous(kind)) => {
-                store.record_outbox_attempt(&batch.path, Some(kind)).await?;
+                store
+                    .record_outbox_attempts(&member_paths, Some(kind))
+                    .await?;
                 race_pull.add(pull_remote(store, client, remote).await?);
-                retry_delay(&batch.path, attempt).await;
+                retry_delay(upload.path(), attempt).await;
             }
             Err(error) => {
                 let _ = store
-                    .record_outbox_attempt(&batch.path, Some(error.kind()))
+                    .record_outbox_attempts(&member_paths, Some(error.kind()))
                     .await;
                 return Err(error);
             }
         }
     }
     Err(SyncError::Contention)
+}
+
+fn prepare_uploads(pending: Vec<PendingBatch>) -> Result<Vec<PendingUpload>, SyncError> {
+    let mut uploads = Vec::new();
+    let mut current = Vec::<PendingBatch>::new();
+    let mut current_estimated_bytes = PACK_JSON_OVERHEAD_ALLOWANCE;
+    let maximum_estimated_bytes =
+        MAX_OPERATION_PACK_BYTES.saturating_sub(PACK_JSON_OVERHEAD_ALLOWANCE);
+
+    for batch in pending {
+        let encoded_bytes = batch.envelope_json.len().div_ceil(3) * 4 + 3;
+        let changes_device = current
+            .first()
+            .is_some_and(|first| first.device_id != batch.device_id);
+        let exceeds_members = current.len() == MAX_OPERATION_PACK_MEMBERS;
+        let exceeds_bytes = !current.is_empty()
+            && current_estimated_bytes.saturating_add(encoded_bytes) > maximum_estimated_bytes;
+        if changes_device || exceeds_members || exceeds_bytes {
+            uploads.push(build_pending_upload(std::mem::take(&mut current))?);
+            current_estimated_bytes = PACK_JSON_OVERHEAD_ALLOWANCE;
+        }
+        current_estimated_bytes = current_estimated_bytes.saturating_add(encoded_bytes);
+        current.push(batch);
+    }
+    if !current.is_empty() {
+        uploads.push(build_pending_upload(current)?);
+    }
+    Ok(uploads)
+}
+
+fn build_pending_upload(mut members: Vec<PendingBatch>) -> Result<PendingUpload, SyncError> {
+    if members.len() == 1 {
+        return Ok(PendingUpload::Direct(members.remove(0)));
+    }
+    let envelopes = members
+        .iter()
+        .map(|batch| batch.envelope_json.clone())
+        .collect::<Vec<_>>();
+    let artifact = create_operation_pack(&envelopes)?;
+    Ok(PendingUpload::Pack { artifact, members })
 }
 
 impl GitHubClient {
@@ -923,7 +1045,8 @@ fn domain_error_kind(error: &DomainError) -> &'static str {
         DomainError::UnsupportedProtocol(_)
         | DomainError::UnsupportedDomainSchema(_)
         | DomainError::UnsupportedCodec(_)
-        | DomainError::UnsupportedFeature(_) => "upgrade_required",
+        | DomainError::UnsupportedFeature(_)
+        | DomainError::UnsupportedOperationPackVersion(_) => "upgrade_required",
         _ => "integrity",
     }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "research-pocket-web",
-  "version": "2.0.0-preview.3",
+  "version": "2.0.0-preview.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "research-pocket-web",
-      "version": "2.0.0-preview.3",
+      "version": "2.0.0-preview.4",
       "dependencies": {
         "idb": "8.0.3",
         "react": "19.2.7",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "research-pocket-web",
   "private": true,
-  "version": "2.0.0-preview.3",
+  "version": "2.0.0-preview.4",
   "type": "module",
   "scripts": {
     "dev": "npm run wasm && vite",

--- a/web/src/data/github.ts
+++ b/web/src/data/github.ts
@@ -3,6 +3,7 @@ const API_VERSION = "2026-03-10";
 
 export const GENESIS_PATH = "sync/v1/library.json";
 export const OPS_PREFIX = "sync/v1/ops/";
+export const PACKS_PREFIX = `${OPS_PREFIX}packs/`;
 
 export interface GitHubRemote {
   owner: string;

--- a/web/src/data/library.ts
+++ b/web/src/data/library.ts
@@ -74,6 +74,12 @@ export interface RemoteEnvelopeInput {
   envelopeJson: string;
 }
 
+export interface RemoteOperationPackInput {
+  path: string;
+  blobSha: string;
+  memberEnvelopes: string[];
+}
+
 export type SyncConfiguration = PersistedSyncConfiguration;
 
 export interface PendingSyncBatch {
@@ -121,6 +127,18 @@ interface EnvelopeIdentity {
   device_id: string;
   sequence: string;
   payload_sha256: string;
+}
+
+interface ValidatedRemoteMember {
+  path: string;
+  envelopeJson: string;
+  identity: EnvelopeIdentity;
+}
+
+interface ValidatedRemoteArtifact {
+  path: string;
+  blobSha: string;
+  members: ValidatedRemoteMember[];
 }
 
 type TextUpdate =
@@ -386,14 +404,30 @@ class LibraryRepository {
   }
 
   async recordOutboxAttempt(path: string, errorKind: string | null): Promise<void> {
+    await this.recordOutboxAttempts([path], errorKind);
+  }
+
+  async recordOutboxAttempts(paths: string[], errorKind: string | null): Promise<void> {
+    const uniquePaths = [...new Set(paths)];
+    if (uniquePaths.length === 0) return;
     await this.write(async (database) => {
-      const entry = await database.get("outbox", path);
-      if (!entry) return;
-      await database.put("outbox", {
-        ...entry,
-        attempts: entry.attempts + 1,
-        lastErrorKind: errorKind,
-      });
+      const transaction = database.transaction("outbox", "readwrite");
+      try {
+        const outbox = transaction.objectStore("outbox");
+        for (const path of uniquePaths) {
+          const entry = await outbox.get(path);
+          if (!entry) continue;
+          await outbox.put({
+            ...entry,
+            attempts: entry.attempts + 1,
+            lastErrorKind: errorKind,
+          });
+        }
+        await transaction.done;
+      } catch (error) {
+        abortTransaction(transaction);
+        throw error;
+      }
     });
   }
 
@@ -409,38 +443,41 @@ class LibraryRepository {
     await this.recordSyncResult(kind);
   }
 
-  async applyRemote(inputs: RemoteEnvelopeInput[]): Promise<void> {
-    if (inputs.length === 0) return;
+  async applyRemote(
+    inputs: RemoteEnvelopeInput[],
+    packs: RemoteOperationPackInput[] = [],
+  ): Promise<number> {
+    if (inputs.length === 0 && packs.length === 0) return 0;
+    let applied = 0;
     await this.write(async (database) => {
       const persisted = await readPersisted(database);
-      const paths = new Set<string>();
-      const identities = inputs.map((input) => {
-        if (paths.has(input.path)) {
-          throw new Error(`A remote update was discovered twice at ${input.path}.`);
-        }
-        paths.add(input.path);
-        const identity = parseEnvelope(input.envelopeJson);
-        validateRemoteIdentity(input, identity, persisted.meta.libraryId);
-        validateBlobSha(input.blobSha);
-        return identity;
-      });
-      const newInputs: RemoteEnvelopeInput[] = [];
-      for (const input of inputs) {
-        const [existing, observation] = await Promise.all([
-          database.get("batches", input.path),
-          database.get("remoteObservations", input.path),
-        ]);
-        if (existing && existing.envelopeJson !== input.envelopeJson) {
-          throw new Error("An immutable remote update changed after it was observed.");
-        }
-        if (observation && observation.blobSha !== input.blobSha) {
+      const artifacts = validateRemoteArtifacts(inputs, packs, persisted.meta.libraryId);
+      const newMembers: ValidatedRemoteMember[] = [];
+      const newMemberPaths = new Set<string>();
+      for (const artifact of artifacts) {
+        const observation = await database.get("remoteObservations", artifact.path);
+        if (observation && observation.blobSha !== artifact.blobSha) {
           throw new Error("An immutable remote path changed its Git object identity.");
         }
-        if (!existing) newInputs.push(input);
+        for (const member of artifact.members) {
+          const existing = await database.get("batches", member.path);
+          if (existing && existing.envelopeJson !== member.envelopeJson) {
+            throw new Error("An immutable remote update changed after it was observed.");
+          }
+          if (!existing && !newMemberPaths.has(member.path)) {
+            newMembers.push(member);
+            newMemberPaths.add(member.path);
+          }
+        }
       }
+      applied = newMembers.length;
       const deferred = await database.getAll("deferred");
       const combined = [
-        ...newInputs,
+        ...newMembers.map((member) => ({
+          path: member.path,
+          blobSha: "",
+          envelopeJson: member.envelopeJson,
+        })),
         ...deferred.map((entry) => ({
           path: entry.path,
           blobSha: "",
@@ -459,12 +496,15 @@ class LibraryRepository {
       const now = new Date().toISOString();
       const items = materializeProjection(result.projection);
       const pendingRecords = materializeDeferred(result.pending_indices, combined);
-      const newBatchRecords = newInputs.map((input) => {
-        const index = inputs.indexOf(input);
-        const identity = identities[index];
-        if (!identity) throw new Error("A remote update identity is missing.");
-        return batchRecord(input.path, input.envelopeJson, identity, "remote", now);
-      });
+      const newBatchRecords = newMembers.map((member) =>
+        batchRecord(
+          member.path,
+          member.envelopeJson,
+          member.identity,
+          "remote",
+          now,
+        ),
+      );
       const transaction = database.transaction(
         ["state", "items", "batches", "outbox", "deferred", "remoteObservations"],
         "readwrite",
@@ -483,11 +523,13 @@ class LibraryRepository {
         for (const record of newBatchRecords) {
           await transaction.objectStore("batches").add(record);
         }
-        for (const input of inputs) {
-          await transaction.objectStore("outbox").delete(input.path);
+        for (const artifact of artifacts) {
+          for (const member of artifact.members) {
+            await transaction.objectStore("outbox").delete(member.path);
+          }
           await transaction.objectStore("remoteObservations").put({
-            path: input.path,
-            blobSha: input.blobSha,
+            path: artifact.path,
+            blobSha: artifact.blobSha,
             observedAt: now,
           });
         }
@@ -498,6 +540,7 @@ class LibraryRepository {
       }
     });
     await this.afterCommit("Remote changes applied");
+    return applied;
   }
 
   private async commitMutation(
@@ -1009,6 +1052,62 @@ function validateRemoteIdentity(
   ) {
     throw new Error("A remote update path does not match its immutable identity.");
   }
+}
+
+function validateRemoteArtifacts(
+  inputs: RemoteEnvelopeInput[],
+  packs: RemoteOperationPackInput[],
+  expectedLibraryId: string,
+): ValidatedRemoteArtifact[] {
+  const artifactPaths = new Set<string>();
+  const memberBytesByPath = new Map<string, string>();
+  const artifacts: ValidatedRemoteArtifact[] = [];
+
+  const addArtifact = (artifact: ValidatedRemoteArtifact) => {
+    if (artifactPaths.has(artifact.path)) {
+      throw new Error(`A remote artifact was discovered twice at ${artifact.path}.`);
+    }
+    artifactPaths.add(artifact.path);
+    validateBlobSha(artifact.blobSha);
+    for (const member of artifact.members) {
+      const existingBytes = memberBytesByPath.get(member.path);
+      if (existingBytes !== undefined && existingBytes !== member.envelopeJson) {
+        throw new Error(`A remote update identity has conflicting bytes at ${member.path}.`);
+      }
+      memberBytesByPath.set(member.path, member.envelopeJson);
+    }
+    artifacts.push(artifact);
+  };
+
+  for (const input of inputs) {
+    const identity = parseEnvelope(input.envelopeJson);
+    validateRemoteIdentity(input, identity, expectedLibraryId);
+    addArtifact({
+      path: input.path,
+      blobSha: input.blobSha,
+      members: [{ path: input.path, envelopeJson: input.envelopeJson, identity }],
+    });
+  }
+
+  for (const pack of packs) {
+    if (!pack.path.startsWith("sync/v1/ops/packs/") || pack.memberEnvelopes.length < 2) {
+      throw new Error("A remote operation pack is malformed.");
+    }
+    const members = pack.memberEnvelopes.map((envelopeJson) => {
+      const identity = parseEnvelope(envelopeJson);
+      if (identity.library_id !== expectedLibraryId) {
+        throw new Error("A remote operation pack belongs to another library.");
+      }
+      return {
+        path: operationPath(identity.device_id, identity.sequence),
+        envelopeJson,
+        identity,
+      };
+    });
+    addArtifact({ path: pack.path, blobSha: pack.blobSha, members });
+  }
+
+  return artifacts;
 }
 
 function operationPath(deviceId: string, sequence: string): string {

--- a/web/src/data/sync.ts
+++ b/web/src/data/sync.ts
@@ -1,5 +1,7 @@
 import initWasm, {
+  createOperationPack,
   createSyncGenesis,
+  unpackOperationPack,
   validateSyncGenesis,
 } from "../generated/research_domain";
 
@@ -8,6 +10,7 @@ import {
   GitHubClient,
   GitHubSyncError,
   OPS_PREFIX,
+  PACKS_PREFIX,
   parseRepository,
   type GitHubRemote,
   type ProtocolTree,
@@ -17,6 +20,7 @@ import {
   libraryRepository,
   type PendingSyncBatch,
   type RemoteEnvelopeInput,
+  type RemoteOperationPackInput,
   type SyncConfiguration,
 } from "./library.ts";
 
@@ -57,11 +61,28 @@ interface PullStats {
   acknowledged: number;
 }
 
+interface OperationPackArtifact {
+  path: string;
+  json: string;
+  member_envelopes: string[];
+}
+
+interface PendingUpload {
+  path: string;
+  json: string;
+  members: PendingSyncBatch[];
+  packed: boolean;
+}
+
 const SYNC_LOCK = "researchpocket-v2-github-sync";
 const LIBRARY_CHANNEL = "researchpocket-v2-state";
 const SESSION_TOKEN_KEY = "researchpocket-v2-github-token";
 const MAX_UPLOAD_ATTEMPTS = 4;
 const PERIODIC_SYNC_MS = 60_000;
+const LOCAL_CHANGE_SYNC_DELAY_MS = 5_000;
+const MAX_PACK_MEMBERS = 1_000;
+const MAX_PACK_BYTES = 20 * 1024 * 1024;
+const PACK_JSON_OVERHEAD_BYTES = 1_024;
 
 let wasmPromise: Promise<unknown> | undefined;
 
@@ -83,13 +104,15 @@ class BrowserSyncService {
   #token: string | null = readSessionToken();
   private retryNotBefore = 0;
   private running: Promise<void> | null = null;
+  private localChangeTimer: number | null = null;
+  private rerunAfterCurrentSync = false;
   private readonly listeners = new Set<(state: BrowserSyncState) => void>();
   private readonly channel = new BroadcastChannel(LIBRARY_CHANNEL);
 
   constructor() {
     this.channel.addEventListener("message", () => {
       if (this.#token && this.state.configuration && document.visibilityState === "visible") {
-        void this.requestSync("local change");
+        this.scheduleLocalChangeSync();
       }
     });
     window.addEventListener("focus", () => void this.requestSync("window focus"));
@@ -198,7 +221,10 @@ class BrowserSyncService {
   }
 
   private async requestSync(reason: string, force = false): Promise<void> {
-    if (this.running) return this.running;
+    if (this.running) {
+      if (reason === "local changes") this.rerunAfterCurrentSync = true;
+      return this.running;
+    }
     if (!this.#token || !this.state.configuration) return;
     if (!navigator.onLine) {
       const error = new GitHubSyncError(
@@ -241,10 +267,26 @@ class BrowserSyncService {
         if (force) throw error;
       })
       .finally(() => {
+        const rerun = this.rerunAfterCurrentSync;
+        this.rerunAfterCurrentSync = false;
         this.patch({ syncing: false });
         this.running = null;
+        if (rerun) this.scheduleLocalChangeSync(0);
       });
     return this.running;
+  }
+
+  private scheduleLocalChangeSync(delay = LOCAL_CHANGE_SYNC_DELAY_MS): void {
+    if (this.localChangeTimer !== null) window.clearTimeout(this.localChangeTimer);
+    this.localChangeTimer = window.setTimeout(() => {
+      this.localChangeTimer = null;
+      void libraryRepository
+        .pendingSyncBatches()
+        .then((pending) => {
+          if (pending.length > 0) return this.requestSync("local changes");
+        })
+        .catch(() => undefined);
+    }, delay);
   }
 
   private async withSyncLock(
@@ -321,9 +363,11 @@ class BrowserSyncService {
     await client.inspectRepository(remote.owner, remote.repository);
     let pull = await this.pullRemote(client, remote);
     let uploaded = 0;
-    for (const batch of await libraryRepository.pendingSyncBatches()) {
-      const upload = await this.ensureUploaded(client, remote, batch);
-      uploaded += upload.created ? 1 : 0;
+    const pendingAtFlushStart = await libraryRepository.pendingSyncBatches();
+    const uploads = await buildPendingUploads(pendingAtFlushStart);
+    for (const pending of uploads) {
+      const upload = await this.ensureUploaded(client, remote, pending);
+      uploaded += upload.created ? pending.members.length : 0;
       pull = addPullStats(pull, upload.pull);
     }
     pull = addPullStats(pull, await this.pullRemote(client, remote));
@@ -353,6 +397,8 @@ class BrowserSyncService {
       .filter(([path]) => path.startsWith(OPS_PREFIX))
       .sort(([left], [right]) => left.localeCompare(right));
     const inputs: RemoteEnvelopeInput[] = [];
+    const packs: RemoteOperationPackInput[] = [];
+    let downloaded = 0;
     for (const [path, blobSha] of operations) {
       const observation = await libraryRepository.remoteObservation(path);
       if (observation) {
@@ -364,14 +410,18 @@ class BrowserSyncService {
         }
         continue;
       }
-      inputs.push({
-        path,
-        blobSha,
-        envelopeJson: await client.downloadText(remote, blobSha),
-      });
+      const json = await client.downloadText(remote, blobSha);
+      if (path.startsWith(PACKS_PREFIX)) {
+        const pack = await unpackRemotePack(path, blobSha, json);
+        packs.push(pack);
+        downloaded += 1;
+      } else {
+        inputs.push({ path, blobSha, envelopeJson: json });
+        downloaded += 1;
+      }
     }
     const pendingBefore = (await libraryRepository.pendingSyncBatches()).length;
-    await this.applyRemoteUpdates(inputs);
+    const applied = await this.applyRemoteUpdates(inputs, packs);
     if ((await libraryRepository.deferredSyncCount()) > 0) {
       throw new GitHubSyncError(
         "Remote updates are missing a causal predecessor. No local changes were uploaded.",
@@ -381,8 +431,8 @@ class BrowserSyncService {
     const pendingAfter = (await libraryRepository.pendingSyncBatches()).length;
     return {
       remoteSeen: operations.length,
-      downloaded: inputs.length,
-      applied: inputs.length,
+      downloaded,
+      applied,
       acknowledged: Math.max(0, pendingBefore - pendingAfter),
     };
   }
@@ -424,43 +474,47 @@ class BrowserSyncService {
   private async ensureUploaded(
     client: GitHubClient,
     remote: GitHubRemote,
-    batch: PendingSyncBatch,
+    pending: PendingUpload,
   ): Promise<{ created: boolean; pull: PullStats }> {
     let racePull = emptyPullStats();
     for (let attempt = 0; attempt < MAX_UPLOAD_ATTEMPTS; attempt += 1) {
       const tree = await client.discover(remote);
-      const existingSha = tree.blobs.get(batch.path);
+      const existingSha = tree.blobs.get(pending.path);
       if (existingSha) {
-        await this.applyRemoteUpdates([
-          {
-            path: batch.path,
-            blobSha: existingSha,
-            envelopeJson: await client.downloadText(remote, existingSha),
-          },
-        ]);
+        const existingJson = await client.downloadText(remote, existingSha);
+        await this.applyUploadedArtifact(pending, existingSha, existingJson);
         return { created: false, pull: racePull };
       }
 
-      const put = await client.putNew(
-        remote,
-        batch.path,
-        batch.envelopeJson,
-        remote.branch,
-      );
+      let put;
+      try {
+        put = await client.putNew(
+          remote,
+          pending.path,
+          pending.json,
+          remote.branch,
+        );
+      } catch (error) {
+        await libraryRepository.recordOutboxAttempts(
+          pending.members.map((member) => member.path),
+          error instanceof GitHubSyncError ? error.kind : "transport",
+        );
+        throw error;
+      }
       if (put.type === "created") {
-        await libraryRepository.recordOutboxAttempt(batch.path, null);
-        await this.applyRemoteUpdates([
-          {
-            path: batch.path,
-            blobSha: put.blobSha,
-            envelopeJson: batch.envelopeJson,
-          },
-        ]);
+        await libraryRepository.recordOutboxAttempts(
+          pending.members.map((member) => member.path),
+          null,
+        );
+        await this.applyUploadedArtifact(pending, put.blobSha, pending.json);
         return { created: true, pull: racePull };
       }
-      await libraryRepository.recordOutboxAttempt(batch.path, put.type === "race" ? "contention" : put.kind);
+      await libraryRepository.recordOutboxAttempts(
+        pending.members.map((member) => member.path),
+        put.type === "race" ? "contention" : put.kind,
+      );
       racePull = addPullStats(racePull, await this.pullRemote(client, remote));
-      await retryDelay(batch.path, attempt);
+      await retryDelay(pending.path, attempt);
     }
     throw new GitHubSyncError(
       "Synchronization remained contended after safe retries.",
@@ -468,9 +522,27 @@ class BrowserSyncService {
     );
   }
 
-  private async applyRemoteUpdates(inputs: RemoteEnvelopeInput[]): Promise<void> {
+  private async applyUploadedArtifact(
+    pending: PendingUpload,
+    blobSha: string,
+    json: string,
+  ): Promise<void> {
+    if (pending.packed) {
+      const pack = await unpackRemotePack(pending.path, blobSha, json);
+      await this.applyRemoteUpdates([], [pack]);
+      return;
+    }
+    await this.applyRemoteUpdates([
+      { path: pending.path, blobSha, envelopeJson: json },
+    ]);
+  }
+
+  private async applyRemoteUpdates(
+    inputs: RemoteEnvelopeInput[],
+    packs: RemoteOperationPackInput[] = [],
+  ): Promise<number> {
     try {
-      await libraryRepository.applyRemote(inputs);
+      return await libraryRepository.applyRemote(inputs, packs);
     } catch (error) {
       if (error instanceof DOMException) throw error;
       throw new GitHubSyncError(
@@ -532,6 +604,158 @@ class BrowserSyncService {
     this.state = { ...this.state, ...patch };
     for (const listener of this.listeners) listener(this.state);
   }
+}
+
+async function buildPendingUploads(
+  pending: PendingSyncBatch[],
+): Promise<PendingUpload[]> {
+  const chunks = chunkPendingBatches(pending);
+  if (chunks.some((chunk) => chunk.length > 1)) await ensureWasm();
+
+  return chunks.map((members) => {
+    const first = members[0];
+    if (!first) {
+      throw new GitHubSyncError(
+        "The browser outbox produced an empty synchronization upload.",
+        "local_state",
+      );
+    }
+    if (members.length === 1) {
+      return {
+        path: first.path,
+        json: first.envelopeJson,
+        members,
+        packed: false,
+      };
+    }
+
+    try {
+      const expectedEnvelopes = members.map((member) => member.envelopeJson);
+      const artifact = parseOperationPackArtifact(
+        createOperationPack(JSON.stringify(expectedEnvelopes)),
+      );
+      if (
+        artifact.member_envelopes.length !== expectedEnvelopes.length ||
+        artifact.member_envelopes.some(
+          (envelope, index) => envelope !== expectedEnvelopes[index],
+        )
+      ) {
+        throw new Error("The shared domain core changed the queued envelope bytes.");
+      }
+      return {
+        path: artifact.path,
+        json: artifact.json,
+        members,
+        packed: true,
+      };
+    } catch (error) {
+      if (error instanceof GitHubSyncError) throw error;
+      throw new GitHubSyncError(
+        "Queued changes failed shared operation-pack validation and remain safely stored here.",
+        "local_state",
+      );
+    }
+  });
+}
+
+function chunkPendingBatches(pending: PendingSyncBatch[]): PendingSyncBatch[][] {
+  const chunks: PendingSyncBatch[][] = [];
+  let current: PendingSyncBatch[] = [];
+  let currentDevice = "";
+  let estimatedBytes = PACK_JSON_OVERHEAD_BYTES;
+
+  const flush = () => {
+    if (current.length > 0) chunks.push(current);
+    current = [];
+    currentDevice = "";
+    estimatedBytes = PACK_JSON_OVERHEAD_BYTES;
+  };
+
+  for (const batch of [...pending].sort((left, right) => left.path.localeCompare(right.path))) {
+    const device = pendingBatchDevice(batch.path);
+    const memberBytes = estimatedEncodedMemberBytes(batch.envelopeJson);
+    const memberFitsPack = PACK_JSON_OVERHEAD_BYTES + memberBytes <= MAX_PACK_BYTES;
+    if (!memberFitsPack) {
+      flush();
+      chunks.push([batch]);
+      continue;
+    }
+    if (
+      current.length > 0 &&
+      (currentDevice !== device ||
+        current.length >= MAX_PACK_MEMBERS ||
+        estimatedBytes + memberBytes > MAX_PACK_BYTES)
+    ) {
+      flush();
+    }
+    currentDevice = device;
+    current.push(batch);
+    estimatedBytes += memberBytes;
+  }
+  flush();
+  return chunks;
+}
+
+function pendingBatchDevice(path: string): string {
+  const match = /^sync\/v1\/ops\/([^/]+)\/\d{20}\.json$/.exec(path);
+  if (!match?.[1] || match[1] === "packs") {
+    throw new GitHubSyncError(
+      "The browser outbox contains an invalid immutable update path.",
+      "local_state",
+    );
+  }
+  return match[1];
+}
+
+function estimatedEncodedMemberBytes(envelopeJson: string): number {
+  const exactBytes = new TextEncoder().encode(envelopeJson).byteLength;
+  return 4 * Math.ceil(exactBytes / 3) + 3;
+}
+
+async function unpackRemotePack(
+  path: string,
+  blobSha: string,
+  json: string,
+): Promise<RemoteOperationPackInput> {
+  try {
+    await ensureWasm();
+    const artifact = parseOperationPackArtifact(unpackOperationPack(path, json));
+    if (artifact.path !== path || artifact.json !== json) {
+      throw new Error("The shared domain core changed the immutable pack bytes.");
+    }
+    return {
+      path,
+      blobSha,
+      memberEnvelopes: artifact.member_envelopes,
+    };
+  } catch (error) {
+    if (error instanceof GitHubSyncError) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    const upgradeRequired = /unsupported (?:protocol|operation pack|feature)/i.test(message);
+    throw new GitHubSyncError(
+      upgradeRequired
+        ? "This private library uses a newer packed synchronization format. Upgrade ResearchPocket before syncing."
+        : "A remote operation pack is malformed or failed its content-address check.",
+      upgradeRequired ? "upgrade_required" : "integrity",
+    );
+  }
+}
+
+function parseOperationPackArtifact(json: string): OperationPackArtifact {
+  const value = JSON.parse(json) as Partial<OperationPackArtifact>;
+  if (
+    typeof value.path !== "string" ||
+    !value.path.startsWith(PACKS_PREFIX) ||
+    typeof value.json !== "string" ||
+    !Array.isArray(value.member_envelopes) ||
+    value.member_envelopes.length < 2 ||
+    value.member_envelopes.length > MAX_PACK_MEMBERS ||
+    value.member_envelopes.some((envelope) => typeof envelope !== "string") ||
+    new TextEncoder().encode(value.json).byteLength > MAX_PACK_BYTES
+  ) {
+    throw new Error("The shared domain core returned an invalid operation-pack artifact.");
+  }
+  return value as OperationPackArtifact;
 }
 
 function remoteFrom(configuration: SyncConfiguration): GitHubRemote {


### PR DESCRIPTION
## Summary

- preserve every logical `UpdateEnvelope` exactly while transporting a normal multi-edit flush in one content-addressed operation pack
- apply/ack packs atomically in SQLite and IndexedDB, accept legacy direct operation files, and fail closed on unsupported pack clients
- coalesce hosted local-change notifications for five seconds so normal online curation actually batches, while manual/startup/focus sync stays immediate
- document the compatibility, migration, recovery, and threat-model consequences in ADR 0003 and prepare `v2.0.0-preview.4`

## Why this is not Git squashing

Git remains storage and transport only. No merge, rebase, force-push, history rewrite, mutable log, commit timestamp, or branch order participates in domain convergence. Pack paths are immutable and SHA-256-addressed; embedded envelopes retain their original device sequence, payload, receipt, and exact retry bytes.

## Compatibility

Pack-aware clients read both existing direct files and packs. Once the first pack is uploaded, preview 3 and older clients stop on the recognized unsupported object and must be upgraded; they never silently ignore packed saves. Existing remote files/history are not rewritten.

## Verification

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `npm test`
- `npm run build`
- independent correctness review: no blockers

Closes #68