### PR TITLE
Add product showcase video

### DIFF
--- a/web/overview/index.html
+++ b/web/overview/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; base-uri 'none'; connect-src 'self' https://api.github.com; font-src 'self'; form-action 'none'; frame-src 'none'; img-src 'self'; manifest-src 'self'; object-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; worker-src 'self'; upgrade-insecure-requests"
+      content="default-src 'none'; base-uri 'none'; connect-src 'self' https://api.github.com; font-src 'self'; form-action 'none'; frame-src https://www.youtube-nocookie.com; img-src 'self'; manifest-src 'self'; object-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; worker-src 'self'; upgrade-insecure-requests"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark" />
@@ -48,6 +48,28 @@
         <div class="overview-actions">
           <a class="primary-link" href="../app/#new">Start a new library</a>
           <a class="secondary-link" href="../docs/">Read the reference</a>
+        </div>
+      </section>
+
+      <section class="overview-showcase" aria-labelledby="showcase-heading">
+        <div class="overview-showcase-copy">
+          <p class="eyebrow">38-second tour</p>
+          <h2 id="showcase-heading">From one-keystroke capture to private sync.</h2>
+          <p>
+            See the browser and terminal share one local-first library, with no
+            ResearchPocket server or tracking in the owner app.
+          </p>
+          <a href="https://www.youtube.com/watch?v=cZYZyPp90xE">Watch on YouTube</a>
+        </div>
+        <div class="overview-video">
+          <iframe
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+            loading="lazy"
+            referrerpolicy="strict-origin-when-cross-origin"
+            src="https://www.youtube-nocookie.com/embed/cZYZyPp90xE"
+            title="ResearchPocket local-first save-it-later product tour"
+          ></iframe>
         </div>
       </section>
 

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -3775,6 +3775,51 @@ kbd {
   margin-top: 1.5rem;
 }
 
+.overview-showcase {
+  align-items: center;
+  border-bottom: var(--rule) solid var(--color-border-strong);
+  display: grid;
+  gap: clamp(2rem, 6vw, 5rem);
+  grid-template-columns: minmax(14rem, 0.55fr) minmax(0, 1fr);
+  padding: clamp(3.5rem, 7vw, 6rem) 0;
+}
+
+.overview-showcase h2 {
+  font-size: clamp(1.5rem, 3vw, 2.5rem);
+  letter-spacing: -0.04em;
+  line-height: 1.05;
+  margin: 0;
+  max-width: 18ch;
+}
+
+.overview-showcase-copy > p:not(.eyebrow) {
+  color: var(--color-text-soft);
+  font-size: var(--font-size-sm);
+  line-height: 1.6;
+  margin: 1rem 0 0;
+}
+
+.overview-showcase-copy > a {
+  display: inline-block;
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  margin-top: 1rem;
+}
+
+.overview-video {
+  aspect-ratio: 16 / 9;
+  background: var(--color-surface);
+  border: var(--rule) solid var(--color-border-strong);
+  width: 100%;
+}
+
+.overview-video iframe {
+  border: 0;
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
 .overview-grid {
   border-bottom: var(--rule) solid var(--color-border-strong);
   display: grid;
@@ -3859,6 +3904,7 @@ kbd {
 }
 
 @media (max-width: 48rem) {
+  .overview-showcase,
   .overview-grid,
   .overview-details {
     grid-template-columns: 1fr;


### PR DESCRIPTION
Closes #89

## Summary
- add the 38-second ResearchPocket launch reel to the public product overview
- use YouTube privacy-enhanced mode with lazy loading and a direct fallback link
- keep the owner app third-party-free and make the showcase responsive on mobile

## User-visible impact
The public overview now includes an inline browser and terminal product tour.

## Protocol and privacy impact
No domain, persistence, sync, or publication schema changes. Only the public overview CSP permits the `youtube-nocookie.com` frame origin.

## Verification
- `npm run verify`
- desktop browser check: embed loaded with HTTP 200 and no console warnings or errors
- mobile browser check at 390px: single-column layout with no horizontal overflow