### PR TITLE
Archive Firecrawl Markdown in saved items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,9 @@ Do not expand V2 into:
 - an AI memory, personal profile, RAG service, or autonomous organizer;
 - a multi-user collaboration or real-time team product;
 - a general notes/wiki application or a store for standalone notes;
-- a webpage archive, file/PDF store, highlighting system, or attachment manager;
+- a general-purpose webpage archive, file/PDF store, highlighting system, or
+  attachment manager beyond the bounded Firecrawl Markdown retained in an
+  item's existing excerpt register;
 - a hosted account service or an application backend that must stay online;
 - a native mobile application;
 - end-to-end encrypted remote storage or encrypted sharing; or

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ custom-scheme decision and alternatives are recorded in
 
 Saving stays URL-first: ResearchPocket commits the item before contacting a
 page or extraction service. A failed request therefore leaves the save intact
-and a bounded local retry job. Fetched metadata fills only title, excerpt, and
+and a bounded local retry job. Fetched data fills only title, excerpt, and
 language fields whose exact missing-field revisions are still current; authored
 values, including a clear, an explicit empty string, or a concurrent edit from
 another client, always win. Short-lived local leases prevent concurrent CLI
@@ -180,7 +180,7 @@ research enrich run
 research enrich status
 ```
 
-Firecrawl is an explicit alternative for pages whose useful metadata needs a
+Firecrawl is an explicit alternative for pages whose useful content needs a
 hosted extractor. The URL is sent to Firecrawl. ResearchPocket calls the small
 REST scrape endpoint with its existing HTTP client; it does not depend on the
 Firecrawl Cargo package. Pass the key through standard input so it never appears
@@ -198,10 +198,14 @@ The optional key file is separate from SQLite, CRDT updates, and the sync
 repository. It is created with owner-only mode on Unix; on Windows it inherits
 the selected data directory's access controls, so keep a custom data directory
 restricted to the owner. `FIRECRAWL_API_KEY` may instead be supplied to the
-current process. Only normalized title, excerpt, and language are retained;
-HTML, Markdown, PDFs, and page files are not archived. The complete contract is
-in [the CLI guide](docs/v2/CLI.md#metadata-enrichment) and
-[ADR 0002](docs/v2/ADR_0002_LINK_ENRICHMENT.md).
+current process. Firecrawl's cleaned Markdown is retained in a missing excerpt
+up to 4 MiB; title and language remain normalized metadata. Raw HTML, PDFs, and
+page files are not archived. The owner Reader renders CommonMark and GitHub
+Flavored Markdown while ignoring raw HTML and remote images. The complete
+contract is in
+[the CLI guide](docs/v2/CLI.md#metadata-enrichment),
+[ADR 0002](docs/v2/ADR_0002_LINK_ENRICHMENT.md), and
+[ADR 0004](docs/v2/ADR_0004_BOUNDED_FIRECRAWL_MARKDOWN.md).
 
 ## Migrate an existing library
 

--- a/crates/research-store/src/enrichment.rs
+++ b/crates/research-store/src/enrichment.rs
@@ -23,12 +23,37 @@ impl V2Store {
         item_id: &str,
         provider: EnrichmentProvider,
     ) -> StoreResult<EnrichmentJob> {
+        self.queue_item_enrichment_with_options(item_id, provider, false)
+            .await
+    }
+
+    pub async fn queue_item_enrichment_replacing_excerpt(
+        &self,
+        item_id: &str,
+        provider: EnrichmentProvider,
+    ) -> StoreResult<EnrichmentJob> {
+        self.queue_item_enrichment_with_options(item_id, provider, true)
+            .await
+    }
+
+    async fn queue_item_enrichment_with_options(
+        &self,
+        item_id: &str,
+        provider: EnrichmentProvider,
+        replace_excerpt: bool,
+    ) -> StoreResult<EnrichmentJob> {
         let mut connection = self.pool.acquire().await?;
         sqlx::query("BEGIN IMMEDIATE")
             .execute(&mut *connection)
             .await?;
         let result = async {
-            queue_enrichment_on_connection(&mut connection, item_id, provider).await?;
+            queue_enrichment_on_connection_with_options(
+                &mut connection,
+                item_id,
+                provider,
+                replace_excerpt,
+            )
+            .await?;
             required_enrichment_job(&mut connection, item_id).await
         }
         .await;
@@ -166,12 +191,23 @@ pub(crate) async fn queue_enrichment_on_connection(
     item_id: &str,
     provider: EnrichmentProvider,
 ) -> StoreResult<()> {
+    queue_enrichment_on_connection_with_options(connection, item_id, provider, false).await
+}
+
+async fn queue_enrichment_on_connection_with_options(
+    connection: &mut SqliteConnection,
+    item_id: &str,
+    provider: EnrichmentProvider,
+    replace_excerpt: bool,
+) -> StoreResult<()> {
     let item = canonical_item_from_connection(connection, item_id).await?;
     let targets = EnrichmentTargets {
         title_revision: (item.title.value.is_none() && item.title.revisions.len() == 1)
             .then(|| item.title.winner.clone()),
-        excerpt_revision: (item.excerpt.value.is_none() && item.excerpt.revisions.len() == 1)
-            .then(|| item.excerpt.winner.clone()),
+        excerpt_revision: (replace_excerpt
+            || (item.excerpt.value.is_none() && item.excerpt.revisions.len() == 1)
+            || enrichment_owned_revision(&item.excerpt.winner))
+        .then(|| item.excerpt.winner.clone()),
         language_revision: (item.language.value.is_none()
             && item.language.revisions.len() == 1)
             .then(|| item.language.winner.clone()),
@@ -246,9 +282,8 @@ async fn apply_enrichment_on_connection(
                 == Some(current_item.title.winner.as_str())
     });
     let excerpt = candidate(candidates.excerpt).filter(|_| {
-        current_item.excerpt.value.is_none()
-            && current_job.expected_excerpt_revision.as_deref()
-                == Some(current_item.excerpt.winner.as_str())
+        current_job.expected_excerpt_revision.as_deref()
+            == Some(current_item.excerpt.winner.as_str())
     });
     let language = candidate(candidates.language).filter(|_| {
         current_item.language.value.is_none()
@@ -283,10 +318,7 @@ async fn apply_enrichment_on_connection(
                 )?;
             }
             if let Some(excerpt) = &excerpt {
-                if item.excerpt.value.is_some()
-                    || expected_excerpt_revision.as_deref()
-                        != Some(item.excerpt.winner.as_str())
-                {
+                if expected_excerpt_revision.as_deref() != Some(item.excerpt.winner.as_str()) {
                     return Err(StoreError::StaleEdit);
                 }
                 library.write_excerpt(
@@ -581,6 +613,11 @@ fn enrichment_revision_id(operation_prefix: &str, field: &str) -> String {
     // `!` sorts before every app-generated UUID revision ID. Existing V2 clients therefore
     // deterministically prefer a concurrent human revision without changing the CRDT schema.
     format!("{ENRICHMENT_REVISION_PREFIX}/{operation_prefix}/{field}")
+}
+
+fn enrichment_owned_revision(revision_id: &str) -> bool {
+    revision_id.starts_with(ENRICHMENT_REVISION_PREFIX)
+        && revision_id.as_bytes().get(ENRICHMENT_REVISION_PREFIX.len()) == Some(&b'/')
 }
 
 fn lifecycle_state_name(state: LifecycleState) -> &'static str {

--- a/crates/research-store/tests/local_mutation_contract.rs
+++ b/crates/research-store/tests/local_mutation_contract.rs
@@ -5,6 +5,150 @@ use research_store::{
 };
 
 #[tokio::test]
+async fn explicit_reenrichment_replaces_only_an_enrichment_owned_excerpt() {
+    let directory = tempfile::tempdir().expect("library temp directory");
+    let store = V2Store::init(directory.path().join("library"))
+        .await
+        .expect("initialize store");
+    let item = store
+        .create_item_with_enrichment(
+            CreateItemRequest {
+                url: "https://example.com/archive".into(),
+                title: Some("Archive".into()),
+                excerpt: None,
+                favorite: false,
+                language: Some("en".into()),
+                saved_at: Some(1_700_000_000),
+                note: String::new(),
+                tags: Vec::new(),
+            },
+            EnrichmentProvider::Firecrawl,
+        )
+        .await
+        .expect("create queued item");
+    let first_claim = store
+        .claim_item_enrichment(&item.id)
+        .await
+        .expect("claim initial enrichment");
+    let first = store
+        .apply_item_enrichment(
+            &item.id,
+            &first_claim.lease_token,
+            &item.url,
+            &item.state,
+            EnrichmentCandidates {
+                excerpt: Some("Short metadata description".into()),
+                ..EnrichmentCandidates::default()
+            },
+        )
+        .await
+        .expect("apply initial enrichment");
+    assert!(first.applied_excerpt);
+
+    let requeued = store
+        .queue_item_enrichment(&item.id, EnrichmentProvider::Firecrawl)
+        .await
+        .expect("requeue enrichment-owned excerpt");
+    assert!(requeued.target_excerpt);
+    let second_claim = store
+        .claim_item_enrichment(&item.id)
+        .await
+        .expect("claim replacement enrichment");
+    let replaced = store
+        .apply_item_enrichment(
+            &item.id,
+            &second_claim.lease_token,
+            &item.url,
+            &item.state,
+            EnrichmentCandidates {
+                excerpt: Some("# Complete page\n\nPreserved Markdown".into()),
+                ..EnrichmentCandidates::default()
+            },
+        )
+        .await
+        .expect("replace enrichment-owned excerpt");
+    assert_eq!(
+        replaced.item.excerpt.as_deref(),
+        Some("# Complete page\n\nPreserved Markdown")
+    );
+
+    store
+        .edit_item(EditItemRequest {
+            item_id: item.id.clone(),
+            excerpt: Some(OptionalTextUpdate::Set("Authored context".into())),
+            ..EditItemRequest::default()
+        })
+        .await
+        .expect("author excerpt");
+    let protected = store
+        .queue_item_enrichment(&item.id, EnrichmentProvider::Firecrawl)
+        .await
+        .expect("requeue after authored edit");
+    assert!(!protected.target_excerpt);
+    assert_eq!(protected.status, EnrichmentStatus::Skipped);
+
+    let forced = store
+        .queue_item_enrichment_replacing_excerpt(&item.id, EnrichmentProvider::Firecrawl)
+        .await
+        .expect("explicitly queue authored excerpt replacement");
+    assert!(forced.target_excerpt);
+    let stale_claim = store
+        .claim_item_enrichment(&item.id)
+        .await
+        .expect("claim forced replacement");
+    store
+        .edit_item(EditItemRequest {
+            item_id: item.id.clone(),
+            excerpt: Some(OptionalTextUpdate::Set("Newer authored context".into())),
+            ..EditItemRequest::default()
+        })
+        .await
+        .expect("edit while re-parsing");
+    let stale = store
+        .apply_item_enrichment(
+            &item.id,
+            &stale_claim.lease_token,
+            &item.url,
+            &item.state,
+            EnrichmentCandidates {
+                excerpt: Some("Stale parsed page".into()),
+                ..EnrichmentCandidates::default()
+            },
+        )
+        .await
+        .expect("complete stale replacement safely");
+    assert!(!stale.applied_excerpt);
+    assert_eq!(
+        stale.item.excerpt.as_deref(),
+        Some("Newer authored context")
+    );
+
+    store
+        .queue_item_enrichment_replacing_excerpt(&item.id, EnrichmentProvider::Firecrawl)
+        .await
+        .expect("queue replacement of current revision");
+    let replacement_claim = store
+        .claim_item_enrichment(&item.id)
+        .await
+        .expect("claim current replacement");
+    let replacement = store
+        .apply_item_enrichment(
+            &item.id,
+            &replacement_claim.lease_token,
+            &item.url,
+            &item.state,
+            EnrichmentCandidates {
+                excerpt: Some("# Fresh parse".into()),
+                ..EnrichmentCandidates::default()
+            },
+        )
+        .await
+        .expect("replace unchanged authored excerpt explicitly");
+    assert!(replacement.applied_excerpt);
+    assert_eq!(replacement.item.excerpt.as_deref(), Some("# Fresh parse"));
+}
+
+#[tokio::test]
 async fn local_mutations_are_atomic_durable_and_lifecycle_safe() {
     let directory = tempfile::tempdir().expect("library temp directory");
     let library_directory = directory.path().join("library");

--- a/docs/v2/ADR_0002_LINK_ENRICHMENT.md
+++ b/docs/v2/ADR_0002_LINK_ENRICHMENT.md
@@ -3,6 +3,7 @@
 - Status: accepted
 - Date: 2026-07-18
 - Issue: [#65](https://github.com/ResearchPocket/researchpocket.github.io/issues/65)
+- Amended by: [ADR 0004](./ADR_0004_BOUNDED_FIRECRAWL_MARKDOWN.md)
 
 ## Context
 
@@ -14,9 +15,10 @@ allowed to lose the URL the owner chose to keep.
 The existing V2 domain already converges nullable title, excerpt, and language
 scalars. A browser has useful page metadata in its loaded DOM, while a native
 client can sometimes retrieve better metadata from the public page or from an
-explicitly selected extraction service. Full page bodies and files have very
-different size, retention, and synchronization requirements and remain outside
-this decision.
+explicitly selected extraction service. Full page bodies and files originally
+remained outside this decision. ADR 0004 subsequently permits bounded cleaned
+Firecrawl Markdown in the existing excerpt register; binary files and a general
+object archive remain deferred.
 
 ## Decision
 
@@ -76,8 +78,9 @@ calls the small Firecrawl `/v2/scrape` REST surface through its existing HTTP
 client; it does not add the Firecrawl Cargo SDK. The owner must deliberately
 configure Firecrawl and is told that the saved URL is sent to that third party.
 The request disables Firecrawl cache storage, requires target TLS validation,
-uses the predictable basic proxy tier, and bounds the response. Only metadata is
-retained, and the API-required returned Markdown is discarded.
+uses the predictable basic proxy tier, and bounds the response. ADR 0004
+supersedes the original discard behavior: bounded cleaned Markdown is retained
+as the missing excerpt while metadata continues to supply title and language.
 
 The Firecrawl key may come from the current process environment or a separate
 per-library credential file written from standard input. The file is created
@@ -109,13 +112,13 @@ Rejected. ResearchPocket needs one authenticated endpoint and already has an
 HTTP client. The SDK would add a second abstraction and more features than this
 human-directed metadata flow uses.
 
-### Store page Markdown, HTML, PDFs, or attachments with the item
+### Store page HTML, PDFs, or attachments with the item
 
-Deferred. Binary and full-page retention needs a separately negotiated,
+Deferred. Binary and raw-page retention needs a separately negotiated,
 content-addressed object protocol with hashes, quotas, immutable remote paths,
 orphan and garbage-collection rules, lazy restoration, integrity checks, and
-publication exclusions. Large bytes must not be embedded in Loro updates or the
-SQLite projection.
+publication exclusions. Binary objects and raw page bodies must not be embedded
+in Loro updates or the SQLite projection.
 
 ## Consequences
 

--- a/docs/v2/ADR_0004_BOUNDED_FIRECRAWL_MARKDOWN.md
+++ b/docs/v2/ADR_0004_BOUNDED_FIRECRAWL_MARKDOWN.md
@@ -1,0 +1,80 @@
+# ADR 0004: Retain bounded Firecrawl Markdown in the excerpt register
+
+- Status: accepted
+- Date: 2026-07-20
+- Issue: [#79](https://github.com/ResearchPocket/researchpocket.github.io/issues/79)
+- Amends: [ADR 0002](./ADR_0002_LINK_ENRICHMENT.md)
+
+## Context
+
+Firecrawl already returns cleaned Markdown from the explicitly selected
+`/v2/scrape` request, but ADR 0002 originally discarded it after reading title,
+description, and language metadata. The owner requires useful page content to
+remain available offline and accepts that this private content will converge and
+remain in immutable synchronization history.
+
+The existing nullable excerpt scalar already has native and WASM convergence,
+missing-revision preconditions, search projection, export behavior, and owner UI
+support. Introducing a second content field or a new object protocol would add a
+compatibility boundary before the product needs binary or independently streamed
+objects.
+
+## Decision
+
+An explicitly selected Firecrawl enrichment requests the complete page rather
+than main-content-only extraction and stores the returned cleaned Markdown in
+the existing excerpt register when that field is still missing at apply time.
+Direct enrichment remains metadata-only. Authored excerpts, explicit clears,
+concurrent edits, lifecycle changes, and URL changes continue to win under the
+ADR 0002 preconditions.
+
+An explicit re-enrichment may replace the currently visible excerpt only when
+its winning revision is owned by the low-priority enrichment namespace. This
+lets items enriched before this ADR upgrade their former metadata description
+to page Markdown without treating authored content as replaceable.
+
+The CLI additionally exposes an explicit `--replace-excerpt` re-parse action.
+It may target any current excerpt, but records that exact winning revision before
+network access and applies the replacement only if the revision is unchanged.
+This is a deliberate visible-field replacement, not background enrichment.
+
+Markdown whitespace is preserved after CRLF normalization and removal of control
+characters other than newline and tab. Retained Markdown is limited to 4 MiB of
+UTF-8, and the complete Firecrawl JSON response is limited to 8 MiB. Content over
+either limit produces the existing sanitized `response_too_large` failure; the
+URL remains saved and the local job remains retryable. Oversized content is never
+silently truncated.
+
+The 4 MiB content limit keeps one Base64 envelope and its nested operation-pack
+representation below the existing 20 MiB pack ceiling. Pack construction still
+splits queued envelopes according to the existing exact-byte budget. Markdown is
+not copied into enrichment job state: after a successful request it enters the
+library only through the normal atomic excerpt mutation and outbox update.
+
+The owner Reader renders retained Markdown through `react-markdown` with GFM
+extensions. Raw HTML remains disabled, scripts cannot execute, and Markdown
+images become inert text placeholders rather than third-party network requests.
+Publication remains allowlisted and must treat enriched excerpts exactly like
+any other private excerpt; no excerpt becomes public without explicit collection
+and field policy.
+
+## Consequences
+
+- A private library, checkpoint, restore, export, and sync history may be much
+  larger than a URL-and-metadata-only library.
+- Re-enrichment can replace a prior enrichment-owned excerpt, but it cannot
+  overwrite an authored excerpt or explicit clear unless the owner invokes the
+  explicit replacement action.
+- Git history retains the Markdown after item deletion; secure erasure still
+  requires the documented history rewrite or a new data repository.
+- Search can match preserved page text through the existing excerpt projection.
+- Raw HTML, PDFs, screenshots, attachments, scheduled refreshes, and a general
+  archival object store remain deferred.
+
+## Verification
+
+- Parse a representative Firecrawl response and preserve Markdown newlines,
+  indentation, and formatting markers exactly after newline normalization.
+- Reject Markdown over the 4 MiB bound without producing a candidate.
+- Preserve ADR 0002's authored-field and concurrent-revision tests.
+- Run native/WASM convergence, sync, web, and production artifact checks.

--- a/docs/v2/CLI.md
+++ b/docs/v2/CLI.md
@@ -127,10 +127,30 @@ parses only public HTML metadata.
 
 Firecrawl is never an automatic fallback. Selecting it means the saved target
 URL is sent to the configured Firecrawl service. ResearchPocket uses the narrow
-`/v2/scrape` REST endpoint through its existing HTTP client and retains only
-normalized metadata; it adds no Firecrawl Cargo dependency. The request disables
-Firecrawl cache storage, requires target TLS validation, uses the basic proxy
-tier, and discards returned Markdown or page content.
+`/v2/scrape` REST endpoint through its existing HTTP client. It retains cleaned
+Markdown in a missing excerpt, plus normalized title and language metadata, and
+adds no Firecrawl Cargo dependency. Markdown is preserved up to 4 MiB inside the
+existing convergent excerpt register; the complete JSON response is limited to
+8 MiB. Larger results fail explicitly and remain retryable without affecting the
+already-saved URL. The request includes the complete page instead of restricting
+extraction to main content, disables Firecrawl cache storage, requires target TLS
+validation, and uses the basic proxy tier.
+
+Passing an item ID and `--provider firecrawl` can upgrade an excerpt created by
+an earlier enrichment run. The replacement is allowed only while the current
+winning excerpt revision is enrichment-owned; authored excerpts and explicit
+clears remain ineligible.
+
+To deliberately re-parse a saved URL and replace any current excerpt, including
+authored content, use the explicit replacement flag:
+
+```sh
+research enrich run <item-id> --provider firecrawl --replace-excerpt
+```
+
+The job records the exact current excerpt revision before network access. If the
+excerpt changes while Firecrawl is running, the fetched Markdown is skipped and
+the newer local or synchronized value wins.
 
 Store the key in a separate per-library file without placing it in process
 arguments or shell history:
@@ -172,10 +192,12 @@ Jobs are local operational state. A short-lived transactional lease ensures two
 local CLI processes cannot contact the provider for the same job concurrently;
 an abandoned lease becomes retryable after it expires. Provider failures use
 bounded retries and a sanitized category; page bodies and credentials are never
-stored in a job. A successful result is one V2 edit/outbox update only when at
-least one eligible field is applied. Full webpage, Markdown, PDF, and attachment
-storage is outside this feature; see
-[ADR 0002](./ADR_0002_LINK_ENRICHMENT.md).
+stored in a job. Successful bounded Firecrawl Markdown is stored only through
+the normal excerpt mutation, not duplicated in the job. A successful result is
+one V2 edit/outbox update only when at least one eligible field is applied. Raw
+HTML, PDF, and attachment storage remains outside this feature; see
+[ADR 0002](./ADR_0002_LINK_ENRICHMENT.md) and
+[ADR 0004](./ADR_0004_BOUNDED_FIRECRAWL_MARKDOWN.md).
 
 ## Firefox bookmarklet capture
 

--- a/docs/v2/PRODUCT.md
+++ b/docs/v2/PRODUCT.md
@@ -66,11 +66,13 @@ feeds; they do not need a ResearchPocket or GitHub account.
 
 - Save a URL immediately while offline; metadata enrichment may be retried and
   must never block or discard the save.
-- Fill only missing title, excerpt, and language metadata through an explicit
-  local direct fetch or user-configured Firecrawl service. Human-authored values
-  remain canonical across in-flight and concurrent edits, local job leases avoid
-  duplicate provider calls, and using Firecrawl is a visible third-party
-  disclosure.
+- Fill only missing title, excerpt, and language fields through an explicit
+  local direct fetch or user-configured Firecrawl service. Firecrawl enrichment
+  retains its bounded cleaned Markdown in the existing excerpt register for
+  offline reading; direct enrichment remains metadata-only. Human-authored
+  values remain canonical across in-flight and concurrent edits, local job
+  leases avoid duplicate provider calls, and using Firecrawl is a visible
+  third-party disclosure.
 - Capture bounded title, description, and language metadata from the current
   browser DOM plus optional non-sensitive prompted tags through the installed
   local protocol handler without requiring a browser extension or always-on

--- a/docs/v2/THREAT_MODEL.md
+++ b/docs/v2/THREAT_MODEL.md
@@ -46,7 +46,7 @@ from existing Git history are outside the V2 guarantee.
 | TM-10 | Deletion creates a tombstone. Historical erasure requires repository replacement or an explicit history rewrite. |
 | TM-11 | Native bookmarklet capture uses a per-user `researchpocket://capture` handler with a versioned, append-only field allowlist. The URI never selects a filesystem path, carries a credential, executes a command, or starts synchronization. |
 | TM-12 | The owner application has exclusive use of the `https://researchpocket.github.io` origin. The former `/ResearchPocket/` paths may contain only compatibility redirects built from the same protected source; no unrelated active Pages project may share the origin. |
-| TM-13 | Optional native enrichment starts only after the item and local retry job commit. Direct fetches are public-network-only and SSRF bounded; Firecrawl is explicit, provider-neutral capture URIs carry no key, and only normalized missing metadata is retained. |
+| TM-13 | Optional native enrichment starts only after the item and local retry job commit. Direct fetches are public-network-only and SSRF bounded; Firecrawl is explicit, provider-neutral capture URIs carry no key, and bounded cleaned Markdown may fill only a still-missing excerpt. |
 
 ## Trust boundaries
 
@@ -64,7 +64,7 @@ from existing Git history are outside the V2 guarantee.
 | Firefox bookmarklet | User-triggered but runs in the current page's untrusted browser context. The standard bookmarklet may send only the current page URL, bounded title/description/language values, and optional non-sensitive tags entered into its visibly labeled prompt in a versioned capture URI. The page may observe prompted text. |
 | OS protocol dispatcher | Trusted only to deliver one URI to the installed per-user handler. Browser and operating-system history, diagnostics, or other same-user processes may observe that payload. |
 | Native direct enrichment | Untrusted public HTTP(S) target. It may receive a metadata-only request for its own saved URL, but no owner credential, cookie, referrer, note, tag, browser state, or other library data. |
-| Firecrawl enrichment | Explicitly selected third party. It receives the saved target URL and the Firecrawl API credential, but no ResearchPocket library, note, tag, GitHub credential, or capture URI. Returned page content is discarded. |
+| Firecrawl enrichment | Explicitly selected third party. It receives the saved target URL and the Firecrawl API credential, but no ResearchPocket library, note, tag, GitHub credential, or capture URI. Returned cleaned Markdown may be retained in the private excerpt register up to 4 MiB. |
 | Other third-party pages and networks | Untrusted. They receive no owner data, analytics events, referrers containing secrets, or runtime requests from hosted owner mode. |
 
 The implemented browser-store, static-shell, and private synchronization
@@ -277,10 +277,16 @@ The Firecrawl provider sends the saved URL only after explicit local selection.
 It uses an authorization header against the configured `/v2/scrape` API and
 bounds the response. The request disables Firecrawl cache storage, requires
 target TLS validation, and selects the basic proxy tier to avoid silent enhanced
-proxy escalation. ResearchPocket retains only normalized title, excerpt, and
-language candidates; it discards Markdown, HTML, screenshots, and response
-bodies. Provider error categories are sanitized before entering retry state or
-diagnostics.
+proxy escalation. ResearchPocket retains bounded cleaned Markdown in a missing
+excerpt plus normalized title and language candidates; it discards raw HTML,
+screenshots, and all unselected response fields. Provider error categories are
+sanitized before entering retry state or diagnostics.
+
+The owner Reader treats retained Markdown as untrusted input. It renders parsed
+Markdown through React without raw HTML support, converts image syntax to inert
+text instead of issuing third-party requests, and opens explicit links in a new
+non-referring browsing context. The owner application's content security policy
+continues to deny arbitrary scripts, frames, objects, and remote images.
 
 Custom protocol schemes do not authenticate their caller. Firefox normally asks
 before handing an external link to an application, but a permission remembered

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,10 +40,10 @@ pub enum Commands {
     /// Initialize a V2 library in the platform data directory
     Init,
 
-    /// Save a URL locally, with optional post-save metadata enrichment
+    /// Save a URL locally, with optional post-save link enrichment
     Add(AddArgs),
 
-    /// Configure and run optional link metadata enrichment
+    /// Configure and run optional link enrichment
     Enrich {
         #[command(subcommand)]
         command: EnrichCommands,
@@ -122,7 +122,7 @@ pub struct AddArgs {
     #[arg(long, value_name = "UNIX_SECONDS")]
     pub saved_at: Option<i64>,
 
-    /// Save first, then fill missing page metadata with this provider
+    /// Save first, then fill missing page data with this provider
     #[arg(long, value_enum, value_name = "PROVIDER")]
     pub enrich: Option<EnrichmentProviderArg>,
 }
@@ -144,7 +144,7 @@ pub enum EnrichCommands {
 
 #[derive(Args)]
 pub struct EnrichConfigureArgs {
-    /// Metadata provider used by queued and automatic enrichment
+    /// Provider used by queued and automatic enrichment
     #[arg(value_enum)]
     pub provider: EnrichmentProviderArg,
 
@@ -169,6 +169,10 @@ pub struct EnrichRunArgs {
     /// Provider for a newly queued item; defaults to local configuration
     #[arg(long, value_enum, value_name = "PROVIDER")]
     pub provider: Option<EnrichmentProviderArg>,
+
+    /// Explicitly replace the current excerpt after re-parsing the saved URL
+    #[arg(long, requires = "item_id")]
+    pub replace_excerpt: bool,
 
     /// Maximum due jobs to process when no item ID is supplied
     #[arg(long, default_value_t = 25, value_parser = parse_enrichment_limit)]
@@ -357,7 +361,7 @@ pub enum OutputFormat {
 pub enum EnrichmentProviderArg {
     /// Fetch public HTML directly from this device
     Direct,
-    /// Send the URL to an explicitly configured Firecrawl API
+    /// Send the URL to Firecrawl and retain bounded Markdown in the excerpt
     Firecrawl,
 }
 

--- a/src/enrichment.rs
+++ b/src/enrichment.rs
@@ -23,7 +23,8 @@ const FIRECRAWL_DEFAULT_API: &str = "https://api.firecrawl.dev";
 const MAX_CONFIG_BYTES: u64 = 64 * 1024;
 const MAX_KEY_BYTES: u64 = 16 * 1024;
 const MAX_DIRECT_BODY_BYTES: usize = 2 * 1024 * 1024;
-const MAX_FIRECRAWL_BODY_BYTES: usize = 2 * 1024 * 1024;
+const MAX_FIRECRAWL_BODY_BYTES: usize = 8 * 1024 * 1024;
+const MAX_FIRECRAWL_MARKDOWN_BYTES: usize = 4 * 1024 * 1024;
 const MAX_REDIRECTS: usize = 5;
 const MAX_TITLE_BYTES: usize = 4 * 1024;
 const MAX_EXCERPT_BYTES: usize = 8 * 1024;
@@ -348,7 +349,7 @@ async fn firecrawl_extract(
         .json(&json!({
             "url": target.as_str(),
             "formats": ["markdown"],
-            "onlyMainContent": true,
+            "onlyMainContent": false,
             "skipTlsVerification": false,
             "timeout": 30_000,
             "proxy": "basic",
@@ -378,13 +379,17 @@ async fn firecrawl_extract(
     if !payload.success {
         return Err(EnrichmentError::InvalidResponse);
     }
-    let metadata = payload
-        .data
-        .and_then(|data| data.metadata)
-        .ok_or(EnrichmentError::InvalidResponse)?;
+    firecrawl_candidates(payload)
+}
+
+fn firecrawl_candidates(payload: FirecrawlResponse) -> EnrichmentResult<EnrichmentCandidates> {
+    let data = payload.data.ok_or(EnrichmentError::InvalidResponse)?;
+    let metadata = data.metadata.unwrap_or_default();
+    let excerpt = bounded_markdown_candidate(data.markdown, MAX_FIRECRAWL_MARKDOWN_BYTES)?
+        .or_else(|| normalized_candidate(metadata.description, MAX_EXCERPT_BYTES));
     Ok(EnrichmentCandidates {
         title: normalized_candidate(metadata.title, MAX_TITLE_BYTES),
-        excerpt: normalized_candidate(metadata.description, MAX_EXCERPT_BYTES),
+        excerpt,
         language: normalized_candidate(metadata.language, MAX_LANGUAGE_BYTES),
     })
 }
@@ -397,14 +402,43 @@ struct FirecrawlResponse {
 
 #[derive(Deserialize)]
 struct FirecrawlData {
+    markdown: Option<String>,
     metadata: Option<FirecrawlMetadata>,
 }
 
-#[derive(Deserialize)]
+#[derive(Default, Deserialize)]
 struct FirecrawlMetadata {
     title: Option<String>,
     description: Option<String>,
     language: Option<String>,
+}
+
+fn bounded_markdown_candidate(
+    value: Option<String>,
+    maximum: usize,
+) -> EnrichmentResult<Option<String>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let normalized_newlines = value.replace("\r\n", "\n").replace('\r', "\n");
+    let sanitized = normalized_newlines
+        .chars()
+        .map(|character| {
+            if character.is_control() && !matches!(character, '\n' | '\t') {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+    let markdown = sanitized.trim();
+    if markdown.is_empty() {
+        return Ok(None);
+    }
+    if markdown.len() > maximum {
+        return Err(EnrichmentError::ResponseTooLarge);
+    }
+    Ok(Some(markdown.to_owned()))
 }
 
 async fn read_bounded_body(
@@ -787,6 +821,37 @@ fn key_path(data_dir: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn firecrawl_markdown_is_preserved_and_bounded() {
+        let markdown =
+            "# CSS Stuff\r\n\r\nA catalog with **formatting**.\r\n\t- Grid\r\n\t- Color";
+        let candidates = firecrawl_candidates(FirecrawlResponse {
+            success: true,
+            data: Some(FirecrawlData {
+                markdown: Some(markdown.to_owned()),
+                metadata: Some(FirecrawlMetadata {
+                    title: Some(" CSS Stuff ".to_owned()),
+                    description: Some("Short fallback".to_owned()),
+                    language: Some(" en ".to_owned()),
+                }),
+            }),
+        })
+        .expect("valid Firecrawl response");
+
+        assert_eq!(
+            candidates.excerpt.as_deref(),
+            Some("# CSS Stuff\n\nA catalog with **formatting**.\n\t- Grid\n\t- Color")
+        );
+        assert_eq!(candidates.title.as_deref(), Some("CSS Stuff"));
+        assert_eq!(candidates.language.as_deref(), Some("en"));
+
+        let oversized = "x".repeat(MAX_FIRECRAWL_MARKDOWN_BYTES + 1);
+        assert!(matches!(
+            bounded_markdown_candidate(Some(oversized), MAX_FIRECRAWL_MARKDOWN_BYTES),
+            Err(EnrichmentError::ResponseTooLarge)
+        ));
+    }
 
     #[test]
     fn private_networks_are_rejected_and_credentials_stay_separate() {

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -265,6 +265,7 @@ async fn handle_enrich(
                     data_dir,
                     item_id,
                     run.provider.map(store_provider),
+                    run.replace_excerpt,
                 )
                 .await?
                 {
@@ -291,8 +292,34 @@ async fn explicit_enrichment_job(
     data_dir: &Path,
     item_id: &str,
     requested_provider: Option<EnrichmentProvider>,
+    replace_excerpt: bool,
 ) -> CliResult<Option<EnrichmentClaim>> {
-    match store.enrichment_job(item_id).await? {
+    let existing = store.enrichment_job(item_id).await?;
+    if replace_excerpt {
+        if existing
+            .as_ref()
+            .is_some_and(|job| job.status == StoreEnrichmentStatus::InProgress)
+        {
+            return Err(io::Error::other(
+                "this item is already being enriched; retry after its local lease expires",
+            )
+            .into());
+        }
+        let provider = match requested_provider.or(existing.as_ref().map(|job| job.provider)) {
+            Some(provider) => provider,
+            None => configured_provider(data_dir)?.ok_or_else(|| {
+                io::Error::other(
+                    "no enrichment provider is configured; pass --provider or run enrich configure",
+                )
+            })?,
+        };
+        let queued = store
+            .queue_item_enrichment_replacing_excerpt(item_id, provider)
+            .await?;
+        return claim_queued_enrichment(store, queued).await;
+    }
+
+    match existing {
         Some(job)
             if matches!(
                 job.status,

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "idb": "8.0.3",
         "react": "19.2.7",
-        "react-dom": "19.2.7"
+        "react-dom": "19.2.7",
+        "react-markdown": "10.1.0",
+        "remark-gfm": "4.0.1"
       },
       "devDependencies": {
         "@types/react": "19.2.17",
@@ -380,11 +382,58 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -399,6 +448,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
       "version": "7.0.2",
@@ -740,6 +795,12 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
@@ -766,12 +827,120 @@
         }
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -782,6 +951,47 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fake-indexeddb": {
       "version": "6.2.5",
@@ -826,11 +1036,123 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/idb": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
       "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
       "license": "ISC"
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1105,6 +1427,865 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
@@ -1123,6 +2304,31 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1173,6 +2379,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
@@ -1192,6 +2408,99 @@
       },
       "peerDependencies": {
         "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rolldown": {
@@ -1244,6 +2553,48 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -1259,6 +2610,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/tslib": {
@@ -1302,6 +2673,121 @@
         "@typescript/typescript-sunos-x64": "7.0.2",
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -1380,6 +2866,16 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,9 @@
   "dependencies": {
     "idb": "8.0.3",
     "react": "19.2.7",
-    "react-dom": "19.2.7"
+    "react-dom": "19.2.7",
+    "react-markdown": "10.1.0",
+    "remark-gfm": "4.0.1"
   },
   "devDependencies": {
     "@types/react": "19.2.17",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,12 +1,15 @@
 import {
   type SubmitEvent,
   type ReactNode,
+  memo,
   useDeferredValue,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
 import {
   type LibraryState,
   type PendingSyncChange,
@@ -42,6 +45,33 @@ type Density = "comfortable" | "compact";
 const DENSITY_STORAGE_KEY = "researchpocket.ui.density";
 
 const LIST_BATCH_SIZE = 100;
+
+const READER_MARKDOWN_COMPONENTS: Components = {
+  a: ({ children, href, title }) => (
+    <a href={href} rel="noreferrer" target="_blank" title={title}>
+      {children}
+    </a>
+  ),
+  img: ({ alt, title }) => (
+    <span className="reader-markdown-image" role="img" aria-label={alt || "Archived image"} title={title}>
+      [Image: {alt || "unlabeled"}]
+    </span>
+  ),
+};
+
+const MarkdownDocument = memo(function MarkdownDocument({ source }: { source: string }) {
+  return (
+    <div className="reader-markdown">
+      <ReactMarkdown
+        components={READER_MARKDOWN_COMPONENTS}
+        remarkPlugins={[remarkGfm]}
+        skipHtml
+      >
+        {source}
+      </ReactMarkdown>
+    </div>
+  );
+});
 
 const EMPTY_LIBRARY_STATE: LibraryState = {
   error: null,
@@ -1472,7 +1502,8 @@ function ReaderView({
   onSelect: (item: LibraryItemView) => void;
 }) {
   const label = item.title?.trim() || item.url;
-  const context = item.excerpt?.trim();
+  const context = item.excerpt;
+  const hasContext = Boolean(context?.trim());
 
   return (
     <div className="reader-view" role="dialog" aria-modal="true" aria-labelledby="reader-title">
@@ -1509,7 +1540,7 @@ function ReaderView({
           {item.tags.length > 0 ? <p className="reader-tags">{item.tags.map((tag) => <span key={tag}>#{tag}</span>)}</p> : null}
           {item.note?.trim() ? <aside className="reader-note"><strong>Your note</strong><p>{item.note}</p></aside> : null}
           <div className="reader-body">
-            {context ? <p>{context}</p> : <p>This save has no extracted preview yet. Open the original to read the full page, or add a private note to keep the context that matters.</p>}
+            {hasContext && context ? <MarkdownDocument source={context} /> : <p>This save has no extracted preview yet. Open the original to read the full page, or add a private note to keep the context that matters.</p>}
             <p className="reader-source">ResearchPocket keeps the URL and your authored context locally. The original page remains at <a href={item.url} rel="noreferrer" target="_blank">{readHostname(item.url)}</a>.</p>
           </div>
         </div>

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2513,6 +2513,132 @@ kbd {
   margin: 0;
 }
 
+.reader-markdown {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.reader-markdown > :first-child {
+  margin-top: 0;
+}
+
+.reader-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+.reader-markdown h1,
+.reader-markdown h2,
+.reader-markdown h3,
+.reader-markdown h4,
+.reader-markdown h5,
+.reader-markdown h6 {
+  color: var(--color-text);
+  line-height: 1.3;
+  margin: 1.75em 0 0.625em;
+}
+
+.reader-markdown h1 {
+  font-size: 1.5rem;
+}
+
+.reader-markdown h2 {
+  border-bottom: var(--rule) solid var(--color-border);
+  font-size: 1.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.reader-markdown h3 {
+  font-size: 1.0625rem;
+}
+
+.reader-markdown h4,
+.reader-markdown h5,
+.reader-markdown h6 {
+  font-size: 0.9375rem;
+}
+
+.reader-markdown p,
+.reader-markdown blockquote,
+.reader-markdown pre,
+.reader-markdown table,
+.reader-markdown ul,
+.reader-markdown ol {
+  margin: 0 0 1em;
+}
+
+.reader-markdown ul,
+.reader-markdown ol {
+  padding-left: 1.5rem;
+}
+
+.reader-markdown li + li {
+  margin-top: 0.25rem;
+}
+
+.reader-markdown blockquote {
+  border-left: 0.1875rem solid var(--color-border-strong);
+  color: var(--color-text-soft);
+  padding-left: 1rem;
+}
+
+.reader-markdown code {
+  background: var(--color-surface-muted);
+  border: var(--rule) solid var(--color-border);
+  border-radius: var(--radius);
+  font-family: inherit;
+  font-size: 0.875em;
+  padding: 0.1em 0.3em;
+}
+
+.reader-markdown pre {
+  background: var(--color-surface-muted);
+  border: var(--rule) solid var(--color-border);
+  border-radius: var(--radius);
+  overflow-x: auto;
+  padding: 0.875rem;
+  white-space: pre;
+}
+
+.reader-markdown pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+}
+
+.reader-markdown table {
+  border-collapse: collapse;
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  width: max-content;
+}
+
+.reader-markdown th,
+.reader-markdown td {
+  border: var(--rule) solid var(--color-border);
+  padding: 0.375rem 0.625rem;
+  text-align: left;
+}
+
+.reader-markdown th {
+  color: var(--color-text);
+}
+
+.reader-markdown hr {
+  border: 0;
+  border-top: var(--rule) solid var(--color-border);
+  margin: 1.5rem 0;
+}
+
+.reader-markdown a {
+  color: var(--color-accent-strong);
+}
+
+.reader-markdown-image {
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
 .reader-source {
   color: var(--color-text-muted);
 }


### PR DESCRIPTION
Closes #79

## User-visible impact
- retain complete Firecrawl Markdown in the existing excerpt field
- render archived Markdown safely in Reader mode with GFM support
- allow explicit, revision-safe re-parsing of existing items
- preserve authored values during ordinary enrichment and concurrent edits

## Protocol and security impact
- bound retained Markdown to 4 MiB and Firecrawl responses to 8 MiB
- keep raw HTML disabled and remote Markdown images inert
- record the decision in ADR 0004

## Verification
- cargo fmt --all -- --check
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- cargo test --locked --workspace --all-targets --all-features
- cargo audit --deny warnings
- cargo build --locked --release
- web: npm run verify
- live Firecrawl scrape smoke test against Spacial/csstuff