### PR TITLE
Restore mobile Reader scrolling

### DIFF
--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2995,6 +2995,14 @@ kbd {
     display: none;
   }
 
+  .reader-article {
+    height: 100%;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior-y: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
   .reader-mobile-header {
     align-items: center;
     border-bottom: var(--rule) solid var(--color-border);


### PR DESCRIPTION
Closes #81

## User-visible impact
- restore vertical scrolling for long saved-item Markdown on mobile
- keep the fixed Reader action bar and desktop split view unchanged

## Cause and fix
The mobile block layout allowed the Reader article to expand to full content height inside a fixed viewport. The article is now bounded to the available viewport and remains the vertical touch scroll container.

## Verification
- deployed reproduction before fix: 11,519px client height and scrollTop remained 0
- patched mobile emulation: 792px client height, 11,519px scroll height, scrollTop moved to 500
- desktop emulation: split columns intact and scrollTop moved to 600
- web: npm run verify