### PR TITLE
Add convergence-safe undo for browser changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ generic label when detailed local summaries are unavailable.
 The token stays in JavaScript memory unless the owner explicitly chooses
 tab-only `sessionStorage`, and it never enters IndexedDB, URLs, logs, or the
 service-worker cache.
+The latest browser item mutation offers a visible, convergence-safe Undo action
+and `Ctrl+Z` or `Cmd+Z`; delete also remains recoverable from the archive.
 
 The canonical Pages origin is `https://researchpocket.github.io/`. The former
 `/ResearchPocket/` project paths remain as same-origin compatibility redirects,

--- a/docs/v2/ADR_0005_COMPENSATING_UNDO.md
+++ b/docs/v2/ADR_0005_COMPENSATING_UNDO.md
@@ -1,0 +1,68 @@
+# ADR 0005: Undo browser mutations with compensating updates
+
+- Status: accepted
+- Date: 2026-07-21
+- Issue: [#83](https://github.com/ResearchPocket/researchpocket.github.io/issues/83)
+
+## Context
+
+The hosted owner applies every mutation immediately to its local Loro snapshot,
+IndexedDB projection, immutable batch store, and synchronization outbox.
+Removing an unsynchronized envelope would not undo the already-applied document
+state, and the same envelope may already exist remotely. Rewriting or deleting
+immutable operations would also violate the synchronization protocol.
+
+Owners nevertheless need an immediate recovery path after accidentally adding,
+editing, favoriting, tagging, deleting, or restoring a saved item.
+
+## Decision
+
+After each successful browser item mutation, the repository returns one bounded
+in-memory undo token containing the compensating mutation, the exact resulting
+item projection expected by that mutation, and any prior exact tag set needed to
+restore an edit. The UI exposes the latest token through a visible Undo notice
+and `Ctrl+Z` or `Cmd+Z`. A later successful item mutation replaces the token;
+dismissal or page reload removes it.
+
+Undo never removes or rewrites an operation, snapshot revision, batch, outbox
+entry, or remote object. It applies the compensation through the same shared
+WASM mutation boundary and atomically creates the next immutable envelope. If
+the original operation was already synchronized, normal synchronization carries
+the compensation afterward.
+
+Before applying the compensation, the repository compares the item's current
+allowlisted projection with the exact projection captured after the original
+action. Any later local or remote difference makes the token stale and the undo
+fails without mutation. This deliberately conservative precondition prevents an
+older undo from overwriting newer work.
+
+Compensations are:
+
+- create → delete;
+- delete → restore;
+- restore → delete; and
+- edit → restore only the prior changed scalar values, note text, favorite
+  state, and exact tag set.
+
+Undoing creation therefore leaves normal lifecycle history rather than
+physically erasing the item. Deleted saves remain independently recoverable from
+the archive even after the immediate undo token is gone.
+
+## Consequences
+
+- Undo converges across replicas because it is an ordinary later mutation.
+- Both the mistaken action and its compensation remain in immutable local and
+  remote history.
+- Only the latest browser action is offered; this is not an unlimited revision
+  history browser.
+- Reloading clears the in-memory edit undo token. Lifecycle deletion remains
+  recoverable through the archive.
+- A stale undo asks the owner to review the newer item instead of guessing which
+  fields to overwrite.
+
+## Verification
+
+- Build compensations for create, edit, delete, and restore.
+- Restore nullable text, note, favorite state, and exact tags after an edit.
+- Reject an undo token after any expected item field changes.
+- Verify the web persistence, WASM, design-system, and production build checks.

--- a/docs/v2/DESIGN_SYSTEM.md
+++ b/docs/v2/DESIGN_SYSTEM.md
@@ -166,6 +166,10 @@ Repository and sync status use a small indicator plus explicit text. Pending
 work always shows whether it is local, queued, or synchronized. Never imply that
 a local commit is remotely backed up.
 
+The latest undoable item mutation uses a fixed status notice with an explicit
+Undo button and dismiss action. It remains above mobile action bars, stays
+keyboard-operable through `Ctrl+Z` or `Cmd+Z`, and is not hidden by a timeout.
+
 ### Library records
 
 Records form one ordered list separated by rules. Source, title, authored

--- a/docs/v2/PRODUCT.md
+++ b/docs/v2/PRODUCT.md
@@ -79,6 +79,9 @@ feeds; they do not need a ResearchPocket or GitHub account.
   backend.
 - Edit titles, notes, tags, collection membership, favorite state, archive
   state, and lifecycle state through the CLI, TUI, or local web UI.
+- Undo the latest browser add, edit, favorite, tag, delete, or restore action as
+  a convergence-safe compensating mutation; deleted items remain recoverable
+  from the archive after the immediate undo affordance is dismissed.
 - Search locally across saved metadata and user-authored notes.
 - Keep concurrently saved copies of the same URL visible for review rather
   than silently deleting one person's intent.

--- a/docs/v2/WEB.md
+++ b/docs/v2/WEB.md
@@ -11,6 +11,15 @@ can initialize a browser library and add, search, edit,
 favorite, tag, delete, and restore saves without a network connection. The UI
 contains no sample library or alternate TypeScript merge rules.
 
+The most recent successful browser item mutation exposes a visible Undo action
+and `Ctrl+Z` or `Cmd+Z`. Undo is a new compensating mutation through the same
+WASM and IndexedDB transaction boundary; it never deletes an outbox row or
+rewrites immutable history. The token records the exact resulting item
+projection and fails stale if any later local or remote item change intervenes.
+Only the latest action is retained in memory. Delete remains recoverable through
+the archive after dismissal or reload. See
+[ADR 0005](./ADR_0005_COMPENSATING_UNDO.md).
+
 First run offers two explicit paths. Starting locally creates an empty browser
 library. Restoring prepares the same empty local shell and opens private sync
 before the owner makes a local mutation, allowing the pristine replica to adopt

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ import remarkGfm from "remark-gfm";
 import {
   type LibraryState,
   type PendingSyncChange,
+  type UndoableChange,
   libraryRepository,
 } from "./data/library.ts";
 import {
@@ -41,6 +42,11 @@ type SortMode = "recent" | "oldest" | "title";
 type TagMatchMode = "any" | "all";
 type WorkspaceView = "library" | "settings" | "sync";
 type Density = "comfortable" | "compact";
+
+interface UndoNotice {
+  change: UndoableChange;
+  message: string;
+}
 
 const DENSITY_STORAGE_KEY = "researchpocket.ui.density";
 
@@ -116,6 +122,7 @@ export function App() {
   const [autoBootstrapAttempted, setAutoBootstrapAttempted] = useState(false);
   const [announcement, setAnnouncement] = useState("");
   const [localError, setLocalError] = useState<string | null>(null);
+  const [undoNotice, setUndoNotice] = useState<UndoNotice | null>(null);
   const captureOpenerRef = useRef<HTMLButtonElement | null>(null);
   const editOpenerRef = useRef<HTMLButtonElement | null>(null);
 
@@ -169,6 +176,20 @@ export function App() {
         return;
       }
 
+      if (
+        !isTyping &&
+        (event.ctrlKey || event.metaKey) &&
+        !event.altKey &&
+        !event.shiftKey &&
+        event.key.toLowerCase() === "z" &&
+        undoNotice &&
+        busyAction === null
+      ) {
+        event.preventDefault();
+        void undoLastChange();
+        return;
+      }
+
       if (!isTyping && event.key === "/") {
         event.preventDefault();
         document.querySelector<HTMLInputElement>("#library-search")?.focus();
@@ -177,7 +198,7 @@ export function App() {
 
     window.addEventListener("keydown", handleShortcut);
     return () => window.removeEventListener("keydown", handleShortcut);
-  }, []);
+  }, [busyAction, undoNotice]);
 
   const items = libraryState.items as unknown as LibraryItemView[];
   const activeCount = items.filter((item) => !item.deleted).length;
@@ -320,10 +341,14 @@ export function App() {
   }, [autoBootstrapAttempted, busyAction, libraryState.initialized, libraryState.loading]);
 
   async function addItem(input: AddInput) {
+    let undo: UndoableChange | null = null;
     const saved = await runAction("Save link", "Saved to your local library.", () =>
-      libraryRepository.add(input),
+      libraryRepository.add(input).then((change) => {
+        undo = change;
+      }),
     );
     if (saved) {
+      offerUndo(undo, "Saved link.");
       navigateToView("library");
       closeCapture();
     }
@@ -331,43 +356,82 @@ export function App() {
   }
 
   async function deleteItem(item: LibraryItemView) {
-    await runAction("Delete link", "Moved to deleted items.", () =>
-      libraryRepository.remove(item.id),
+    let undo: UndoableChange | null = null;
+    const deleted = await runAction("Delete link", "Moved to deleted items.", () =>
+      libraryRepository.remove(item.id).then((change) => {
+        undo = change;
+      }),
     );
+    if (deleted) offerUndo(undo, "Moved link to deleted items.");
   }
 
   async function restoreItem(item: LibraryItemView) {
+    let undo: UndoableChange | null = null;
     const restored = await runAction("Restore link", "Link restored.", () =>
-      libraryRepository.restore(item.id),
+      libraryRepository.restore(item.id).then((change) => {
+        undo = change;
+      }),
     );
     if (restored) {
+      offerUndo(undo, "Restored link.");
       setFilter("active");
     }
   }
 
   async function toggleFavorite(item: LibraryItemView) {
-    await runAction(
+    let undo: UndoableChange | null = null;
+    const saved = await runAction(
       item.favorite ? "Remove favorite" : "Add favorite",
       item.favorite ? "Removed from favorites." : "Added to favorites.",
       () =>
         libraryRepository.edit(item.id, {
           favorite: !item.favorite,
           expectedNote: item.note ?? null,
+        }).then((change) => {
+          undo = change;
         }),
     );
+    if (saved) {
+      offerUndo(
+        undo,
+        item.favorite ? "Removed from favorites." : "Added to favorites.",
+      );
+    }
   }
 
   async function saveEdit(item: LibraryItemView, input: EditInput) {
+    let undo: UndoableChange | null = null;
     const saved = await runAction("Update link", "Changes saved locally.", () =>
       libraryRepository.edit(item.id, {
         ...input,
         expectedNote: item.note ?? null,
+      }).then((change) => {
+        undo = change;
       }),
     );
     if (saved) {
+      offerUndo(undo, "Changes saved.");
       closeEditor();
     }
     return saved;
+  }
+
+  function offerUndo(change: UndoableChange | null, message: string) {
+    if (!change) return;
+    setUndoNotice({ change, message });
+    setAnnouncement(`${message} Undo is available.`);
+  }
+
+  async function undoLastChange() {
+    const notice = undoNotice;
+    if (!notice || busyAction !== null) return;
+    const undone = await runAction("Undo change", "Last change undone.", () =>
+      libraryRepository.undo(notice.change),
+    );
+    if (undone) {
+      setUndoNotice(null);
+      setAnnouncement("Last change undone.");
+    }
   }
 
   function openEditor(item: LibraryItemView, opener: HTMLButtonElement) {
@@ -878,6 +942,28 @@ export function App() {
       <div aria-atomic="true" aria-live="polite" className="sr-only">
         {announcement}
       </div>
+
+      {undoNotice ? (
+        <div className="undo-notice" role="status">
+          <span>{undoNotice.message}</span>
+          <button
+            disabled={busyAction !== null}
+            onClick={() => void undoLastChange()}
+            type="button"
+          >
+            Undo
+          </button>
+          <button
+            aria-label="Dismiss undo"
+            className="undo-dismiss"
+            disabled={busyAction !== null}
+            onClick={() => setUndoNotice(null)}
+            type="button"
+          >
+            ×
+          </button>
+        </div>
+      ) : null}
 
       {displayedError && !editingItem && !capturing ? (
         <div className="error-banner" role="alert">

--- a/web/src/data/library.ts
+++ b/web/src/data/library.ts
@@ -20,6 +20,13 @@ import {
   type PersistedSyncConfiguration,
   type RemoteObservation,
 } from "./db";
+import {
+  createUndoableChange,
+  matchesUndoExpectation,
+  type UndoableChange,
+} from "./undo.ts";
+
+export type { UndoableChange } from "./undo.ts";
 
 export type LibraryItem = PersistedItem;
 
@@ -231,9 +238,9 @@ class LibraryRepository {
     await this.afterCommit("Offline library ready");
   }
 
-  async add(input: AddItemInput): Promise<void> {
+  async add(input: AddItemInput): Promise<UndoableChange | null> {
     const itemId = uuidV7();
-    await this.commitMutation({
+    return this.commitMutation({
       type: "create",
       item_id: itemId,
       url: input.url,
@@ -247,7 +254,7 @@ class LibraryRepository {
     });
   }
 
-  async edit(itemId: string, input: EditItemInput): Promise<void> {
+  async edit(itemId: string, input: EditItemInput): Promise<UndoableChange | null> {
     const mutation: Record<string, unknown> = { type: "edit", item_id: itemId };
     if (input.url !== undefined) mutation.url = input.url;
     if (input.title !== undefined) mutation.title = textUpdate(input.title);
@@ -258,18 +265,26 @@ class LibraryRepository {
     }
     if (input.favorite !== undefined) mutation.favorite = input.favorite;
     if (input.language !== undefined) mutation.language = textUpdate(input.language);
-    await this.commitMutation(
+    return this.commitMutation(
       mutation,
       input.tags === undefined ? undefined : exactTags(input.tags),
     );
   }
 
-  async remove(itemId: string): Promise<void> {
-    await this.commitMutation({ type: "delete", item_id: itemId });
+  async remove(itemId: string): Promise<UndoableChange | null> {
+    return this.commitMutation({ type: "delete", item_id: itemId });
   }
 
-  async restore(itemId: string): Promise<void> {
-    await this.commitMutation({ type: "restore", item_id: itemId });
+  async restore(itemId: string): Promise<UndoableChange | null> {
+    return this.commitMutation({ type: "restore", item_id: itemId });
+  }
+
+  async undo(change: UndoableChange): Promise<void> {
+    await this.commitMutation(
+      change.mutation,
+      change.targetTags,
+      change.expectedItem,
+    );
   }
 
   async syncIdentity(): Promise<BrowserSyncIdentity> {
@@ -546,12 +561,19 @@ class LibraryRepository {
   private async commitMutation(
     mutation: Record<string, unknown>,
     targetTags?: string[],
-  ): Promise<void> {
+    expectedItem?: PersistedItem,
+  ): Promise<UndoableChange | null> {
     let committed = false;
+    let undoableChange: UndoableChange | null = null;
     await this.write(async (database) => {
       const persisted = await readPersisted(database);
       const itemId = mutationItemId(mutation);
       const beforeItem = await database.get("items", itemId);
+      if (expectedItem && !matchesUndoExpectation(beforeItem, expectedItem)) {
+        throw new Error(
+          "This save changed after that action, so the older undo was not applied.",
+        );
+      }
       const normalizedMutation = normalizeMutation(mutation, beforeItem, targetTags);
       if (!normalizedMutation) return;
       await ensureWasm();
@@ -582,7 +604,11 @@ class LibraryRepository {
       };
       const items = materializeProjection(result.projection);
       const afterItem = items.find((item) => item.id === itemId);
+      if (!afterItem) {
+        throw new Error("The domain core omitted the changed item from its projection.");
+      }
       const summary = summarizeMutation(normalizedMutation, beforeItem, afterItem);
+      undoableChange = createUndoableChange(summary.kind, beforeItem, afterItem);
       const batch = batchRecord(path, result.envelope, identity, "local", now);
       const outbox: PersistedOutbox = {
         path,
@@ -615,6 +641,7 @@ class LibraryRepository {
     if (committed) {
       await this.afterCommit("Saved offline — queued for synchronization");
     }
+    return undoableChange;
   }
 
   private async recordSyncResult(errorKind: string | null): Promise<void> {

--- a/web/src/data/undo.test.mjs
+++ b/web/src/data/undo.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { createUndoableChange, matchesUndoExpectation } from "./undo.ts";
+
+const original = {
+  id: "00000000-0000-7000-8000-000000000003",
+  url: "https://example.com/original",
+  title: "Original",
+  excerpt: "Old context",
+  note: "Old note",
+  favorite: false,
+  language: "en",
+  savedAt: "2026-07-21T00:00:00.000Z",
+  savedAtUnix: 1_784_592_000,
+  tags: ["keep", "read"],
+  deleted: false,
+};
+
+test("undo builds compensating mutations for item lifecycle changes", () => {
+  const created = createUndoableChange("create", undefined, original);
+  assert.deepEqual(created.mutation, { type: "delete", item_id: original.id });
+
+  const deletedItem = { ...original, deleted: true };
+  const deleted = createUndoableChange("delete", original, deletedItem);
+  assert.deepEqual(deleted.mutation, { type: "restore", item_id: original.id });
+
+  const restored = createUndoableChange("restore", deletedItem, original);
+  assert.deepEqual(restored.mutation, { type: "delete", item_id: original.id });
+});
+
+test("undo restores edited fields and refuses a stale item projection", () => {
+  const edited = {
+    ...original,
+    url: "https://example.com/edited",
+    title: null,
+    excerpt: "New context",
+    note: "New note",
+    favorite: true,
+    language: null,
+    tags: ["new"],
+  };
+  const undo = createUndoableChange("edit", original, edited);
+
+  assert.deepEqual(undo.mutation, {
+    type: "edit",
+    item_id: original.id,
+    url: original.url,
+    title: { type: "set", value: "Original" },
+    excerpt: { type: "set", value: "Old context" },
+    note: { type: "set", value: "Old note" },
+    expected_note: "New note",
+    favorite: false,
+    language: { type: "set", value: "en" },
+  });
+  assert.deepEqual(undo.targetTags, ["keep", "read"]);
+  assert.equal(matchesUndoExpectation(edited, undo.expectedItem), true);
+  assert.equal(
+    matchesUndoExpectation({ ...edited, favorite: false }, undo.expectedItem),
+    false,
+  );
+  assert.equal(matchesUndoExpectation(undefined, undo.expectedItem), false);
+});

--- a/web/src/data/undo.ts
+++ b/web/src/data/undo.ts
@@ -1,0 +1,100 @@
+import type { PersistedChangeKind, PersistedItem } from "./db.ts";
+
+export interface UndoableChange {
+  readonly itemId: string;
+  readonly label: string;
+  readonly mutation: Record<string, unknown>;
+  readonly targetTags?: string[];
+  readonly expectedItem: PersistedItem;
+}
+
+export function createUndoableChange(
+  kind: PersistedChangeKind,
+  beforeItem: PersistedItem | undefined,
+  afterItem: PersistedItem,
+): UndoableChange {
+  const base = {
+    itemId: afterItem.id,
+    label: afterItem.title?.trim() || afterItem.url,
+    expectedItem: cloneItem(afterItem),
+  };
+
+  if (kind === "create") {
+    return {
+      ...base,
+      mutation: { type: "delete", item_id: afterItem.id },
+    };
+  }
+  if (!beforeItem) {
+    throw new Error("The previous item state required for undo is unavailable.");
+  }
+  if (kind === "delete") {
+    return {
+      ...base,
+      mutation: { type: "restore", item_id: afterItem.id },
+    };
+  }
+  if (kind === "restore") {
+    return {
+      ...base,
+      mutation: { type: "delete", item_id: afterItem.id },
+    };
+  }
+
+  const mutation: Record<string, unknown> = {
+    type: "edit",
+    item_id: afterItem.id,
+  };
+  if (beforeItem.url !== afterItem.url) mutation.url = beforeItem.url;
+  if (beforeItem.title !== afterItem.title) mutation.title = textUpdate(beforeItem.title);
+  if (beforeItem.excerpt !== afterItem.excerpt) {
+    mutation.excerpt = textUpdate(beforeItem.excerpt);
+  }
+  if (beforeItem.note !== afterItem.note) {
+    mutation.note = textUpdate(beforeItem.note);
+    mutation.expected_note = afterItem.note;
+  }
+  if (beforeItem.favorite !== afterItem.favorite) mutation.favorite = beforeItem.favorite;
+  if (beforeItem.language !== afterItem.language) {
+    mutation.language = textUpdate(beforeItem.language);
+  }
+  const tagsChanged = !sameTags(beforeItem.tags, afterItem.tags);
+
+  return {
+    ...base,
+    mutation,
+    targetTags: tagsChanged ? [...beforeItem.tags] : undefined,
+  };
+}
+
+export function matchesUndoExpectation(
+  current: PersistedItem | undefined,
+  expected: PersistedItem,
+): boolean {
+  return Boolean(
+    current &&
+      current.id === expected.id &&
+      current.url === expected.url &&
+      current.title === expected.title &&
+      current.excerpt === expected.excerpt &&
+      current.note === expected.note &&
+      current.favorite === expected.favorite &&
+      current.language === expected.language &&
+      current.savedAt === expected.savedAt &&
+      current.savedAtUnix === expected.savedAtUnix &&
+      current.deleted === expected.deleted &&
+      sameTags(current.tags, expected.tags),
+  );
+}
+
+function textUpdate(value: string | null) {
+  return value === null ? { type: "clear" } : { type: "set", value };
+}
+
+function sameTags(left: string[], right: string[]) {
+  return left.length === right.length && left.every((tag, index) => tag === right[index]);
+}
+
+function cloneItem(item: PersistedItem): PersistedItem {
+  return { ...item, tags: [...item.tags] };
+}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1304,6 +1304,41 @@ footer {
   grid-row: 1 / span 2;
 }
 
+.undo-notice {
+  align-items: center;
+  background: var(--color-inverse-surface);
+  border: var(--rule) solid var(--color-border-strong);
+  bottom: var(--space-4);
+  color: var(--color-inverse);
+  display: flex;
+  gap: var(--space-3);
+  left: 50%;
+  max-width: min(32rem, calc(100vw - var(--space-6)));
+  padding: var(--space-3) var(--space-4);
+  position: fixed;
+  transform: translateX(-50%);
+  width: max-content;
+  z-index: 70;
+}
+
+.undo-notice span {
+  font-size: var(--font-size-sm);
+}
+
+.undo-notice button {
+  background: transparent;
+  border: var(--rule) solid currentColor;
+  color: inherit;
+  min-height: var(--control-height);
+}
+
+.undo-notice .undo-dismiss {
+  border: 0;
+  font-size: var(--font-size-lg);
+  min-width: var(--control-height);
+  padding: 0;
+}
+
 .capture-dialog,
 .edit-dialog {
   background: var(--color-surface);
@@ -2710,6 +2745,11 @@ kbd {
     min-height: 100dvh;
     overflow: visible;
     padding: 0;
+  }
+
+  .undo-notice {
+    bottom: calc(4.75rem + env(safe-area-inset-bottom));
+    max-width: calc(100vw - 1.5rem);
   }
 
   .workspace-chrome {


### PR DESCRIPTION
Closes #83

## User-visible impact
- offers a persistent Undo notice after the latest add, edit, favorite, tag, archive, or restore action
- supports Ctrl+Z and Cmd+Z outside editable fields
- keeps archived saves recoverable through the existing deleted-items view
- positions the notice above the mobile action bar

## Protocol and recovery
Undo is a new compensating mutation through the existing WASM and IndexedDB transaction boundary. It creates a normal immutable outbox envelope and never removes or rewrites history. An exact post-action item precondition makes an older undo fail stale when later local or remote work has changed the item.

The decision and bounded one-level scope are recorded in ADR 0005.

## Verification
- `npm run verify`
- browser: create → edit → Undo restored the prior title while pending sync advanced from 2 to 3
- browser: archive → Undo restored the item while pending sync advanced from 4 to 5
- `git diff --check`

## UI evidence
Chrome accessibility snapshots confirmed the fixed status notice exposes named Undo and Dismiss controls, remains available while the item reader is open, and updates the live region after recovery.
