### PR TITLE
Fix Firefox mobile restore and pull-to-refresh

### DIFF
--- a/web/src/data/github.test.mjs
+++ b/web/src/data/github.test.mjs
@@ -1,13 +1,15 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { test } from "node:test";
 
 import { GitHubClient } from "./github.ts";
 
 test("the browser GitHub adapter keeps credentials in headers and exact bytes in immutable writes", async () => {
   const token = "github-test-credential";
-  const blobSha = "a".repeat(40);
   const envelope = "{\"exact\":true}";
+  const blobSha = gitBlobSha(envelope);
   const requests = [];
+  let blobAttempts = 0;
   const fetcher = async (input, init) => {
     const url = input instanceof URL ? input : new URL(input.toString());
     requests.push({ url, init });
@@ -37,12 +39,18 @@ test("the browser GitHub adapter keeps credentials in headers and exact bytes in
       });
     }
     if (url.pathname.endsWith(`/git/blobs/${blobSha}`)) {
-      return Response.json({
-        content: Buffer.from(envelope).toString("base64"),
-        encoding: "base64",
-        sha: blobSha,
-        size: Buffer.byteLength(envelope),
+      blobAttempts += 1;
+      const response = new Response(envelope, {
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
       });
+      if (blobAttempts === 1) {
+        Object.defineProperty(response, "arrayBuffer", {
+          value: async () => {
+            throw new TypeError("transient mobile body read failure");
+          },
+        });
+      }
+      return response;
     }
     if (init?.method === "PUT") return new Response(null, { status: 409 });
     throw new Error(`Unexpected request ${url}`);
@@ -57,6 +65,7 @@ test("the browser GitHub adapter keeps credentials in headers and exact bytes in
   const tree = await client.discover(remote);
   assert.equal(tree.blobs.size, 1);
   assert.equal(await client.downloadText(remote, blobSha), envelope);
+  assert.equal(blobAttempts, 2);
   assert.deepEqual(
     await client.putNew(remote, [...tree.blobs.keys()][0], envelope, remote.branch),
     { type: "race" },
@@ -72,7 +81,46 @@ test("the browser GitHub adapter keeps credentials in headers and exact bytes in
   }
   const write = requests.find(({ init }) => init?.method === "PUT");
   assert.ok(write);
+  const blobReads = requests.filter(({ url }) => url.pathname.endsWith(`/git/blobs/${blobSha}`));
+  assert.equal(blobReads.length, 2);
+  for (const { init } of blobReads) {
+    assert.equal(
+      new Headers(init?.headers).get("Accept"),
+      "application/vnd.github.raw+json",
+    );
+  }
   const body = JSON.parse(write.init.body);
   assert.equal(Buffer.from(body.content, "base64").toString(), envelope);
   assert.equal("sha" in body, false);
 });
+
+test("the browser GitHub adapter rejects raw bytes with the wrong Git identity", async () => {
+  const expected = "original";
+  const blobSha = gitBlobSha(expected);
+  const client = new GitHubClient("github-test-credential", async () => {
+    return new Response("tampered", {
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  });
+
+  await assert.rejects(
+    () =>
+      client.downloadText(
+        { owner: "owner", repository: "private-library", branch: "main" },
+        blobSha,
+      ),
+    (error) => {
+      assert.equal(error?.name, "GitHubSyncError");
+      assert.equal(error?.kind, "integrity");
+      return true;
+    },
+  );
+});
+
+function gitBlobSha(text) {
+  const bytes = Buffer.from(text);
+  return createHash("sha1")
+    .update(`blob ${bytes.byteLength}\0`)
+    .update(bytes)
+    .digest("hex");
+}

--- a/web/src/data/github.ts
+++ b/web/src/data/github.ts
@@ -1,5 +1,9 @@
 const API_ROOT = "https://api.github.com";
 const API_VERSION = "2026-03-10";
+const JSON_MEDIA_TYPE = "application/vnd.github+json";
+const RAW_BLOB_MEDIA_TYPE = "application/vnd.github.raw+json";
+const GET_ATTEMPTS = 2;
+const GET_RETRY_DELAY_MS = 250;
 
 export const GENESIS_PATH = "sync/v1/library.json";
 export const OPS_PREFIX = "sync/v1/ops/";
@@ -49,13 +53,6 @@ interface TreeEntry {
   sha: string;
 }
 
-interface BlobResponse {
-  content: string;
-  encoding: string;
-  sha: string;
-  size: number;
-}
-
 interface PutContentResponse {
   content?: {
     sha?: string;
@@ -95,7 +92,7 @@ export class GitHubClient {
       );
     }
     this.headers = new Headers({
-      Accept: "application/vnd.github+json",
+      Accept: JSON_MEDIA_TYPE,
       Authorization: `Bearer ${token}`,
       "X-GitHub-Api-Version": API_VERSION,
     });
@@ -250,19 +247,14 @@ export class GitHubClient {
 
   private async downloadBlob(remote: GitHubRemote, sha: string): Promise<Uint8Array> {
     validateGitSha(sha);
-    const blob = await this.getJson<BlobResponse>(
+    const bytes = await this.get(
       repositoryUrl(remote.owner, remote.repository, "git", "blobs", sha),
+      RAW_BLOB_MEDIA_TYPE,
+      async (response) => new Uint8Array(await response.arrayBuffer()),
     );
-    if (blob.sha !== sha || blob.encoding !== "base64") {
+    if ((await gitBlobSha(bytes, sha.length)) !== sha) {
       throw new GitHubSyncError(
-        "GitHub returned a synchronization blob with the wrong identity or encoding.",
-        "integrity",
-      );
-    }
-    const bytes = base64ToBytes(blob.content.replace(/\s/g, ""));
-    if (!Number.isSafeInteger(blob.size) || blob.size !== bytes.byteLength) {
-      throw new GitHubSyncError(
-        "GitHub returned a synchronization blob with an invalid size.",
+        "GitHub returned synchronization content that did not match its immutable identity.",
         "integrity",
       );
     }
@@ -270,24 +262,40 @@ export class GitHubClient {
   }
 
   private async getJson<T>(url: URL): Promise<T> {
-    let response: Response;
-    try {
-      response = await this.fetcher(url, {
-        method: "GET",
-        headers: this.headers,
-        cache: "no-store",
-        credentials: "omit",
-        redirect: "error",
-        referrerPolicy: "no-referrer",
-      });
-    } catch {
-      throw new GitHubSyncError(
-        "GitHub could not be reached. Your queued changes remain safely stored here.",
-        "transport",
-      );
+    return this.get(url, JSON_MEDIA_TYPE, readJsonResponse) as Promise<T>;
+  }
+
+  private async get<T>(
+    url: URL,
+    accept: string,
+    read: (response: Response) => Promise<T>,
+  ): Promise<T> {
+    const headers = new Headers(this.headers);
+    headers.set("Accept", accept);
+    for (let attempt = 0; attempt < GET_ATTEMPTS; attempt += 1) {
+      try {
+        const response = await this.fetcher(url, {
+          method: "GET",
+          headers,
+          cache: "no-store",
+          credentials: "omit",
+          redirect: "error",
+          referrerPolicy: "no-referrer",
+        });
+        if (!response.ok) throw apiError(response);
+        return await read(response);
+      } catch (error) {
+        if (error instanceof GitHubSyncError) throw error;
+        if (attempt + 1 < GET_ATTEMPTS) {
+          await delay(GET_RETRY_DELAY_MS);
+          continue;
+        }
+      }
     }
-    if (!response.ok) throw apiError(response);
-    return (await responseJson(response)) as T;
+    throw new GitHubSyncError(
+      "GitHub could not be reached. Your queued changes remain safely stored here.",
+      "transport",
+    );
   }
 }
 
@@ -380,19 +388,6 @@ function validateGitSha(sha: string): void {
   }
 }
 
-function base64ToBytes(value: string): Uint8Array {
-  let decoded: string;
-  try {
-    decoded = atob(value);
-  } catch {
-    throw new GitHubSyncError(
-      "GitHub returned invalid Base64 synchronization data.",
-      "integrity",
-    );
-  }
-  return Uint8Array.from(decoded, (character) => character.charCodeAt(0));
-}
-
 function bytesToBase64(bytes: Uint8Array): string {
   let binary = "";
   const chunkSize = 32_768;
@@ -404,13 +399,57 @@ function bytesToBase64(bytes: Uint8Array): string {
 
 async function responseJson(response: Response): Promise<unknown> {
   try {
-    return await response.json();
+    return await readJsonResponse(response);
   } catch {
     throw new GitHubSyncError(
       "GitHub returned a malformed API response.",
       "github_api",
     );
   }
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new GitHubSyncError(
+      "GitHub returned a malformed API response.",
+      "github_api",
+    );
+  }
+}
+
+async function gitBlobSha(bytes: Uint8Array, identityLength: number): Promise<string> {
+  if (!globalThis.crypto?.subtle) {
+    throw new GitHubSyncError(
+      "This browser cannot verify downloaded synchronization content.",
+      "local_state",
+    );
+  }
+  const header = new TextEncoder().encode(`blob ${bytes.byteLength}\0`);
+  const object = new Uint8Array(header.byteLength + bytes.byteLength);
+  object.set(header);
+  object.set(bytes, header.byteLength);
+  let digest: ArrayBuffer;
+  try {
+    digest = await globalThis.crypto.subtle.digest(
+      identityLength === 40 ? "SHA-1" : "SHA-256",
+      object,
+    );
+  } catch {
+    throw new GitHubSyncError(
+      "This browser could not verify downloaded synchronization content.",
+      "local_state",
+    );
+  }
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function delay(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => globalThis.setTimeout(resolve, milliseconds));
 }
 
 function apiError(response: Response): GitHubSyncError {

--- a/web/src/data/sync.ts
+++ b/web/src/data/sync.ts
@@ -155,6 +155,11 @@ class BrowserSyncService {
         async () => {
           const client = new GitHubClient(this.requireToken());
           const repositoryInfo = await client.inspectRepository(owner, repository);
+          this.patch({
+            status: repositoryInfo.empty
+              ? "Preparing the private repository…"
+              : "Repository found — reading its library identity…",
+          });
           const branch = input.branch?.trim() || repositoryInfo.defaultBranch;
           if (repositoryInfo.empty && branch !== repositoryInfo.defaultBranch) {
             throw new GitHubSyncError(
@@ -169,7 +174,10 @@ class BrowserSyncService {
             repository,
             branch,
           );
-          this.patch({ configuration });
+          this.patch({
+            configuration,
+            status: "Repository connected — restoring your library…",
+          });
           await this.runConfigured(client, remote);
         },
         true,
@@ -361,15 +369,22 @@ class BrowserSyncService {
 
   private async runConfigured(client: GitHubClient, remote: GitHubRemote): Promise<void> {
     await client.inspectRepository(remote.owner, remote.repository);
+    this.patch({ status: "Checking remote changes…" });
     let pull = await this.pullRemote(client, remote);
     let uploaded = 0;
     const pendingAtFlushStart = await libraryRepository.pendingSyncBatches();
     const uploads = await buildPendingUploads(pendingAtFlushStart);
+    if (pendingAtFlushStart.length > 0) {
+      this.patch({
+        status: `Uploading ${pendingAtFlushStart.length} queued change${pendingAtFlushStart.length === 1 ? "" : "s"}…`,
+      });
+    }
     for (const pending of uploads) {
       const upload = await this.ensureUploaded(client, remote, pending);
       uploaded += upload.created ? pending.members.length : 0;
       pull = addPullStats(pull, upload.pull);
     }
+    this.patch({ status: "Confirming the synchronized library…" });
     pull = addPullStats(pull, await this.pullRemote(client, remote));
     const pending = (await libraryRepository.pendingSyncBatches()).length;
     const result: SyncCycleResult = {
@@ -396,19 +411,27 @@ class BrowserSyncService {
     const operations = [...tree.blobs.entries()]
       .filter(([path]) => path.startsWith(OPS_PREFIX))
       .sort(([left], [right]) => left.localeCompare(right));
+    const unseen: Array<[string, string]> = [];
+    for (const [path, blobSha] of operations) {
+      const observation = await libraryRepository.remoteObservation(path);
+      if (!observation) {
+        unseen.push([path, blobSha]);
+      } else if (observation.blobSha !== blobSha) {
+        throw new GitHubSyncError(
+          "An immutable remote update changed after it was observed.",
+          "integrity",
+        );
+      }
+    }
     const inputs: RemoteEnvelopeInput[] = [];
     const packs: RemoteOperationPackInput[] = [];
     let downloaded = 0;
-    for (const [path, blobSha] of operations) {
-      const observation = await libraryRepository.remoteObservation(path);
-      if (observation) {
-        if (observation.blobSha !== blobSha) {
-          throw new GitHubSyncError(
-            "An immutable remote update changed after it was observed.",
-            "integrity",
-          );
-        }
-        continue;
+    const progressStep = Math.max(1, Math.ceil(unseen.length / 20));
+    for (const [index, [path, blobSha]] of unseen.entries()) {
+      if (index === 0 || index + 1 === unseen.length || index % progressStep === 0) {
+        this.patch({
+          status: `Downloading remote change ${index + 1} of ${unseen.length}…`,
+        });
       }
       const json = await client.downloadText(remote, blobSha);
       if (path.startsWith(PACKS_PREFIX)) {
@@ -419,6 +442,9 @@ class BrowserSyncService {
         inputs.push({ path, blobSha, envelopeJson: json });
         downloaded += 1;
       }
+    }
+    if (unseen.length > 0) {
+      this.patch({ status: "Applying downloaded remote changes…" });
     }
     const pendingBefore = (await libraryRepository.pendingSyncBatches()).length;
     const applied = await this.applyRemoteUpdates(inputs, packs);

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -8,7 +8,6 @@ html {
   background: var(--color-canvas);
   color: var(--color-text);
   min-width: 20rem;
-  overscroll-behavior-y: none;
   text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
 }


### PR DESCRIPTION
## Summary

- stream GitHub synchronization blobs as raw bytes instead of Base64 JSON and verify each response against its Git object ID
- retry one interrupted GET body read and show staged restore/download progress
- restore native mobile pull-to-refresh while preserving the sticky workspace header

## Verification

- `cd web && npm test`
- `cd web && npm run build`
- fetched and verified the real 4,354,380-byte migrated operation from the private V1/V2 data repository with the updated adapter
- mobile-emulated production preview: root overscroll `auto`, document scroll root `HTML`, workspace chrome `sticky` at `0px`, no console warnings/errors

Closes #72
