### PR TITLE
Simplify social metadata

### DIFF
--- a/web/app/index.html
+++ b/web/app/index.html
@@ -16,7 +16,7 @@
     <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" href="../favicon.png" type="image/png" />
     <link rel="manifest" href="../manifest.webmanifest" />
-    <title>ResearchPocket Owner — private library</title>
+    <title>ResearchPocket Owner: private library</title>
   </head>
   <body>
     <noscript>

--- a/web/docs/index.html
+++ b/web/docs/index.html
@@ -16,7 +16,7 @@
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://researchpocket.github.io/docs/" />
     <link rel="icon" href="../favicon.png" type="image/png" />
-    <title>Reference guide — ResearchPocket</title>
+    <title>Reference guide: ResearchPocket</title>
   </head>
   <body class="docs-body">
     <noscript>

--- a/web/index.html
+++ b/web/index.html
@@ -11,15 +11,15 @@
     <meta name="theme-color" content="#1a150c" />
     <meta
       name="description"
-      content="ResearchPocket is a private, local-first library for the useful links you choose to keep. Capture, curate, search, and sync without a hosted backend."
+      content="Keep useful links, notes, and sources in a private library on your own device. Add sync only when you need another device."
     />
     <meta name="robots" content="index, follow" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="ResearchPocket" />
-    <meta property="og:title" content="ResearchPocket — useful links, kept yours" />
+    <meta property="og:title" content="ResearchPocket" />
     <meta
       property="og:description"
-      content="A human-first, local-first library for the useful links you choose to keep."
+      content="Keep useful links, notes, and sources in a private library on your own device."
     />
     <meta
       property="og:url"
@@ -30,10 +30,10 @@
       content="https://researchpocket.github.io/og.png"
     />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="ResearchPocket — useful links, kept yours" />
+    <meta name="twitter:title" content="ResearchPocket" />
     <meta
       name="twitter:description"
-      content="A human-first, local-first library for the useful links you choose to keep."
+      content="Keep useful links, notes, and sources in a private library on your own device."
     />
     <meta
       name="twitter:image"
@@ -48,7 +48,7 @@
     <link rel="stylesheet" href="/src/styles/tokens.css" />
     <link rel="stylesheet" href="/src/styles/base.css" />
     <link rel="stylesheet" href="/src/styles/app.css" />
-    <title>ResearchPocket — a private, local-first link library</title>
+    <title>ResearchPocket: private link library</title>
   </head>
   <body class="landing-body">
     <main class="landing-welcome" id="content">

--- a/web/overview/index.html
+++ b/web/overview/index.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" href="/src/styles/tokens.css" />
     <link rel="stylesheet" href="/src/styles/base.css" />
     <link rel="stylesheet" href="/src/styles/app.css" />
-    <title>Product overview — ResearchPocket</title>
+    <title>Product overview: ResearchPocket</title>
   </head>
   <body class="overview-body">
     <a class="skip-link" href="#overview">Skip to overview</a>

--- a/web/src/DocsApp.tsx
+++ b/web/src/DocsApp.tsx
@@ -81,7 +81,7 @@ export function DocsApp() {
   }, []);
 
   useEffect(() => {
-    document.title = `${selectedDocument.title} — ResearchPocket reference`;
+    document.title = `${selectedDocument.title}: ResearchPocket reference`;
     const canonical = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
     const description = document.querySelector<HTMLMetaElement>('meta[name="description"]');
     if (canonical) {


### PR DESCRIPTION
## Summary

- replace promotional social-title copy with the project name
- describe the local library directly in standard, Open Graph, and Twitter metadata
- replace em dashes in document titles with plain punctuation

## User-visible impact

Link previews now describe ResearchPocket as a private place for useful links, notes, and sources on the owner device. Browser titles use straightforward labels without em dashes.

## Protocol and privacy impact

No application, persistence, authentication, or protocol behavior changes.

## Verification

- `npm test`
- `npm run build`
- production artifact scan passed

Closes #98