### PR TITLE
Keep app navigation within library

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -429,17 +429,20 @@ export function App() {
 
       <div className="workspace-chrome">
         <header className="masthead">
-          <a
-            aria-label="ResearchPocket product overview"
+          <button
+            aria-label={view === "library" ? "ResearchPocket library" : "Back to library"}
             className="brand-lockup"
-            href="../"
+            onClick={() => setView("library")}
+            type="button"
           >
             <span aria-hidden="true" className="brand-mark">
               rp
             </span>
             <p className="brand-name">ResearchPocket</p>
-            <p className="brand-context">owner workspace</p>
-          </a>
+            <p className="brand-context">
+              {view === "library" ? "owner workspace" : "← library"}
+            </p>
+          </button>
 
           <div className="masthead-actions">
             <div className="local-status" role="status">

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -327,8 +327,12 @@
 }
 
 .brand-lockup {
+  background: transparent;
+  border: 0;
   color: var(--color-text);
   gap: var(--space-3);
+  min-height: 0;
+  padding: 0;
   text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary
- make the owner-app wordmark return to the Library view
- show explicit back-to-library context from Sync and Settings
- prevent app navigation from unexpectedly returning to the public welcome page

## Verification
- `npm run typecheck`
- `npm run check:design`
- `npm test`
- `git diff --check`

## Protocol and privacy impact
None. This is an in-app navigation-only change.