### PR TITLE
Publish the Markdown reference guide

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Hosted owner app
+name: ResearchPocket website
 
 on:
   pull_request:
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build static owner app
+    name: Build static website
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -49,7 +49,7 @@ jobs:
         working-directory: web
         run: npm ci
 
-      - name: Verify and build static owner app
+      - name: Verify and build static website
         working-directory: web
         run: npm run verify
 
@@ -64,7 +64,7 @@ jobs:
           path: web/dist
 
   deploy:
-    name: Deploy static owner app
+    name: Deploy static website
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build static website
+    name: Build static owner app
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/README.md
+++ b/README.md
@@ -215,13 +215,12 @@ copy after use, preserves supported save fields and exact tag spelling, reports
 malformed fields or records, and records per-row receipts so a repeated import is
 idempotent.
 
-For the recovered library in this workspace:
+To import into a separate V2 data directory:
 
 ```sh
-export RESEARCHPOCKET_DATA_DIR="$HOME/Developer/pocket/recovered/i-like-to-save-it-save-it-2025-08-30/v2-library"
+export RESEARCHPOCKET_DATA_DIR="$HOME/path/to/new-v2-library"
 research init
-research import v1 \
-  "$HOME/Developer/pocket/recovered/i-like-to-save-it-save-it-2025-08-30/current-db/research.sqlite"
+research import v1 "$HOME/path/to/v1/research.sqlite"
 research status
 research list --limit 20
 ```

--- a/docs/v2/DESIGN_SYSTEM.md
+++ b/docs/v2/DESIGN_SYSTEM.md
@@ -3,7 +3,8 @@
 Status: canonical visual and interaction contract for every V2 web surface
 
 This system applies to the hosted owner application, the future loopback web
-interface, the project landing page, and selective public collection views. A
+interface, the public welcome, product overview, reference guide, and selective
+public collection views. A
 surface may expose different capabilities, but it must not invent another
 visual language or styling toolchain.
 
@@ -67,12 +68,12 @@ The styles load in a fixed order:
    overrides.
 2. `web/src/styles/base.css` establishes element behavior, focus, controls, and
    shared accessibility utilities.
-3. `web/src/styles/app.css` composes landing, onboarding, workspace, and
-   component patterns exclusively from tokens.
+3. `web/src/styles/app.css` composes landing, reference, onboarding, workspace,
+   and component patterns exclusively from tokens.
 
-The script-free landing document links these files directly in that order. The
-owner application imports the same order from its TypeScript entry so Vite can
-extract one shared first-party stylesheet for both production documents.
+The script-free public documents link these files directly in that order. The
+owner application and reference guide import the same order from their
+TypeScript entries so Vite can extract shared first-party styles.
 
 Raw colors may appear only in `tokens.css`. Component styles use semantic token
 names rather than palette names so light, dark, and increased-contrast modes do
@@ -128,10 +129,11 @@ remain content-sized, use compact icon controls for row actions, and never force
 a record past three text lines. The page must work from 320 CSS pixels through
 wide desktop screens without horizontal page overflow.
 
-The public landing page uses a wider editorial reading layout at `/`; the owner
-application lives at `/app/`. Both use the same tokens, typography, controls,
-rules, states, and responsive breakpoints. The root must not load the owner
-JavaScript/WASM bundle or initialize private browser storage.
+The public welcome and overview use wider editorial layouts at `/` and
+`/overview/`. The Markdown-backed reference reader lives at `/docs/`, and the
+owner application lives at `/app/`. Every surface uses the same tokens,
+typography, controls, rules, states, and responsive breakpoints. Public pages
+must not load the owner WASM bundle or initialize private browser storage.
 
 ## Patterns
 
@@ -211,14 +213,14 @@ npm run verify
 
 `npm run verify` runs browser persistence/sync contracts and then the production
 build. The build compiles Rust/WASM, type-checks TypeScript, checks the design
-system, emits the static root and owner app, and checks the final artifact.
+system, emits the public website and owner app, and checks the final artifact.
 GitHub Pages invokes the same command; it does not contain a second build recipe.
 
 The artifact check rejects source maps, source-map references, development CSP
 nonces, `unsafe-inline`, external runtime assets, credential markers, and
 private test sentinels across text and binary artifacts. It also requires an
-indexable root landing document, a noindex owner document, an app-scoped
-manifest, and noindex same-origin redirects for the retired project paths.
+indexable public documents, a noindex owner document, an app-scoped manifest,
+and noindex same-origin redirects for the retired project paths.
 Deployment uploads only `web/dist` and uses no owner credential.
 
 ## Change rule

--- a/docs/v2/MIGRATION.md
+++ b/docs/v2/MIGRATION.md
@@ -27,18 +27,16 @@ research status
 research list --limit 20
 ```
 
-For the recovered `i-like-to-save-it-save-it` library in this workspace, use:
+To keep the imported V2 library in an explicit directory, use:
 
 ```sh
-export RESEARCHPOCKET_DATA_DIR="$HOME/Developer/pocket/recovered/i-like-to-save-it-save-it-2025-08-30/v2-library"
+export RESEARCHPOCKET_DATA_DIR="$HOME/path/to/new-v2-library"
 research init
-research import v1 \
-  "$HOME/Developer/pocket/recovered/i-like-to-save-it-save-it-2025-08-30/current-db/research.sqlite"
+research import v1 "$HOME/path/to/v1/research.sqlite"
 ```
 
-That recovered source contains 978 saves, 415 tags, and 2,439 item-tag links.
-It contains no notes. Those counts are useful acceptance checks, not values the
-importer hard-codes.
+Use `research status` and representative `research list` or `research search`
+queries to compare the imported library with your private source and backup.
 
 ## Safety and idempotency
 

--- a/docs/v2/WEB.md
+++ b/docs/v2/WEB.md
@@ -4,8 +4,10 @@ Status: public product explainer, offline owner editing, and private GitHub brow
 
 ## What works now
 
-The static Pages build in `web/` has two deliberately separate entries. The
-root is an indexable, script-free product explainer. `/app/` is the private owner
+The static Pages build in `web/` has four deliberately separate entries. The
+root is an indexable, script-free welcome, `/overview/` is the script-free
+product explainer, and `/docs/` is an indexable React reference reader built from
+an explicit allowlist of checked-in Markdown. `/app/` is the private owner
 application and uses the same pinned Rust/Loro domain core as the native CLI. It
 can initialize a browser library and add, search, edit,
 favorite, tag, delete, and restore saves without a network connection. The UI
@@ -82,9 +84,11 @@ WASM result cannot be persisted.
 
 The owner application bundles React, IndexedDB helpers, JavaScript, CSS,
 same-origin Berkeley Mono webfonts, and the WASM domain artifact. The public
-root loads only the shared first-party CSS and its bundled font files; it does
-not initialize IndexedDB, JavaScript, or WASM. Neither entry loads a remote
-third-party runtime script, font, image, analytics, or error reporter.
+root and overview load only the shared first-party CSS and bundled font files.
+The reference reader loads React and the reviewed Markdown corpus, but it does
+not initialize IndexedDB, WASM, synchronization, or a service worker. No entry
+loads a remote third-party runtime script, font, image, analytics, or error
+reporter.
 Production builds omit source maps.
 
 The document CSP allows only same-origin application resources and future
@@ -159,8 +163,9 @@ npm run build
 ```
 
 The build compiles `research-domain` to WASM, generates the local JavaScript
-bridge, runs strict TypeScript and policy checking, and emits the root landing
-page plus the relative-path owner app under `web/dist/app/`. The protected
+bridge, runs strict TypeScript and policy checking, and emits the root welcome,
+product overview, Markdown-backed reference guide, and relative-path owner app.
+The protected
 source repository is also the reserved organization Pages repository,
 `ResearchPocket/researchpocket.github.io`; its workflow performs the same build
 and deploys only `web/dist/`. The former repository URL continues through

--- a/web/README.md
+++ b/web/README.md
@@ -35,8 +35,10 @@ After the locked `npm ci` install, Bun can also run the development script:
 bun dev
 ```
 
-Both commands start the public explainer at `http://localhost:5173/` and the
-owner application at `http://localhost:5173/app/`. The development server
+Both commands start the public welcome at `http://localhost:5173/`, product
+overview at `http://localhost:5173/overview/`, Markdown reference at
+`http://localhost:5173/docs/`, and owner application at
+`http://localhost:5173/app/`. The development server
 creates a fresh CSP nonce at startup for Vite's injected scripts and styles, so
 CSS and hot reload work without allowing arbitrary inline content. Restart the
 server after changing its configuration. Production builds do not contain this
@@ -49,10 +51,10 @@ immutable bytes without a replacement SHA.
 
 `npm run build` first compiles `research-domain` for
 `wasm32-unknown-unknown`, runs the matching `wasm-bindgen` CLI, type-checks the
-app, checks the canonical design-system rules, creates the script-free landing
-page and relative-path owner app in `dist/`, and rejects unsafe deployment
-artifacts. The app-scoped service worker caches only same-origin owner-shell
-resources and bypasses `api.github.com`.
+app, checks the canonical design-system rules, creates the script-free public
+pages, Markdown-backed reference, and relative-path owner app in `dist/`, and
+rejects unsafe deployment artifacts. The app-scoped service worker caches only
+same-origin owner-shell resources and bypasses `api.github.com`.
 
 Production is served from `https://researchpocket.github.io/`, with the owner
 application at `/app/`. The build also emits noindex compatibility redirects

--- a/web/docs/index.html
+++ b/web/docs/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; base-uri 'none'; connect-src 'self' https://api.github.com; font-src 'self'; form-action 'none'; frame-src 'none'; img-src 'self'; manifest-src 'self'; object-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; worker-src 'self'; upgrade-insecure-requests"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#1a150c" />
+    <meta
+      name="description"
+      content="The complete ResearchPocket reference: setup, CLI, migration, synchronization protocol, privacy, architecture decisions, and releases."
+    />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://researchpocket.github.io/docs/" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
+    <title>Reference guide — ResearchPocket</title>
+  </head>
+  <body class="docs-body">
+    <noscript>
+      The ResearchPocket reference needs JavaScript to parse and navigate its
+      checked-in Markdown sources.
+      <a href="https://github.com/ResearchPocket/researchpocket.github.io/tree/main/docs">
+        Read the source documentation on GitHub.
+      </a>
+    </noscript>
+    <div id="docs-root"></div>
+    <script type="module" src="/src/docs-main.tsx"></script>
+  </body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -81,7 +81,8 @@
 
         <p class="landing-footnote">
           Restoring first avoids merges. Keep browser storage enabled.
-          <a href="./overview/">Product overview</a>
+          <a href="./overview/">Product overview</a> ·
+          <a href="./docs/">Reference guide</a>
         </p>
       </section>
     </main>

--- a/web/overview/index.html
+++ b/web/overview/index.html
@@ -30,6 +30,7 @@
         <span>ResearchPocket</span>
       </a>
       <nav aria-label="Overview navigation">
+        <a href="../docs/">Docs</a>
         <a href="https://github.com/ResearchPocket/researchpocket.github.io">Source</a>
         <a class="overview-open" href="../app/">Open app</a>
       </nav>
@@ -46,7 +47,7 @@
         </p>
         <div class="overview-actions">
           <a class="primary-link" href="../app/#new">Start a new library</a>
-          <a class="secondary-link" href="../app/#restore">Restore from sync</a>
+          <a class="secondary-link" href="../docs/">Read the reference</a>
         </div>
       </section>
 

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -11,5 +11,7 @@ recovery, and hosted owner editing. Selective public collections, the loopback
 web server, checkpoints, and background scheduling remain planned work.
 
 - [Project source and documentation](https://github.com/ResearchPocket/researchpocket.github.io)
-- [Public product overview](https://researchpocket.github.io/)
+- [Public welcome](https://researchpocket.github.io/)
+- [Product overview](https://researchpocket.github.io/overview/)
+- [Complete reference guide](https://researchpocket.github.io/docs/)
 - [Hosted owner app](https://researchpocket.github.io/app/)

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -2,10 +2,82 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://researchpocket.github.io/</loc>
-    <lastmod>2026-07-20</lastmod>
+    <lastmod>2026-07-22</lastmod>
   </url>
   <url>
     <loc>https://researchpocket.github.io/overview/</loc>
-    <lastmod>2026-07-20</lastmod>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=cli</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=migration</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=hosted-owner</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=product</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=sync-protocol</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=threat-model</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=design-system</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=adr-native-capture</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=adr-enrichment</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=adr-operation-packs</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=adr-firecrawl-markdown</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=adr-undo</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=contributing</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=roadmap</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=release-preview-4</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=release-preview-3</loc>
+    <lastmod>2026-07-22</lastmod>
+  </url>
+  <url>
+    <loc>https://researchpocket.github.io/docs/?page=release-preview-2</loc>
+    <lastmod>2026-07-22</lastmod>
   </url>
 </urlset>

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,5 +1,5 @@
 const CACHE_PREFIX = "research-pocket-shell-";
-const CACHE_NAME = `${CACHE_PREFIX}v3-root`;
+const CACHE_NAME = `${CACHE_PREFIX}v4-root`;
 const SITE_ROOT = new URL("../", self.registration.scope);
 const ASSET_MANIFEST = new URL("asset-manifest.json", SITE_ROOT);
 const SHELL_FILES = ["app/", "app/index.html", "manifest.webmanifest", "favicon.svg"];
@@ -27,11 +27,19 @@ async function cacheApplicationShell() {
 
   const manifest = await manifestResponse.clone().json();
   const generatedFiles = new Set();
-  for (const entry of Object.values(manifest)) {
+
+  function collectEntry(entryKey) {
+    const entry = manifest[entryKey];
+    if (!entry) {
+      throw new Error(`The application shell manifest is missing ${entryKey}.`);
+    }
     if (typeof entry.file === "string") generatedFiles.add(entry.file);
     for (const cssFile of entry.css ?? []) generatedFiles.add(cssFile);
     for (const assetFile of entry.assets ?? []) generatedFiles.add(assetFile);
+    for (const importedEntry of entry.imports ?? []) collectEntry(importedEntry);
   }
+
+  collectEntry("app/index.html");
 
   await cache.put(manifestRequest, manifestResponse);
   const shellUrls = [...SHELL_FILES, ...generatedFiles].map(

--- a/web/scripts/check-design-system.mjs
+++ b/web/scripts/check-design-system.mjs
@@ -97,15 +97,19 @@ for (const file of files) {
   }
 }
 
-const mainEntry = readFileSync(resolve(webRoot, "src/main.tsx"), "utf8");
-const importPositions = requiredFiles.map((file) =>
-  mainEntry.indexOf(`./styles/${file}`),
-);
-if (
-  importPositions.some((position) => position === -1) ||
-  importPositions.some((position, index) => index > 0 && position < importPositions[index - 1])
-) {
-  failures.push("main.tsx must import tokens.css, base.css, then app.css");
+for (const entryFile of ["main.tsx", "docs-main.tsx"]) {
+  const entry = readFileSync(resolve(webRoot, `src/${entryFile}`), "utf8");
+  const importPositions = requiredFiles.map((file) =>
+    entry.indexOf(`./styles/${file}`),
+  );
+  if (
+    importPositions.some((position) => position === -1) ||
+    importPositions.some(
+      (position, index) => index > 0 && position < importPositions[index - 1],
+    )
+  ) {
+    failures.push(`${entryFile} must import tokens.css, base.css, then app.css`);
+  }
 }
 
 if (failures.length > 0) {

--- a/web/scripts/check-dist.mjs
+++ b/web/scripts/check-dist.mjs
@@ -16,6 +16,7 @@ function walk(directory) {
 for (const requiredFile of [
   "index.html",
   "app/index.html",
+  "docs/index.html",
   "overview/index.html",
   "sw.js",
   "manifest.webmanifest",
@@ -45,6 +46,7 @@ if (sourceMaps.length > 0) {
 }
 
 const artifacts = files.map((file) => ({ file, bytes: readFileSync(file) }));
+const htmlArtifacts = artifacts.filter(({ file }) => extname(file) === ".html");
 const textExtensions = new Set([
   ".css",
   ".html",
@@ -61,12 +63,22 @@ const text = artifacts
   .join("\n");
 
 for (const [name, pattern] of [
-  ["unsafe-inline CSP source", /unsafe-inline/i],
-  ["development CSP nonce", /nonce-[a-z0-9]+/i],
   ["source map reference", /sourceMappingURL=/i],
 ]) {
   if (pattern.test(text)) {
     failures.push(`Production artifact contains ${name}`);
+  }
+}
+
+for (const [name, pattern] of [
+  ["unsafe-inline CSP source", /unsafe-inline/i],
+  ["development CSP nonce", /nonce-[a-z0-9]+/i],
+]) {
+  const matchingFiles = htmlArtifacts
+    .filter(({ bytes }) => pattern.test(bytes.toString("utf8")))
+    .map(({ file }) => relative(distRoot, file));
+  if (matchingFiles.length > 0) {
+    failures.push(`Production HTML contains ${name}: ${matchingFiles.join(", ")}`);
   }
 }
 
@@ -86,7 +98,7 @@ for (const [name, markers] of [
   }
 }
 
-const documents = ["index.html", "app/index.html", "overview/index.html"];
+const documents = ["index.html", "app/index.html", "docs/index.html", "overview/index.html"];
 for (const document of documents) {
   const path = resolve(distRoot, document);
   if (!existsSync(path)) continue;
@@ -96,6 +108,9 @@ for (const document of documents) {
   }
   if (!html.includes("style-src 'self'")) {
     failures.push(`${document} is missing the expected style CSP`);
+  }
+  if (/unsafe-inline|nonce-[a-z0-9]+/i.test(html)) {
+    failures.push(`${document} contains an unsafe or development-only CSP source`);
   }
 
   const runtimeTags = html.match(/<(?:img|link|script)\b[^>]*>/gi) ?? [];
@@ -110,6 +125,20 @@ for (const document of documents) {
   });
   if (externalRuntimeTag) {
     failures.push(`${document} loads a third-party runtime asset`);
+  }
+}
+
+const docsPath = resolve(distRoot, "docs/index.html");
+if (existsSync(docsPath)) {
+  const docs = readFileSync(docsPath, "utf8");
+  if (!docs.includes('name="robots" content="index, follow"')) {
+    failures.push("The public reference guide is not indexable");
+  }
+  if (!docs.includes('rel="canonical" href="https://researchpocket.github.io/docs/"')) {
+    failures.push("The public reference guide canonical URL is incorrect");
+  }
+  if (docs.includes('rel="manifest"') || docs.includes("research_domain_bg")) {
+    failures.push("The public reference guide is coupled to owner-app resources");
   }
 }
 
@@ -133,11 +162,43 @@ if (existsSync(landingPath)) {
 for (const [file, expected] of [
   ["robots.txt", "Sitemap: https://researchpocket.github.io/sitemap.xml"],
   ["sitemap.xml", "<loc>https://researchpocket.github.io/</loc>"],
+  ["sitemap.xml", "<loc>https://researchpocket.github.io/docs/</loc>"],
   ["llms.txt", "https://researchpocket.github.io/app/"],
+  ["llms.txt", "https://researchpocket.github.io/docs/"],
 ]) {
   const path = resolve(distRoot, file);
   if (existsSync(path) && !readFileSync(path, "utf8").includes(expected)) {
     failures.push(`${file} does not point to the organization site`);
+  }
+}
+
+const assetManifestPath = resolve(distRoot, "asset-manifest.json");
+if (existsSync(assetManifestPath)) {
+  const assetManifest = JSON.parse(readFileSync(assetManifestPath, "utf8"));
+  if (!assetManifest["app/index.html"] || !assetManifest["docs/index.html"]) {
+    failures.push("The Vite manifest is missing the owner or reference entry");
+  } else {
+    const collectEntryFiles = (entryKey, collected = new Set()) => {
+      if (collected.has(entryKey)) return collected;
+      collected.add(entryKey);
+      const entry = assetManifest[entryKey];
+      if (!entry) return collected;
+      if (typeof entry.file === "string") collected.add(entry.file);
+      for (const file of entry.css ?? []) collected.add(file);
+      for (const file of entry.assets ?? []) collected.add(file);
+      for (const importedEntry of entry.imports ?? []) {
+        collectEntryFiles(importedEntry, collected);
+      }
+      return collected;
+    };
+    const appFiles = collectEntryFiles("app/index.html");
+    const docsFiles = collectEntryFiles("docs/index.html");
+    if (appFiles.has(assetManifest["docs/index.html"].file)) {
+      failures.push("The owner application dependency closure contains the docs entry");
+    }
+    if ([...docsFiles].some((file) => file.endsWith(".wasm"))) {
+      failures.push("The public reference dependency closure contains WASM");
+    }
   }
 }
 
@@ -216,6 +277,17 @@ if (existsSync(compatibilityScriptPath)) {
         `The compatibility redirect is missing migration behavior: ${requiredMarker}`,
       );
     }
+  }
+}
+
+const serviceWorkerPath = resolve(distRoot, "sw.js");
+if (existsSync(serviceWorkerPath)) {
+  const serviceWorker = readFileSync(serviceWorkerPath, "utf8");
+  if (!serviceWorker.includes('collectEntry("app/index.html")')) {
+    failures.push("The owner service worker does not scope precaching to the app entry");
+  }
+  if (serviceWorker.includes("Object.values(manifest)")) {
+    failures.push("The owner service worker precaches unrelated website entries");
   }
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,15 +1,13 @@
 import {
   type SubmitEvent,
   type ReactNode,
-  memo,
   useDeferredValue,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
-import ReactMarkdown, { type Components } from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { MarkdownDocument } from "./components/MarkdownDocument.tsx";
 import {
   type LibraryState,
   type PendingSyncChange,
@@ -51,33 +49,6 @@ interface UndoNotice {
 const DENSITY_STORAGE_KEY = "researchpocket.ui.density";
 
 const LIST_BATCH_SIZE = 100;
-
-const READER_MARKDOWN_COMPONENTS: Components = {
-  a: ({ children, href, title }) => (
-    <a href={href} rel="noreferrer" target="_blank" title={title}>
-      {children}
-    </a>
-  ),
-  img: ({ alt, title }) => (
-    <span className="reader-markdown-image" role="img" aria-label={alt || "Archived image"} title={title}>
-      [Image: {alt || "unlabeled"}]
-    </span>
-  ),
-};
-
-const MarkdownDocument = memo(function MarkdownDocument({ source }: { source: string }) {
-  return (
-    <div className="reader-markdown">
-      <ReactMarkdown
-        components={READER_MARKDOWN_COMPONENTS}
-        remarkPlugins={[remarkGfm]}
-        skipHtml
-      >
-        {source}
-      </ReactMarkdown>
-    </div>
-  );
-});
 
 const EMPTY_LIBRARY_STATE: LibraryState = {
   error: null,

--- a/web/src/DocsApp.tsx
+++ b/web/src/DocsApp.tsx
@@ -1,0 +1,519 @@
+import {
+  type MouseEvent as ReactMouseEvent,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { Components } from "react-markdown";
+import { MarkdownDocument } from "./components/MarkdownDocument.tsx";
+import {
+  type ReferenceDocument,
+  referenceDocumentById,
+  referenceDocumentBySourcePath,
+  referenceDocuments,
+  referenceSections,
+} from "./docs/catalog.ts";
+
+interface MarkdownHeading {
+  depth: number;
+  line: number;
+  slug: string;
+  text: string;
+}
+
+const DEFAULT_DOCUMENT_ID = "overview";
+const SOURCE_ROOT = "https://github.com/ResearchPocket/researchpocket.github.io/blob/main/";
+
+export function DocsApp() {
+  const [selectedDocumentId, setSelectedDocumentId] = useState(readDocumentId);
+  const [navigationOpen, setNavigationOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const deferredQuery = useDeferredValue(query);
+  const contentRef = useRef<HTMLElement>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const selectedDocument =
+    referenceDocumentById.get(selectedDocumentId) ??
+    referenceDocumentById.get(DEFAULT_DOCUMENT_ID)!;
+  const headings = useMemo(
+    () => parseMarkdownHeadings(selectedDocument.source),
+    [selectedDocument],
+  );
+  const headingIds = useMemo(
+    () => new Map(headings.map((heading) => [heading.line, heading.slug])),
+    [headings],
+  );
+  const outline = headings.filter((heading) => heading.depth === 2 || heading.depth === 3);
+  const normalizedQuery = deferredQuery.trim().toLocaleLowerCase();
+  const matchingDocuments = useMemo(
+    () =>
+      normalizedQuery
+        ? referenceDocuments.filter((document) =>
+            [document.title, document.description, document.status, document.source]
+              .join("\n")
+              .toLocaleLowerCase()
+              .includes(normalizedQuery),
+          )
+        : referenceDocuments,
+    [normalizedQuery],
+  );
+  const selectedIndex = referenceDocuments.findIndex(
+    (document) => document.id === selectedDocument.id,
+  );
+  const previousDocument = referenceDocuments[selectedIndex - 1];
+  const nextDocument = referenceDocuments[selectedIndex + 1];
+
+  useEffect(() => {
+    function restoreLocation() {
+      setSelectedDocumentId(readDocumentId());
+      setNavigationOpen(false);
+      window.requestAnimationFrame(() => focusDocument(window.location.hash));
+    }
+
+    window.addEventListener("popstate", restoreLocation);
+    window.addEventListener("hashchange", restoreLocation);
+    return () => {
+      window.removeEventListener("popstate", restoreLocation);
+      window.removeEventListener("hashchange", restoreLocation);
+    };
+  }, []);
+
+  useEffect(() => {
+    document.title = `${selectedDocument.title} — ResearchPocket reference`;
+    const canonical = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+    const description = document.querySelector<HTMLMetaElement>('meta[name="description"]');
+    if (canonical) {
+      canonical.href = new URL(canonicalDocumentHref(selectedDocument.id), window.location.origin).href;
+    }
+    if (description) description.content = selectedDocument.description;
+    if (window.location.hash) {
+      window.requestAnimationFrame(() => focusDocument(window.location.hash));
+    }
+  }, [selectedDocument]);
+
+  useEffect(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      const target = event.target as HTMLElement | null;
+      const isTyping =
+        target?.matches("input, textarea, select") || target?.isContentEditable;
+
+      if (!isTyping && event.key === "/") {
+        event.preventDefault();
+        const menuVisible =
+          menuButtonRef.current &&
+          window.getComputedStyle(menuButtonRef.current).display !== "none";
+        if (menuVisible) setNavigationOpen(true);
+        window.requestAnimationFrame(() => searchRef.current?.focus());
+      }
+      if (event.key === "Escape" && navigationOpen) {
+        setNavigationOpen(false);
+        window.requestAnimationFrame(() => menuButtonRef.current?.focus());
+      }
+    }
+
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, [navigationOpen]);
+
+  function focusDocument(hash: string) {
+    const content = contentRef.current;
+    if (hash) {
+      const target = document.getElementById(decodeURIComponent(hash.slice(1)));
+      if (target && content) {
+        const top =
+          content.scrollTop +
+          target.getBoundingClientRect().top -
+          content.getBoundingClientRect().top;
+        content.scrollTo({ top });
+        return;
+      }
+    }
+    content?.scrollTo({ top: 0 });
+    content?.focus({ preventScroll: true });
+  }
+
+  function navigateToDocument(documentId: string, hash = "") {
+    const document = referenceDocumentById.get(documentId);
+    if (!document) return;
+    const nextUrl = documentHref(document.id, hash);
+    const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    if (nextUrl !== currentUrl) {
+      window.history.pushState(window.history.state, "", nextUrl);
+    }
+    setSelectedDocumentId(document.id);
+    setNavigationOpen(false);
+    window.requestAnimationFrame(() => focusDocument(hash));
+  }
+
+  function handleDocumentClick(
+    event: ReactMouseEvent<HTMLAnchorElement>,
+    documentId: string,
+    hash = "",
+  ) {
+    if (
+      event.button !== 0 ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    navigateToDocument(documentId, hash);
+  }
+
+  const markdownComponents = createMarkdownComponents(
+    selectedDocument,
+    headingIds,
+    handleDocumentClick,
+  );
+
+  return (
+    <div className="docs-app">
+      <a className="skip-link" href="#docs-content">
+        Skip to reference
+      </a>
+
+      <header className="docs-header">
+        <a className="docs-brand" href="../">
+          <span aria-hidden="true" className="brand-mark">rp</span>
+          <span>ResearchPocket</span>
+          <small>Reference</small>
+        </a>
+        <nav aria-label="Site navigation" className="docs-header-actions">
+          <a className="docs-header-link" href="../overview/">Overview</a>
+          <a
+            className="docs-header-link"
+            href="https://github.com/ResearchPocket/researchpocket.github.io"
+          >
+            Source
+          </a>
+          <a className="docs-open-app" href="../app/">Open app</a>
+          <button
+            aria-controls="docs-navigation"
+            aria-expanded={navigationOpen}
+            className="docs-menu-button"
+            onClick={() => setNavigationOpen((open) => !open)}
+            ref={menuButtonRef}
+            type="button"
+          >
+            Guide
+          </button>
+        </nav>
+      </header>
+
+      <div className="docs-layout">
+        <aside
+          className="docs-sidebar"
+          data-open={navigationOpen ? "true" : "false"}
+          id="docs-navigation"
+        >
+          <div className="docs-search">
+            <label htmlFor="docs-search">Find a page</label>
+            <div>
+              <input
+                autoComplete="off"
+                id="docs-search"
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search the reference"
+                ref={searchRef}
+                type="search"
+                value={query}
+              />
+              <kbd>/</kbd>
+            </div>
+            <p>{matchingDocuments.length} of {referenceDocuments.length} pages</p>
+          </div>
+
+          <nav aria-label="Reference pages" className="docs-nav">
+            {referenceSections.map((section) => {
+              const sectionDocuments = matchingDocuments.filter(
+                (document) => document.section === section.id,
+              );
+              if (sectionDocuments.length === 0) return null;
+              return (
+                <section aria-labelledby={`docs-section-${section.id}`} key={section.id}>
+                  <h2 id={`docs-section-${section.id}`}>{section.label}</h2>
+                  {sectionDocuments.map((document) => (
+                    <a
+                      aria-current={document.id === selectedDocument.id ? "page" : undefined}
+                      href={documentHref(document.id)}
+                      key={document.id}
+                      onClick={(event) => handleDocumentClick(event, document.id)}
+                    >
+                      <span>{document.title}</span>
+                      <small>{document.status}</small>
+                    </a>
+                  ))}
+                </section>
+              );
+            })}
+            {matchingDocuments.length === 0 ? (
+              <p className="docs-search-empty">No reference pages match that search.</p>
+            ) : null}
+          </nav>
+
+        </aside>
+
+        <main
+          className="docs-content"
+          id="docs-content"
+          inert={navigationOpen ? true : undefined}
+          ref={contentRef}
+          tabIndex={-1}
+        >
+          <article className="docs-article">
+            <header className="docs-document-meta">
+              <div>
+                <span>{sectionLabel(selectedDocument.section)}</span>
+                <strong>{selectedDocument.status}</strong>
+              </div>
+              <a href={`${SOURCE_ROOT}${selectedDocument.sourcePath}`}>View source ↗</a>
+            </header>
+
+            <MarkdownDocument
+              className="reader-markdown docs-markdown"
+              components={markdownComponents}
+              source={selectedDocument.source}
+            />
+
+            <nav aria-label="Adjacent reference pages" className="docs-pagination">
+              {previousDocument ? (
+                <a
+                  href={documentHref(previousDocument.id)}
+                  onClick={(event) => handleDocumentClick(event, previousDocument.id)}
+                >
+                  <small>Previous</small>
+                  <span>← {previousDocument.title}</span>
+                </a>
+              ) : <span />}
+              {nextDocument ? (
+                <a
+                  href={documentHref(nextDocument.id)}
+                  onClick={(event) => handleDocumentClick(event, nextDocument.id)}
+                >
+                  <small>Next</small>
+                  <span>{nextDocument.title} →</span>
+                </a>
+              ) : null}
+            </nav>
+          </article>
+        </main>
+
+        <aside className="docs-outline">
+          <nav aria-label="On this page">
+            <h2>On this page</h2>
+            {outline.map((heading) => (
+              <a
+                className={heading.depth === 3 ? "docs-outline-nested" : undefined}
+                href={documentHref(selectedDocument.id, `#${heading.slug}`)}
+                key={`${heading.line}-${heading.slug}`}
+                onClick={(event) =>
+                  handleDocumentClick(event, selectedDocument.id, `#${heading.slug}`)
+                }
+              >
+                {heading.text}
+              </a>
+            ))}
+          </nav>
+        </aside>
+      </div>
+
+      <div aria-atomic="true" aria-live="polite" className="sr-only">
+        Showing {selectedDocument.title}
+      </div>
+    </div>
+  );
+}
+
+function createMarkdownComponents(
+  currentDocument: ReferenceDocument,
+  headingIds: ReadonlyMap<number, string>,
+  handleDocumentClick: (
+    event: ReactMouseEvent<HTMLAnchorElement>,
+    documentId: string,
+    hash?: string,
+  ) => void,
+): Components {
+  return {
+    a: ({ children, href, node: _node, title, ...props }) => {
+      const resolved = resolveMarkdownLink(currentDocument, href);
+      if (resolved.documentId) {
+        return (
+          <a
+            {...props}
+            href={resolved.href}
+            onClick={(event) =>
+              handleDocumentClick(event, resolved.documentId!, resolved.hash)
+            }
+            title={title}
+          >
+            {children}
+          </a>
+        );
+      }
+      return (
+        <a
+          {...props}
+          href={resolved.href}
+          rel={resolved.external ? "noreferrer" : undefined}
+          target={resolved.external ? "_blank" : undefined}
+          title={title}
+        >
+          {children}
+        </a>
+      );
+    },
+    h1: ({ children, node, ...props }) => (
+      <h1 {...props} id={headingId(node?.position?.start.line, headingIds)}>{children}</h1>
+    ),
+    h2: ({ children, node, ...props }) => (
+      <h2 {...props} id={headingId(node?.position?.start.line, headingIds)}>{children}</h2>
+    ),
+    h3: ({ children, node, ...props }) => (
+      <h3 {...props} id={headingId(node?.position?.start.line, headingIds)}>{children}</h3>
+    ),
+    h4: ({ children, node, ...props }) => (
+      <h4 {...props} id={headingId(node?.position?.start.line, headingIds)}>{children}</h4>
+    ),
+    h5: ({ children, node, ...props }) => (
+      <h5 {...props} id={headingId(node?.position?.start.line, headingIds)}>{children}</h5>
+    ),
+    h6: ({ children, node, ...props }) => (
+      <h6 {...props} id={headingId(node?.position?.start.line, headingIds)}>{children}</h6>
+    ),
+  };
+}
+
+function headingId(line: number | undefined, headings: ReadonlyMap<number, string>) {
+  return line === undefined ? undefined : headings.get(line);
+}
+
+function parseMarkdownHeadings(source: string): MarkdownHeading[] {
+  const headings: MarkdownHeading[] = [];
+  const slugCounts = new Map<string, number>();
+  let fence: { character: string; length: number } | null = null;
+
+  source.split("\n").forEach((line, index) => {
+    const fenceMatch = line.match(/^\s*(`{3,}|~{3,})/);
+    if (fenceMatch?.[1]) {
+      const marker = fenceMatch[1];
+      if (!fence) {
+        fence = { character: marker[0]!, length: marker.length };
+      } else if (marker[0] === fence.character && marker.length >= fence.length) {
+        fence = null;
+      }
+      return;
+    }
+    if (fence) return;
+
+    const match = line.match(/^(#{1,6})[\t ]+(.+?)[\t ]*$/);
+    if (!match?.[1] || !match[2]) return;
+    const text = plainHeadingText(match[2].replace(/[\t ]+#+[\t ]*$/, ""));
+    const baseSlug = slugifyHeading(text);
+    const count = slugCounts.get(baseSlug) ?? 0;
+    slugCounts.set(baseSlug, count + 1);
+    headings.push({
+      depth: match[1].length,
+      line: index + 1,
+      slug: count === 0 ? baseSlug : `${baseSlug}-${count}`,
+      text,
+    });
+  });
+
+  return headings;
+}
+
+function plainHeadingText(value: string) {
+  return value
+    .replace(/!?\[([^\]]+)]\([^)]+\)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/[*_~]/g, "")
+    .replace(/<[^>]+>/g, "")
+    .trim();
+}
+
+function slugifyHeading(value: string) {
+  return (
+    value
+      .normalize("NFKD")
+      .toLocaleLowerCase()
+      .replace(/[^\p{Letter}\p{Number}\p{Mark}\s-]/gu, "")
+      .trim()
+      .replace(/\s+/g, "-") || "section"
+  );
+}
+
+function resolveMarkdownLink(currentDocument: ReferenceDocument, href?: string) {
+  if (!href) return { external: false, href: "#" };
+  if (/^(?:https?:|mailto:)/i.test(href)) {
+    return { external: true, href };
+  }
+
+  const hashIndex = href.indexOf("#");
+  const hash = hashIndex >= 0 ? href.slice(hashIndex) : "";
+  const sourceHref = (hashIndex >= 0 ? href.slice(0, hashIndex) : href).split("?")[0]!;
+  if (!sourceHref) {
+    return {
+      documentId: currentDocument.id,
+      external: false,
+      hash,
+      href: documentHref(currentDocument.id, hash),
+    };
+  }
+
+  const sourcePath = resolveSourcePath(currentDocument.sourcePath, sourceHref);
+  const referencedDocument = referenceDocumentBySourcePath.get(sourcePath);
+  if (referencedDocument) {
+    return {
+      documentId: referencedDocument.id,
+      external: false,
+      hash,
+      href: documentHref(referencedDocument.id, hash),
+    };
+  }
+
+  return {
+    external: true,
+    href: `${SOURCE_ROOT}${sourcePath}${hash}`,
+  };
+}
+
+function resolveSourcePath(currentPath: string, targetPath: string) {
+  const currentSegments = currentPath.split("/");
+  currentSegments.pop();
+  const targetSegments = targetPath.startsWith("/")
+    ? targetPath.slice(1).split("/")
+    : [...currentSegments, ...targetPath.split("/")];
+  const resolved: string[] = [];
+  for (const segment of targetSegments) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") resolved.pop();
+    else resolved.push(segment);
+  }
+  return resolved.join("/");
+}
+
+function readDocumentId() {
+  const requested = new URLSearchParams(window.location.search).get("page");
+  return requested && referenceDocumentById.has(requested)
+    ? requested
+    : DEFAULT_DOCUMENT_ID;
+}
+
+function documentHref(documentId: string, hash = "") {
+  return `${window.location.pathname}?page=${encodeURIComponent(documentId)}${hash}`;
+}
+
+function canonicalDocumentHref(documentId: string) {
+  return documentId === DEFAULT_DOCUMENT_ID
+    ? window.location.pathname
+    : documentHref(documentId);
+}
+
+function sectionLabel(sectionId: string) {
+  return referenceSections.find((section) => section.id === sectionId)?.label ?? "Reference";
+}

--- a/web/src/components/MarkdownDocument.tsx
+++ b/web/src/components/MarkdownDocument.tsx
@@ -1,0 +1,43 @@
+import { memo } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+const SAFE_MARKDOWN_COMPONENTS: Components = {
+  a: ({ children, href, title }) => (
+    <a href={href} rel="noreferrer" target="_blank" title={title}>
+      {children}
+    </a>
+  ),
+  img: ({ alt, title }) => (
+    <span
+      aria-label={alt || "Referenced image"}
+      className="reader-markdown-image"
+      role="img"
+      title={title}
+    >
+      [Image: {alt || "unlabeled"}]
+    </span>
+  ),
+};
+
+export const MarkdownDocument = memo(function MarkdownDocument({
+  className = "reader-markdown",
+  components,
+  source,
+}: {
+  className?: string;
+  components?: Components;
+  source: string;
+}) {
+  return (
+    <div className={className}>
+      <ReactMarkdown
+        components={{ ...SAFE_MARKDOWN_COMPONENTS, ...components }}
+        remarkPlugins={[remarkGfm]}
+        skipHtml
+      >
+        {source}
+      </ReactMarkdown>
+    </div>
+  );
+});

--- a/web/src/docs-main.tsx
+++ b/web/src/docs-main.tsx
@@ -1,0 +1,18 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { DocsApp } from "./DocsApp.tsx";
+import "./styles/tokens.css";
+import "./styles/base.css";
+import "./styles/app.css";
+
+const rootElement = document.getElementById("docs-root");
+
+if (!rootElement) {
+  throw new Error("ResearchPocket could not find its reference root.");
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <DocsApp />
+  </StrictMode>,
+);

--- a/web/src/docs/catalog.ts
+++ b/web/src/docs/catalog.ts
@@ -1,0 +1,215 @@
+import contributingSource from "../../../CONTRIBUTING.md?raw";
+import overviewSource from "../../../README.md?raw";
+import releasePreview2Source from "../../../docs/releases/v2.0.0-preview.2.md?raw";
+import releasePreview3Source from "../../../docs/releases/v2.0.0-preview.3.md?raw";
+import releasePreview4Source from "../../../docs/releases/v2.0.0-preview.4.md?raw";
+import adrNativeCaptureSource from "../../../docs/v2/ADR_0001_NATIVE_BROWSER_CAPTURE.md?raw";
+import adrEnrichmentSource from "../../../docs/v2/ADR_0002_LINK_ENRICHMENT.md?raw";
+import adrOperationPacksSource from "../../../docs/v2/ADR_0003_OPERATION_PACKS.md?raw";
+import adrFirecrawlMarkdownSource from "../../../docs/v2/ADR_0004_BOUNDED_FIRECRAWL_MARKDOWN.md?raw";
+import adrUndoSource from "../../../docs/v2/ADR_0005_COMPENSATING_UNDO.md?raw";
+import cliSource from "../../../docs/v2/CLI.md?raw";
+import designSystemSource from "../../../docs/v2/DESIGN_SYSTEM.md?raw";
+import migrationSource from "../../../docs/v2/MIGRATION.md?raw";
+import productSource from "../../../docs/v2/PRODUCT.md?raw";
+import roadmapSource from "../../../docs/v2/ROADMAP.md?raw";
+import syncProtocolSource from "../../../docs/v2/SYNC_PROTOCOL.md?raw";
+import threatModelSource from "../../../docs/v2/THREAT_MODEL.md?raw";
+import webSource from "../../../docs/v2/WEB.md?raw";
+
+export interface ReferenceSection {
+  id: string;
+  label: string;
+}
+
+export interface ReferenceDocument {
+  description: string;
+  id: string;
+  section: string;
+  source: string;
+  sourcePath: string;
+  status: string;
+  title: string;
+}
+
+export const referenceSections: ReferenceSection[] = [
+  { id: "start", label: "Start here" },
+  { id: "guides", label: "Use ResearchPocket" },
+  { id: "reference", label: "Architecture and security" },
+  { id: "decisions", label: "Architecture decisions" },
+  { id: "project", label: "Project" },
+  { id: "releases", label: "Release archive" },
+];
+
+export const referenceDocuments: ReferenceDocument[] = [
+  {
+    description: "Install, build, capture, curate, synchronize, and understand the current V2 boundary.",
+    id: "overview",
+    section: "start",
+    source: overviewSource,
+    sourcePath: "README.md",
+    status: "Current",
+    title: "ResearchPocket overview",
+  },
+  {
+    description: "Complete command, option, capture, enrichment, TUI, synchronization, and output reference.",
+    id: "cli",
+    section: "guides",
+    source: cliSource,
+    sourcePath: "docs/v2/CLI.md",
+    status: "Current",
+    title: "CLI reference",
+  },
+  {
+    description: "Import a V1 library without mutating the source and verify authored-field preservation.",
+    id: "migration",
+    section: "guides",
+    source: migrationSource,
+    sourcePath: "docs/v2/MIGRATION.md",
+    status: "Current",
+    title: "V1 migration",
+  },
+  {
+    description: "Hosted owner application, browser persistence, offline boundary, and synchronization lifecycle.",
+    id: "hosted-owner",
+    section: "guides",
+    source: webSource,
+    sourcePath: "docs/v2/WEB.md",
+    status: "Current",
+    title: "Hosted owner app",
+  },
+  {
+    description: "The product vision, use cases, required surfaces, success criteria, and explicit non-goals.",
+    id: "product",
+    section: "reference",
+    source: productSource,
+    sourcePath: "docs/v2/PRODUCT.md",
+    status: "Canonical",
+    title: "Product contract",
+  },
+  {
+    description: "Normative immutable update, operation-pack, convergence, checkpoint, and recovery protocol.",
+    id: "sync-protocol",
+    section: "reference",
+    source: syncProtocolSource,
+    sourcePath: "docs/v2/SYNC_PROTOCOL.md",
+    status: "Normative",
+    title: "Synchronization protocol",
+  },
+  {
+    description: "Privacy goals, trust boundaries, credential handling, data flows, and threat mitigations.",
+    id: "threat-model",
+    section: "reference",
+    source: threatModelSource,
+    sourcePath: "docs/v2/THREAT_MODEL.md",
+    status: "Canonical",
+    title: "Privacy threat model",
+  },
+  {
+    description: "Canonical visual language, interaction patterns, accessibility, and deployment rules.",
+    id: "design-system",
+    section: "reference",
+    source: designSystemSource,
+    sourcePath: "docs/v2/DESIGN_SYSTEM.md",
+    status: "Canonical",
+    title: "Design system",
+  },
+  {
+    description: "Native browser capture through a versioned, provider-neutral invocation bridge.",
+    id: "adr-native-capture",
+    section: "decisions",
+    source: adrNativeCaptureSource,
+    sourcePath: "docs/v2/ADR_0001_NATIVE_BROWSER_CAPTURE.md",
+    status: "Accepted",
+    title: "ADR 0001 · Native capture",
+  },
+  {
+    description: "Retryable direct and Firecrawl metadata enrichment after durable local capture.",
+    id: "adr-enrichment",
+    section: "decisions",
+    source: adrEnrichmentSource,
+    sourcePath: "docs/v2/ADR_0002_LINK_ENRICHMENT.md",
+    status: "Accepted",
+    title: "ADR 0002 · Link enrichment",
+  },
+  {
+    description: "Transport many exact synchronization envelopes in one immutable bounded pack.",
+    id: "adr-operation-packs",
+    section: "decisions",
+    source: adrOperationPacksSource,
+    sourcePath: "docs/v2/ADR_0003_OPERATION_PACKS.md",
+    status: "Accepted",
+    title: "ADR 0003 · Operation packs",
+  },
+  {
+    description: "Retain bounded Firecrawl Markdown in the convergent excerpt register.",
+    id: "adr-firecrawl-markdown",
+    section: "decisions",
+    source: adrFirecrawlMarkdownSource,
+    sourcePath: "docs/v2/ADR_0004_BOUNDED_FIRECRAWL_MARKDOWN.md",
+    status: "Accepted",
+    title: "ADR 0004 · Firecrawl Markdown",
+  },
+  {
+    description: "Undo browser actions through convergence-safe compensating mutations.",
+    id: "adr-undo",
+    section: "decisions",
+    source: adrUndoSource,
+    sourcePath: "docs/v2/ADR_0005_COMPENSATING_UNDO.md",
+    status: "Accepted",
+    title: "ADR 0005 · Compensating undo",
+  },
+  {
+    description: "Contribution workflow, repository conventions, toolchain, and required local checks.",
+    id: "contributing",
+    section: "project",
+    source: contributingSource,
+    sourcePath: "CONTRIBUTING.md",
+    status: "Current",
+    title: "Contributing",
+  },
+  {
+    description: "Ordered V2 delivery phases, dependencies, acceptance gates, and planned work.",
+    id: "roadmap",
+    section: "project",
+    source: roadmapSource,
+    sourcePath: "docs/v2/ROADMAP.md",
+    status: "Planned",
+    title: "Delivery roadmap",
+  },
+  {
+    description: "Current preview release notes, operation-pack upgrade requirements, and downloads.",
+    id: "release-preview-4",
+    section: "releases",
+    source: releasePreview4Source,
+    sourcePath: "docs/releases/v2.0.0-preview.4.md",
+    status: "Latest release",
+    title: "v2.0.0-preview.4",
+  },
+  {
+    description: "Historical preview notes for enrichment, native capture, and hosted owner editing.",
+    id: "release-preview-3",
+    section: "releases",
+    source: releasePreview3Source,
+    sourcePath: "docs/releases/v2.0.0-preview.3.md",
+    status: "Historical",
+    title: "v2.0.0-preview.3",
+  },
+  {
+    description: "Historical preview notes for the first published V2 migration and sync release.",
+    id: "release-preview-2",
+    section: "releases",
+    source: releasePreview2Source,
+    sourcePath: "docs/releases/v2.0.0-preview.2.md",
+    status: "Historical",
+    title: "v2.0.0-preview.2",
+  },
+];
+
+export const referenceDocumentById = new Map(
+  referenceDocuments.map((document) => [document.id, document]),
+);
+
+export const referenceDocumentBySourcePath = new Map(
+  referenceDocuments.map((document) => [document.sourcePath, document]),
+);

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -3799,3 +3799,483 @@ kbd {
     gap: 0.75rem;
   }
 }
+
+/* Public reference guide */
+.docs-body,
+#docs-root,
+.docs-app {
+  height: 100dvh;
+  overflow: hidden;
+}
+
+.docs-app {
+  display: flex;
+  flex-direction: column;
+}
+
+.docs-header {
+  align-items: center;
+  border-bottom: var(--rule) solid var(--color-border-strong);
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: space-between;
+  min-height: 3.125rem;
+  padding: 0 1.25rem;
+  position: relative;
+  z-index: 40;
+}
+
+.docs-brand,
+.docs-header-actions {
+  align-items: center;
+  display: flex;
+}
+
+.docs-brand {
+  color: var(--color-text);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  gap: 0.625rem;
+  text-decoration: none;
+}
+
+.docs-brand small {
+  border-left: var(--rule) solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: 400;
+  margin-left: 0.125rem;
+  padding-left: 0.75rem;
+}
+
+.docs-header-actions {
+  gap: 1rem;
+}
+
+.docs-header-link {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.docs-header-link:hover,
+.docs-header-link:focus-visible {
+  color: var(--color-text);
+  text-decoration: underline;
+}
+
+.docs-open-app,
+.docs-menu-button {
+  align-items: center;
+  border: var(--rule) solid var(--color-border-strong);
+  border-radius: var(--radius);
+  display: inline-flex;
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  justify-content: center;
+  min-height: 2rem;
+  padding: 0 0.625rem;
+  text-decoration: none;
+}
+
+.docs-open-app {
+  background: var(--color-inverse-surface);
+  border-color: var(--color-inverse-surface);
+  color: var(--color-inverse);
+}
+
+.docs-menu-button {
+  background: transparent;
+  color: var(--color-text);
+  display: none;
+}
+
+.docs-layout {
+  display: grid;
+  flex: 1 1 auto;
+  grid-template-columns: 17rem minmax(0, 1fr) 15rem;
+  min-height: 0;
+}
+
+.docs-sidebar,
+.docs-outline,
+.docs-content {
+  min-height: 0;
+  min-width: 0;
+  overflow: auto;
+}
+
+.docs-sidebar {
+  border-right: var(--rule) solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+}
+
+.docs-search {
+  border-bottom: var(--rule) solid var(--color-border);
+  padding: 1rem;
+}
+
+.docs-search label,
+.docs-nav h2,
+.docs-outline h2 {
+  color: var(--color-accent-strong);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.docs-search > div {
+  align-items: center;
+  border: var(--rule) solid var(--color-border-strong);
+  border-radius: var(--radius);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  margin-top: 0.5rem;
+}
+
+.docs-search > div:focus-within {
+  outline: 0.1875rem solid var(--color-focus);
+  outline-offset: 0.1875rem;
+}
+
+.docs-search input {
+  background: transparent;
+  border: 0;
+  font-size: var(--font-size-sm);
+  min-width: 0;
+  outline: 0;
+}
+
+.docs-search kbd {
+  margin-right: 0.5rem;
+}
+
+.docs-search p {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  margin: 0.5rem 0 0;
+}
+
+.docs-nav {
+  flex: 1 0 auto;
+  padding: 0.5rem 0 1rem;
+}
+
+.docs-nav section + section {
+  border-top: var(--rule) solid var(--color-border-subtle);
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+}
+
+.docs-nav h2 {
+  margin: 0;
+  padding: 0.625rem 1rem 0.375rem;
+}
+
+.docs-nav a {
+  border-left: 0.125rem solid transparent;
+  color: var(--color-text-soft);
+  display: grid;
+  gap: 0.125rem;
+  min-height: 2.75rem;
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+}
+
+.docs-nav a:hover,
+.docs-nav a:focus-visible,
+.docs-nav a[aria-current="page"] {
+  background: var(--color-surface-raised);
+  border-left-color: var(--color-accent-strong);
+  color: var(--color-text);
+}
+
+.docs-nav a[aria-current="page"] {
+  font-weight: 700;
+}
+
+.docs-nav a span {
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-tight);
+}
+
+.docs-nav a small {
+  color: var(--color-text-soft);
+  font-size: var(--font-size-xs);
+  font-weight: 400;
+}
+
+.docs-search-empty {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  margin: 1rem;
+}
+
+.docs-content {
+  outline: 0;
+  overscroll-behavior-y: contain;
+  scrollbar-gutter: stable;
+}
+
+.docs-article {
+  margin: 0 auto;
+  max-width: 58rem;
+  padding: 1.75rem clamp(1.5rem, 5vw, 4rem) 4rem;
+}
+
+.docs-document-meta {
+  align-items: center;
+  border-bottom: var(--rule) solid var(--color-border);
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1.75rem;
+  min-height: 2.5rem;
+}
+
+.docs-document-meta > div {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.docs-document-meta span,
+.docs-document-meta strong,
+.docs-document-meta a {
+  font-size: var(--font-size-xs);
+}
+
+.docs-document-meta span {
+  color: var(--color-text-muted);
+}
+
+.docs-document-meta strong {
+  color: var(--color-accent-strong);
+  font-weight: 700;
+}
+
+.docs-document-meta a {
+  color: var(--color-text-muted);
+}
+
+.docs-markdown {
+  color: var(--color-text-reader);
+  font-size: 0.9375rem;
+  line-height: 1.7;
+}
+
+.docs-markdown h1,
+.docs-markdown h2,
+.docs-markdown h3,
+.docs-markdown h4,
+.docs-markdown h5,
+.docs-markdown h6 {
+  scroll-margin-top: 1rem;
+}
+
+.docs-markdown h1 {
+  color: var(--color-text);
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  letter-spacing: -0.045em;
+  line-height: 1.05;
+  max-width: 24ch;
+}
+
+.docs-markdown h2 {
+  color: var(--color-text);
+  font-size: 1.25rem;
+  letter-spacing: -0.02em;
+  margin-top: 2.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.docs-markdown h3 {
+  color: var(--color-text);
+  font-size: 1rem;
+  margin-top: 2rem;
+}
+
+.docs-markdown h4,
+.docs-markdown h5,
+.docs-markdown h6 {
+  color: var(--color-text);
+}
+
+.docs-markdown p,
+.docs-markdown li {
+  max-width: var(--measure);
+}
+
+.docs-markdown pre {
+  max-width: 100%;
+}
+
+.docs-markdown table {
+  font-size: var(--font-size-sm);
+}
+
+.docs-markdown blockquote {
+  background: var(--color-reader-note);
+  border-left-color: var(--color-accent);
+  margin-left: 0;
+  padding: 0.75rem 1rem;
+}
+
+.docs-markdown blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.docs-pagination {
+  border-top: var(--rule) solid var(--color-border-strong);
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 3rem;
+  padding-top: 1rem;
+}
+
+.docs-pagination a {
+  color: var(--color-text);
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+  text-decoration: none;
+}
+
+.docs-pagination a:last-child {
+  text-align: right;
+}
+
+.docs-pagination a:hover span,
+.docs-pagination a:focus-visible span {
+  color: var(--color-accent-strong);
+  text-decoration: underline;
+}
+
+.docs-pagination small {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.docs-pagination span {
+  font-size: var(--font-size-sm);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.docs-outline {
+  border-left: var(--rule) solid var(--color-border);
+  padding: 1.25rem 1rem;
+}
+
+.docs-outline nav {
+  display: grid;
+}
+
+.docs-outline h2 {
+  margin: 0 0 0.625rem;
+}
+
+.docs-outline a {
+  border-left: var(--rule) solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  line-height: 1.35;
+  padding: 0.4rem 0 0.4rem 0.75rem;
+  text-decoration: none;
+}
+
+.docs-outline a:hover,
+.docs-outline a:focus-visible {
+  border-left-color: var(--color-accent-strong);
+  color: var(--color-text);
+}
+
+.docs-outline .docs-outline-nested {
+  padding-left: 1.5rem;
+}
+
+@media (max-width: 68rem) {
+  .docs-layout {
+    grid-template-columns: 16rem minmax(0, 1fr);
+  }
+
+  .docs-outline {
+    display: none;
+  }
+}
+
+@media (max-width: 48rem) {
+  .docs-header {
+    padding: 0 0.75rem;
+  }
+
+  .docs-brand small,
+  .docs-header-link {
+    display: none;
+  }
+
+  .docs-header-actions {
+    gap: 0.5rem;
+  }
+
+  .docs-menu-button {
+    display: inline-flex;
+  }
+
+  .docs-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .docs-sidebar {
+    background: var(--color-canvas);
+    border-right: 0;
+    display: none;
+    inset: 3.125rem 0 0;
+    position: fixed;
+    z-index: 30;
+  }
+
+  .docs-sidebar[data-open="true"] {
+    display: flex;
+  }
+
+  .docs-content {
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .docs-article {
+    padding: 1rem 1rem 3rem;
+  }
+
+  .docs-document-meta {
+    align-items: flex-start;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .docs-document-meta > div {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+
+  .docs-markdown {
+    font-size: 0.875rem;
+  }
+
+  .docs-markdown h1 {
+    font-size: 1.625rem;
+  }
+
+  .docs-pagination {
+    grid-template-columns: 1fr;
+  }
+
+  .docs-pagination a:last-child {
+    text-align: left;
+  }
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -42,6 +42,7 @@ export default defineConfig(({ command }) => {
       rollupOptions: {
         input: {
           app: "app/index.html",
+          docs: "docs/index.html",
           landing: "index.html",
           overview: "overview/index.html",
         },
@@ -51,5 +52,10 @@ export default defineConfig(({ command }) => {
     },
     html: nonce ? { cspNonce: nonce } : undefined,
     plugins: [react(), ...(nonce ? [developmentCsp(nonce)] : [])],
+    server: {
+      fs: {
+        allow: [".."],
+      },
+    },
   };
 });


### PR DESCRIPTION
Closes #5

## Summary
- add a public React reference reader at `/docs/` backed by an explicit allowlist of 18 checked-in Markdown documents
- provide full-text page filtering, grouped navigation, source-aware internal links, stable heading anchors, browser history, adjacent-page navigation, and per-page outlines
- preserve the ResearchPocket visual system across desktop and mobile layouts
- expose the guide through the welcome, overview, sitemap, and `llms.txt`
- keep internal agent instructions, spikes, unpublished release notes, and asset-maintainer notes outside the public bundle

## User-visible impact
The complete current guide, architecture/security references, ADR archive, contributor guidance, roadmap, and published preview release notes are available from the website without browsing repository files. The guide works from 320 px mobile layouts through wide desktop screens.

## Privacy and protocol impact
No synchronization or domain protocol changes. The docs entry initializes no IndexedDB, WASM, synchronization, credentials, analytics, or service worker. The owner service worker now traverses only the owner app manifest dependency closure so it does not pre-cache the documentation corpus. Raw Markdown HTML stays disabled and remote images render as inert text placeholders.

## Deployment
- add the fourth Vite/Pages entry at `web/docs/index.html`
- extend CSP, artifact, manifest-boundary, sitemap, and design-system checks
- rename the Pages workflow labels to cover the complete website

## Verification
- `npm run verify`
- production artifact checks passed for 26 files
- all 18 allowlisted documents rendered with heading IDs
- source-relative Markdown links and fragments verified in-browser
- owner app verified at 320 px with no docs source requests
- docs verified at 320, 390, and wide desktop widths with no horizontal page overflow
- mobile drawer, `/` search shortcut, Escape focus return, history, and direct fragment loads verified
- Lighthouse mobile: Accessibility 100, Best Practices 100, SEO 100, Agentic Browsing 100
- Lighthouse desktop: Accessibility 100, Best Practices 100, SEO 100, Agentic Browsing 100