### PR TITLE
Publish ResearchPocket 2.0.1 through Cargo and simplify docs

### DIFF
--- a/.github/workflows/cargo-release.yml
+++ b/.github/workflows/cargo-release.yml
@@ -1,0 +1,169 @@
+name: Publish Cargo workspace
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Stable release tag (for example, v2.0.1)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-publish:
+    name: Publish ${{ inputs.tag }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out tagged sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
+        with:
+          toolchain: 1.97.0
+
+      - name: Verify tag, versions, and public GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="$RELEASE_TAG"
+          version="${tag#v}"
+
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Cargo publication requires a stable v-prefixed semantic version tag." >&2
+            exit 1
+          fi
+
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "Cargo release tags must belong to protected main." >&2
+            exit 1
+          fi
+
+          package_report="$(
+            cargo metadata --locked --no-deps --format-version 1 |
+              jq -r --arg version "$version" '
+                [.packages[]
+                  | select(.name == "research"
+                      or .name == "research-domain"
+                      or .name == "research-store")]
+                | if length != 3 then
+                    "expected three release packages"
+                  elif any(.version != $version) then
+                    map("\(.name)=\(.version)") | join(", ")
+                  else
+                    empty
+                  end'
+          )"
+          if [[ -n "$package_report" ]]; then
+            echo "Package versions do not match $version: $package_report" >&2
+            exit 1
+          fi
+
+          release="$(gh release view "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json isDraft,isPrerelease,tagName)"
+          if [[ "$(jq -r '.isDraft' <<<"$release")" != false ||
+                "$(jq -r '.isPrerelease' <<<"$release")" != false ||
+                "$(jq -r '.tagName' <<<"$release")" != "$tag" ]]; then
+            echo "Publish and verify the matching stable GitHub release first." >&2
+            exit 1
+          fi
+
+      - name: Publish exact workspace packages
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$RELEASE_TAG"
+          version="${version#v}"
+          user_agent='ResearchPocket cargo release (https://github.com/ResearchPocket/researchpocket.github.io)'
+
+          remote_checksum() {
+            local crate_name="$1"
+            curl --fail --silent --show-error \
+              --user-agent "$user_agent" \
+              "https://crates.io/api/v1/crates/$crate_name" 2>/dev/null |
+              jq -r --arg version "$version" \
+                '.versions[]? | select(.num == $version) | .checksum' |
+              head -n 1
+          }
+
+          publish_one() {
+            local crate_name="$1"
+            local archive="target/package/$crate_name-$version.crate"
+            local packaged=false
+            for package_attempt in {1..10}; do
+              if cargo package --locked --no-verify -p "$crate_name"; then
+                packaged=true
+                break
+              fi
+              if [[ "$package_attempt" -eq 10 ]]; then
+                echo "Failed to package $crate_name $version after registry retries." >&2
+                return 1
+              fi
+              sleep 15
+            done
+            if [[ "$packaged" != true ]]; then
+              return 1
+            fi
+            local expected_checksum
+            expected_checksum="$(sha256sum "$archive" | cut -d ' ' -f 1)"
+
+            for attempt in {1..10}; do
+              local existing_checksum
+              existing_checksum="$(remote_checksum "$crate_name" || true)"
+              if [[ -n "$existing_checksum" ]]; then
+                if [[ "$existing_checksum" == "$expected_checksum" ]]; then
+                  echo "$crate_name $version already exists with the expected checksum."
+                  return 0
+                fi
+                echo "$crate_name $version exists with different bytes." >&2
+                return 1
+              fi
+
+              if cargo publish --locked -p "$crate_name"; then
+                echo "Uploaded $crate_name $version; waiting for registry visibility."
+              elif [[ "$attempt" -eq 10 ]]; then
+                echo "Failed to publish $crate_name $version after bounded retries." >&2
+                return 1
+              fi
+              sleep 15
+            done
+
+            echo "$crate_name $version did not become visible with the expected checksum." >&2
+            return 1
+          }
+
+          publish_one research-domain
+          publish_one research-store
+          publish_one research
+
+      - name: Install the published CLI
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$RELEASE_TAG"
+          version="${version#v}"
+          install_root="$RUNNER_TEMP/research-cargo-install"
+          cargo install --locked --version "=$version" --root "$install_root" research
+          if [[ "$("$install_root/bin/research" --version)" != "research $version" ]]; then
+            echo "The installed registry binary does not match the release version." >&2
+            exit 1
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "research"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "base64",
  "chrono",
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "research-domain"
-version = "0.0.0"
+version = "2.0.1"
 dependencies = [
  "base64",
  "chrono",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "research-store"
-version = "0.0.0"
+version = "2.0.1"
 dependencies = [
  "chrono",
  "research-domain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 rust-version = "1.94"
 keywords = ["bookmarks", "reading-list", "local-first", "knowledge", "cli"]
@@ -22,8 +22,8 @@ crossterm = "0.29.0"
 directories = "6.0.0"
 ratatui = { version = "0.30.2", default-features = false, features = ["crossterm_0_29"] }
 reqwest = { version = "0.13.4", features = ["json"] }
-research-domain = { path = "crates/research-domain" }
-research-store = { path = "crates/research-store" }
+research-domain = { version = "=2.0.1", path = "crates/research-domain" }
+research-store = { version = "=2.0.1", path = "crates/research-store" }
 scraper = "0.27.0"
 serde = "1.0.228"
 serde_json = "1.0.150"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ existing library** before adding anything on the new device.
 
 ### From the terminal
 
-Download the archive for your platform from the
+If Rust is installed, install the current CLI directly from crates.io:
+
+```sh
+cargo install --locked research
+```
+
+Alternatively, download the archive for your platform from the
 [release page](https://github.com/ResearchPocket/researchpocket.github.io/releases),
 check it against `SHA256SUMS`, and put `research` or `research.exe` somewhere on
 your `PATH`.
@@ -59,7 +65,7 @@ accept one, install [Rust](https://www.rust-lang.org/tools/install) and build th
 matching release tag from source instead of weakening system-wide security:
 
 ```sh
-git clone --branch v2.0.0 --depth 1 \
+git clone --branch v2.0.1 --depth 1 \
   https://github.com/ResearchPocket/researchpocket.github.io.git
 cd researchpocket.github.io
 cargo build --locked --release

--- a/crates/research-domain/Cargo.toml
+++ b/crates/research-domain/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "research-domain"
-version = "0.0.0"
+version = "2.0.1"
 edition = "2024"
 rust-version = "1.94"
-publish = false
+authors = ["KorigamiK <korigamik.is-a.dev>"]
+license = "Apache-2.0"
+repository = "https://github.com/ResearchPocket/researchpocket.github.io"
+description = "Shared CRDT domain and immutable synchronization protocol for ResearchPocket."
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/research-store/Cargo.toml
+++ b/crates/research-store/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
 name = "research-store"
-version = "0.0.0"
+version = "2.0.1"
 edition = "2024"
 rust-version = "1.94"
-publish = false
+authors = ["KorigamiK <korigamik.is-a.dev>"]
+license = "Apache-2.0"
+repository = "https://github.com/ResearchPocket/researchpocket.github.io"
+description = "Local SQLite projection, import, enrichment, and outbox for ResearchPocket."
 
 [dependencies]
 chrono = { version = "0.4.45", default-features = false, features = ["clock", "serde"] }
-research-domain = { path = "../research-domain" }
+research-domain = { version = "=2.0.1", path = "../research-domain" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 sha2 = "0.11.0"

--- a/docs/releases/v2.0.1.md
+++ b/docs/releases/v2.0.1.md
@@ -1,0 +1,63 @@
+# ResearchPocket 2.0.1
+
+ResearchPocket 2.0.1 makes the stable CLI available through Cargo and turns the
+public reference into a shorter, reader-focused guide.
+
+## Install
+
+With Rust installed:
+
+```sh
+cargo install --locked research
+```
+
+Or download the verified archive for Linux, macOS, or Windows from the GitHub
+release and check it against `SHA256SUMS`.
+
+## What changed
+
+- The `research`, `research-domain`, and `research-store` crates now publish
+  from one exact release tag in dependency order. Exact-version requirements
+  ensure a Cargo installation uses the reviewed domain and store source from
+  the same release.
+- The public docs show only getting started, usage, migration, browser,
+  data/sync/security, and current-release material.
+- Internal ADRs, governance/project material, design-system documentation, and
+  historical preview notes remain in the repository but no longer crowd the
+  reader guide or its search results.
+- Fenced code blocks have bundled language-aware highlighting and an accessible
+  copy button with visible and announced feedback.
+
+There is no domain, CRDT, synchronization protocol, SQLite, or machine-output
+schema change in this patch.
+
+## Upgrade
+
+Replace the 2.0.0 binary or run:
+
+```sh
+cargo install --locked --force research
+research --version
+```
+
+The expected version is `research 2.0.1`. Existing 2.0.0 libraries and private
+repositories require no migration.
+
+## GitHub release archives
+
+| Platform | Release asset |
+| --- | --- |
+| Linux GNU/glibc x86-64 (glibc 2.35 or newer) | `research-v2.0.1-linux-amd64.tar.gz` |
+| Windows x86-64 | `research-v2.0.1-windows-amd64.zip` |
+| macOS Intel | `research-v2.0.1-macos-amd64.tar.gz` |
+| macOS Apple Silicon | `research-v2.0.1-macos-arm64.tar.gz` |
+
+The archives remain unsigned. Verify the selected file with `SHA256SUMS`, or
+build the exact tag with the pinned toolchain:
+
+```sh
+git clone --branch v2.0.1 --depth 1 \
+  https://github.com/ResearchPocket/researchpocket.github.io.git
+cd researchpocket.github.io
+cargo build --locked --release
+```

--- a/docs/v2/ADR_0006_STAGED_V2_PARITY.md
+++ b/docs/v2/ADR_0006_STAGED_V2_PARITY.md
@@ -51,6 +51,10 @@ release requires an explicit workspace-publication design; it must not silently
 publish internal crates or substitute registry versions for reviewed path
 dependencies.
 
+[ADR 0007](./ADR_0007_CARGO_WORKSPACE_PUBLICATION.md) subsequently defines that
+workspace-publication design for patch release 2.0.1. This paragraph remains
+the distribution decision for the immutable 2.0.0 tag.
+
 The binary release workflow continues to stage every tag as a draft. Tags
 containing a prerelease suffix are marked prerelease; stable tags are not.
 Maintainers inspect artifacts and checksums before publishing a stable draft as
@@ -65,8 +69,9 @@ latest.
 - Users who need local loopback serving, collections, selective publication,
   broader import/export, or repository profiles must wait for a later release.
 - The `research` crate on crates.io remains on its historical version; 2.0
-  installation instructions point only to verified GitHub assets or tagged
-  source.
+  installation instructions initially point only to verified GitHub assets or
+  tagged source. Patch release 2.0.1 supersedes this consequence through ADR
+  0007.
 - No protocol version, CRDT schema, SQLite schema, or immutable update bytes
   change solely because of the stable version label.
 

--- a/docs/v2/ADR_0007_CARGO_WORKSPACE_PUBLICATION.md
+++ b/docs/v2/ADR_0007_CARGO_WORKSPACE_PUBLICATION.md
@@ -1,0 +1,70 @@
+# ADR 0007: Publish the Cargo workspace in dependency order
+
+- Status: accepted
+- Date: 2026-07-24
+- Issue: [#108](https://github.com/ResearchPocket/researchpocket.github.io/issues/108)
+- Supersedes: the 2.0.0-only distribution decision in
+  [ADR 0006](./ADR_0006_STAGED_V2_PARITY.md)
+
+## Context
+
+The historical `research` crate predates the V2 workspace. V2 separates the
+shared CRDT/protocol implementation into `research-domain` and local
+persistence into `research-store`. Both were private version `0.0.0` path
+dependencies, so crates.io could not package or verify the root binary.
+
+Publishing only the root crate would cause Cargo to remove its path
+dependencies and resolve unrelated or missing registry packages. Publishing
+placeholder internal crates would create the same risk while making an
+accidental compatibility promise.
+
+## Decision
+
+Publish three Apache-2.0 crates from one exact protected-main tag:
+
+1. `research-domain`;
+2. `research-store`, with an exact-version dependency on `research-domain`; and
+3. `research`, with exact-version dependencies on both internal crates.
+
+All three use the product release version and move in lockstep. Local workspace
+builds retain path dependencies, while published packages require that same
+exact registry version. The internal crates are implementation packages, not
+independently versioned product extension points.
+
+The Cargo publication workflow is manual and may run only after the matching
+GitHub release is public. It verifies that:
+
+- the tag belongs to protected `main`;
+- the tag, every package, and the public GitHub release use the same version;
+- all packages can be assembled from the clean tagged tree;
+- an existing registry version has the same crate checksum before it is treated
+  as an idempotent success; and
+- publication proceeds in dependency order with bounded retries for registry
+  propagation.
+
+After publication, the workflow installs the exact `research` version from
+crates.io and confirms the binary version. A different checksum at an existing
+name/version is an integrity failure.
+
+## Consequences
+
+- `cargo install --locked research` becomes a supported installation path from
+  version 2.0.1 onward.
+- The internal domain and store source is packaged publicly under the same
+  license and tag as the binary.
+- A release cannot publish only one workspace crate and still be considered
+  complete.
+- Future package changes must preserve lockstep versions or replace this ADR
+  with a reviewed compatibility and release-order plan.
+- Registry publication remains downstream of the verified GitHub release;
+  crates.io is not the source of tag, release-note, or artifact truth.
+
+## Verification
+
+- Run `cargo package --locked` or `cargo publish --dry-run --locked` for each
+  package at the point its exact dependencies are available.
+- Verify packaged source excludes credentials, local databases, build output,
+  and private protocol data.
+- Publish through the pinned workflow and confirm remote checksums.
+- Install the exact registry version into an empty Cargo root and confirm
+  `research --version`.

--- a/docs/v2/DATA_AND_PRIVACY.md
+++ b/docs/v2/DATA_AND_PRIVACY.md
@@ -1,0 +1,104 @@
+# Your data, sync, and privacy
+
+ResearchPocket is local first. Saving, editing, searching, deleting, and
+restoring links does not require a ResearchPocket account or an always-running
+server.
+
+## Where the library lives
+
+The native CLI and TUI keep their working library in the platform data
+directory. SQLite makes local search and editing fast, but it is not copied to
+GitHub and is not the synchronization format.
+
+The browser app keeps its local copy and pending changes in IndexedDB for that
+browser profile. Clearing site data removes that local copy, so connect private
+sync before relying on the browser as the only home for a library.
+
+An optional private GitHub repository stores immutable synchronization updates.
+Only people and credentials with access to that repository can read them.
+
+## How synchronization works
+
+Every save or edit commits locally first and creates an immutable update for
+later delivery. A client pulls unseen updates, applies them through the shared
+ResearchPocket data model, and then uploads its queued updates.
+
+GitHub stores and transports those files. Git commit order, merges, rebases,
+timestamps, and branch history never decide which title, note, tag, or lifecycle
+state wins.
+
+This gives ResearchPocket a few useful properties:
+
+- editing can continue offline;
+- retries and duplicate downloads do not duplicate a change;
+- concurrent note edits preserve text from both clients;
+- repository races keep local changes queued instead of asking for a Git merge;
+- changed bytes at an existing immutable path stop sync as an integrity error;
+  and
+- saving the same URL twice keeps two separate items.
+
+Run sync explicitly:
+
+```sh
+research sync run
+```
+
+Or keep it active in the foreground:
+
+```sh
+research --format ndjson sync run --every 60
+```
+
+## Credentials
+
+Native GitHub credentials belong in the operating-system credential store or a
+separate local credential file. They never belong in SQLite, link metadata,
+notes, synchronization updates, exports, or a public repository.
+
+The browser app keeps its fine-grained GitHub token in memory by default.
+Optional session storage lasts only for the current browser session. The token
+is never stored in localStorage, IndexedDB, a URL, generated output, analytics,
+or the service-worker cache.
+
+Use a fine-grained token limited to the one private data repository with
+Contents read/write access. Do not give that token access to unrelated
+repositories.
+
+## Enrichment privacy
+
+Direct enrichment fetches the saved public URL from the current device.
+ResearchPocket rejects private and special network addresses and applies
+redirect, size, and timeout limits.
+
+Firecrawl is an explicit third-party option. When selected, the target URL is
+sent to the configured Firecrawl service. The credential remains local and is
+not written into the library or synchronization data.
+
+The browser-capture URI never accepts a provider or credential.
+
+## Backups and recovery
+
+Before an upgrade that includes a migration, close every ResearchPocket process
+and copy the complete native data directory to offline storage. Release notes
+call out migrations and coordinated upgrades.
+
+A private sync repository provides remote durability, but it is not a
+substitute for every backup:
+
+- keep the original V1 database after import;
+- retain an offline backup before a coordinated protocol upgrade;
+- do not edit or delete immutable operation files by hand; and
+- treat a changed immutable path as a possible corruption or credential
+  compromise.
+
+On a new browser profile, choose **Restore an existing library** before making
+the first local edit. On a new native device, initialize the intended data
+directory, connect it to the existing private repository, and synchronize.
+
+## Public sharing
+
+ResearchPocket 2.0.1 does not publish selected collections. The hosted browser
+app is a private owner surface, not a public library.
+
+Never place a private database, token, synchronization update, operation pack,
+credential file, or unredacted export in a public repository or issue.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "research-pocket-web",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "research-pocket-web",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
+        "highlight.js": "11.11.1",
         "idb": "8.0.3",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -1074,6 +1075,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/html-url-attributes": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "research-pocket-web",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "dev": "npm run wasm && vite",
@@ -15,6 +15,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "highlight.js": "11.11.1",
     "idb": "8.0.3",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/web/src/DocsApp.tsx
+++ b/web/src/DocsApp.tsx
@@ -1,4 +1,6 @@
 import {
+  Children,
+  isValidElement,
   type MouseEvent as ReactMouseEvent,
   useDeferredValue,
   useEffect,
@@ -7,6 +9,7 @@ import {
   useState,
 } from "react";
 import type { Components } from "react-markdown";
+import { HighlightedCodeBlock } from "./components/HighlightedCodeBlock.tsx";
 import { MarkdownDocument } from "./components/MarkdownDocument.tsx";
 import {
   type ReferenceDocument,
@@ -51,7 +54,7 @@ export function DocsApp() {
     () =>
       normalizedQuery
         ? referenceDocuments.filter((document) =>
-            [document.title, document.description, document.status, document.source]
+            [document.title, document.description, document.source]
               .join("\n")
               .toLocaleLowerCase()
               .includes(normalizedQuery),
@@ -81,7 +84,7 @@ export function DocsApp() {
   }, []);
 
   useEffect(() => {
-    document.title = `${selectedDocument.title}: ResearchPocket reference`;
+    document.title = `${selectedDocument.title}: ResearchPocket docs`;
     const canonical = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
     const description = document.querySelector<HTMLMetaElement>('meta[name="description"]');
     if (canonical) {
@@ -174,14 +177,14 @@ export function DocsApp() {
   return (
     <div className="docs-app">
       <a className="skip-link" href="#docs-content">
-        Skip to reference
+        Skip to guide
       </a>
 
       <header className="docs-header">
         <a className="docs-brand" href="../">
           <span aria-hidden="true" className="brand-mark">rp</span>
           <span>ResearchPocket</span>
-          <small>Reference</small>
+          <small>Docs</small>
         </a>
         <nav aria-label="Site navigation" className="docs-header-actions">
           <a className="docs-header-link" href="../overview/">Overview</a>
@@ -212,13 +215,13 @@ export function DocsApp() {
           id="docs-navigation"
         >
           <div className="docs-search">
-            <label htmlFor="docs-search">Find a page</label>
+            <label htmlFor="docs-search">Search docs</label>
             <div>
               <input
                 autoComplete="off"
                 id="docs-search"
                 onChange={(event) => setQuery(event.target.value)}
-                placeholder="Search the reference"
+                placeholder="Search the guide"
                 ref={searchRef}
                 type="search"
                 value={query}
@@ -228,7 +231,7 @@ export function DocsApp() {
             <p>{matchingDocuments.length} of {referenceDocuments.length} pages</p>
           </div>
 
-          <nav aria-label="Reference pages" className="docs-nav">
+          <nav aria-label="Guide pages" className="docs-nav">
             {referenceSections.map((section) => {
               const sectionDocuments = matchingDocuments.filter(
                 (document) => document.section === section.id,
@@ -245,7 +248,6 @@ export function DocsApp() {
                       onClick={(event) => handleDocumentClick(event, document.id)}
                     >
                       <span>{document.title}</span>
-                      <small>{document.status}</small>
                     </a>
                   ))}
                 </section>
@@ -266,14 +268,6 @@ export function DocsApp() {
           tabIndex={-1}
         >
           <article className="docs-article">
-            <header className="docs-document-meta">
-              <div>
-                <span>{sectionLabel(selectedDocument.section)}</span>
-                <strong>{selectedDocument.status}</strong>
-              </div>
-              <a href={`${SOURCE_ROOT}${selectedDocument.sourcePath}`}>View source ↗</a>
-            </header>
-
             <MarkdownDocument
               className="reader-markdown docs-markdown"
               components={markdownComponents}
@@ -385,6 +379,19 @@ function createMarkdownComponents(
     h6: ({ children, node, ...props }) => (
       <h6 {...props} id={headingId(node?.position?.start.line, headingIds)}>{children}</h6>
     ),
+    pre: ({ children }) => {
+      const child = Children.toArray(children)[0];
+      if (isValidElement<{ children?: unknown; className?: string }>(child)) {
+        const language = child.props.className?.match(/(?:^|\s)language-([\w-]+)/)?.[1];
+        return (
+          <HighlightedCodeBlock
+            code={String(child.props.children ?? "").replace(/\n$/, "")}
+            language={language}
+          />
+        );
+      }
+      return <pre>{children}</pre>;
+    },
   };
 }
 
@@ -512,8 +519,4 @@ function canonicalDocumentHref(documentId: string) {
   return documentId === DEFAULT_DOCUMENT_ID
     ? window.location.pathname
     : documentHref(documentId);
-}
-
-function sectionLabel(sectionId: string) {
-  return referenceSections.find((section) => section.id === sectionId)?.label ?? "Reference";
 }

--- a/web/src/components/HighlightedCodeBlock.tsx
+++ b/web/src/components/HighlightedCodeBlock.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import hljs from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import css from "highlight.js/lib/languages/css";
+import ini from "highlight.js/lib/languages/ini";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import markdown from "highlight.js/lib/languages/markdown";
+import powershell from "highlight.js/lib/languages/powershell";
+import rust from "highlight.js/lib/languages/rust";
+import sql from "highlight.js/lib/languages/sql";
+import typescript from "highlight.js/lib/languages/typescript";
+import xml from "highlight.js/lib/languages/xml";
+import yaml from "highlight.js/lib/languages/yaml";
+
+hljs.registerLanguage("bash", bash);
+hljs.registerLanguage("css", css);
+hljs.registerLanguage("ini", ini);
+hljs.registerLanguage("javascript", javascript);
+hljs.registerLanguage("json", json);
+hljs.registerLanguage("markdown", markdown);
+hljs.registerLanguage("powershell", powershell);
+hljs.registerLanguage("rust", rust);
+hljs.registerLanguage("sql", sql);
+hljs.registerLanguage("typescript", typescript);
+hljs.registerLanguage("xml", xml);
+hljs.registerLanguage("yaml", yaml);
+hljs.registerAliases(["sh", "shell", "zsh"], { languageName: "bash" });
+hljs.registerAliases(["js", "jsx"], { languageName: "javascript" });
+hljs.registerAliases(["ts", "tsx"], { languageName: "typescript" });
+hljs.registerAliases(["html"], { languageName: "xml" });
+hljs.registerAliases(["md"], { languageName: "markdown" });
+hljs.registerAliases(["ps1"], { languageName: "powershell" });
+hljs.registerAliases(["toml"], { languageName: "ini" });
+hljs.registerAliases(["yml"], { languageName: "yaml" });
+
+const LANGUAGE_LABELS: Record<string, string> = {
+  bash: "Shell",
+  css: "CSS",
+  html: "HTML",
+  ini: "INI",
+  javascript: "JavaScript",
+  js: "JavaScript",
+  json: "JSON",
+  markdown: "Markdown",
+  md: "Markdown",
+  powershell: "PowerShell",
+  ps1: "PowerShell",
+  rust: "Rust",
+  sh: "Shell",
+  shell: "Shell",
+  sql: "SQL",
+  toml: "TOML",
+  ts: "TypeScript",
+  tsx: "TypeScript",
+  typescript: "TypeScript",
+  xml: "HTML/XML",
+  yaml: "YAML",
+  yml: "YAML",
+  zsh: "Shell",
+};
+
+export function HighlightedCodeBlock({
+  code,
+  language,
+}: {
+  code: string;
+  language?: string;
+}) {
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
+  const resetTimer = useRef<number | undefined>(undefined);
+  const normalizedLanguage = language?.toLocaleLowerCase();
+  const highlighted = useMemo(() => {
+    if (!normalizedLanguage || !hljs.getLanguage(normalizedLanguage)) {
+      return escapeHtml(code);
+    }
+    return hljs.highlight(code, {
+      ignoreIllegals: true,
+      language: normalizedLanguage,
+    }).value;
+  }, [code, normalizedLanguage]);
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current !== undefined) window.clearTimeout(resetTimer.current);
+    },
+    [],
+  );
+
+  async function copyCode() {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopyState("copied");
+    } catch {
+      setCopyState("error");
+    }
+    if (resetTimer.current !== undefined) window.clearTimeout(resetTimer.current);
+    resetTimer.current = window.setTimeout(() => setCopyState("idle"), 2_000);
+  }
+
+  const label =
+    (normalizedLanguage && LANGUAGE_LABELS[normalizedLanguage]) || "Code";
+  const buttonLabel =
+    copyState === "copied" ? "Copied" : copyState === "error" ? "Copy failed" : "Copy";
+
+  return (
+    <figure className="docs-code-block">
+      <figcaption>
+        <span>{label}</span>
+        <button
+          aria-label={`Copy ${label} code`}
+          onClick={copyCode}
+          type="button"
+        >
+          {buttonLabel}
+        </button>
+      </figcaption>
+      <pre>
+        <code
+          className={normalizedLanguage ? `hljs language-${normalizedLanguage}` : "hljs"}
+          dangerouslySetInnerHTML={{ __html: highlighted }}
+        />
+      </pre>
+      <span aria-live="polite" className="sr-only">
+        {copyState === "copied"
+          ? `${label} code copied to clipboard.`
+          : copyState === "error"
+            ? `Could not copy ${label} code.`
+            : ""}
+      </span>
+    </figure>
+  );
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}

--- a/web/src/docs/catalog.ts
+++ b/web/src/docs/catalog.ts
@@ -1,22 +1,8 @@
-import contributingSource from "../../../CONTRIBUTING.md?raw";
 import overviewSource from "../../../README.md?raw";
-import release2Source from "../../../docs/releases/v2.0.0.md?raw";
-import releasePreview2Source from "../../../docs/releases/v2.0.0-preview.2.md?raw";
-import releasePreview3Source from "../../../docs/releases/v2.0.0-preview.3.md?raw";
-import releasePreview4Source from "../../../docs/releases/v2.0.0-preview.4.md?raw";
-import adrNativeCaptureSource from "../../../docs/v2/ADR_0001_NATIVE_BROWSER_CAPTURE.md?raw";
-import adrEnrichmentSource from "../../../docs/v2/ADR_0002_LINK_ENRICHMENT.md?raw";
-import adrOperationPacksSource from "../../../docs/v2/ADR_0003_OPERATION_PACKS.md?raw";
-import adrFirecrawlMarkdownSource from "../../../docs/v2/ADR_0004_BOUNDED_FIRECRAWL_MARKDOWN.md?raw";
-import adrUndoSource from "../../../docs/v2/ADR_0005_COMPENSATING_UNDO.md?raw";
-import adrStagedParitySource from "../../../docs/v2/ADR_0006_STAGED_V2_PARITY.md?raw";
+import releaseSource from "../../../docs/releases/v2.0.1.md?raw";
 import cliSource from "../../../docs/v2/CLI.md?raw";
-import designSystemSource from "../../../docs/v2/DESIGN_SYSTEM.md?raw";
+import dataAndPrivacySource from "../../../docs/v2/DATA_AND_PRIVACY.md?raw";
 import migrationSource from "../../../docs/v2/MIGRATION.md?raw";
-import productSource from "../../../docs/v2/PRODUCT.md?raw";
-import roadmapSource from "../../../docs/v2/ROADMAP.md?raw";
-import syncProtocolSource from "../../../docs/v2/SYNC_PROTOCOL.md?raw";
-import threatModelSource from "../../../docs/v2/THREAT_MODEL.md?raw";
 import webSource from "../../../docs/v2/WEB.md?raw";
 
 export interface ReferenceSection {
@@ -30,199 +16,64 @@ export interface ReferenceDocument {
   section: string;
   source: string;
   sourcePath: string;
-  status: string;
   title: string;
 }
 
 export const referenceSections: ReferenceSection[] = [
-  { id: "start", label: "Start here" },
+  { id: "start", label: "Start" },
   { id: "guides", label: "Use ResearchPocket" },
-  { id: "reference", label: "Architecture and security" },
-  { id: "decisions", label: "Architecture decisions" },
-  { id: "project", label: "Project" },
-  { id: "releases", label: "Release archive" },
+  { id: "reference", label: "Understand your data" },
+  { id: "release", label: "Release" },
 ];
 
 export const referenceDocuments: ReferenceDocument[] = [
   {
-    description: "Create a local library, save the sources you need, add context, and find them again.",
+    description: "Install ResearchPocket, save a link, add context, and find it again.",
     id: "overview",
     section: "start",
     source: overviewSource,
     sourcePath: "README.md",
-    status: "Current",
     title: "Getting started",
   },
   {
-    description: "Complete command, option, capture, enrichment, TUI, synchronization, and output reference.",
+    description: "Commands for capture, enrichment, search, TUI use, and synchronization.",
     id: "cli",
     section: "guides",
     source: cliSource,
     sourcePath: "docs/v2/CLI.md",
-    status: "Current",
-    title: "CLI reference",
+    title: "CLI guide",
   },
   {
-    description: "Import a V1 library without mutating the source and verify authored-field preservation.",
+    description: "Import an existing V1 library without changing the source database.",
     id: "migration",
     section: "guides",
     source: migrationSource,
     sourcePath: "docs/v2/MIGRATION.md",
-    status: "Current",
-    title: "V1 migration",
+    title: "Move from V1",
   },
   {
-    description: "Hosted owner application, browser persistence, offline boundary, and synchronization lifecycle.",
+    description: "Use the private browser app, work offline, and understand synchronization.",
     id: "hosted-owner",
     section: "guides",
     source: webSource,
     sourcePath: "docs/v2/WEB.md",
-    status: "Current",
-    title: "Hosted owner app",
+    title: "Browser app",
   },
   {
-    description: "The product vision, use cases, required surfaces, success criteria, and explicit non-goals.",
-    id: "product",
+    description: "Where the library lives, how sync converges, and how credentials stay private.",
+    id: "data-and-privacy",
     section: "reference",
-    source: productSource,
-    sourcePath: "docs/v2/PRODUCT.md",
-    status: "Canonical",
-    title: "Product contract",
+    source: dataAndPrivacySource,
+    sourcePath: "docs/v2/DATA_AND_PRIVACY.md",
+    title: "Data, sync, and privacy",
   },
   {
-    description: "Normative immutable update, operation-pack, convergence, checkpoint, and recovery protocol.",
-    id: "sync-protocol",
-    section: "reference",
-    source: syncProtocolSource,
-    sourcePath: "docs/v2/SYNC_PROTOCOL.md",
-    status: "Normative",
-    title: "Synchronization protocol",
-  },
-  {
-    description: "Privacy goals, trust boundaries, credential handling, data flows, and threat mitigations.",
-    id: "threat-model",
-    section: "reference",
-    source: threatModelSource,
-    sourcePath: "docs/v2/THREAT_MODEL.md",
-    status: "Canonical",
-    title: "Privacy threat model",
-  },
-  {
-    description: "Canonical visual language, interaction patterns, accessibility, and deployment rules.",
-    id: "design-system",
-    section: "reference",
-    source: designSystemSource,
-    sourcePath: "docs/v2/DESIGN_SYSTEM.md",
-    status: "Canonical",
-    title: "Design system",
-  },
-  {
-    description: "Native browser capture through a versioned, provider-neutral invocation bridge.",
-    id: "adr-native-capture",
-    section: "decisions",
-    source: adrNativeCaptureSource,
-    sourcePath: "docs/v2/ADR_0001_NATIVE_BROWSER_CAPTURE.md",
-    status: "Accepted",
-    title: "ADR 0001 · Native capture",
-  },
-  {
-    description: "Retryable direct and Firecrawl metadata enrichment after durable local capture.",
-    id: "adr-enrichment",
-    section: "decisions",
-    source: adrEnrichmentSource,
-    sourcePath: "docs/v2/ADR_0002_LINK_ENRICHMENT.md",
-    status: "Accepted",
-    title: "ADR 0002 · Link enrichment",
-  },
-  {
-    description: "Transport many exact synchronization envelopes in one immutable bounded pack.",
-    id: "adr-operation-packs",
-    section: "decisions",
-    source: adrOperationPacksSource,
-    sourcePath: "docs/v2/ADR_0003_OPERATION_PACKS.md",
-    status: "Accepted",
-    title: "ADR 0003 · Operation packs",
-  },
-  {
-    description: "Retain bounded Firecrawl Markdown in the convergent excerpt register.",
-    id: "adr-firecrawl-markdown",
-    section: "decisions",
-    source: adrFirecrawlMarkdownSource,
-    sourcePath: "docs/v2/ADR_0004_BOUNDED_FIRECRAWL_MARKDOWN.md",
-    status: "Accepted",
-    title: "ADR 0004 · Firecrawl Markdown",
-  },
-  {
-    description: "Undo browser actions through convergence-safe compensating mutations.",
-    id: "adr-undo",
-    section: "decisions",
-    source: adrUndoSource,
-    sourcePath: "docs/v2/ADR_0005_COMPENSATING_UNDO.md",
-    status: "Accepted",
-    title: "ADR 0005 · Compensating undo",
-  },
-  {
-    description: "Stabilize the implemented foundation while keeping full V2 parity scheduled and explicit.",
-    id: "adr-staged-parity",
-    section: "decisions",
-    source: adrStagedParitySource,
-    sourcePath: "docs/v2/ADR_0006_STAGED_V2_PARITY.md",
-    status: "Accepted",
-    title: "ADR 0006 · Staged V2 parity",
-  },
-  {
-    description: "Contribution workflow, repository conventions, toolchain, and required local checks.",
-    id: "contributing",
-    section: "project",
-    source: contributingSource,
-    sourcePath: "CONTRIBUTING.md",
-    status: "Current",
-    title: "Contributing",
-  },
-  {
-    description: "Ordered V2 delivery phases, dependencies, acceptance gates, and planned work.",
-    id: "roadmap",
-    section: "project",
-    source: roadmapSource,
-    sourcePath: "docs/v2/ROADMAP.md",
-    status: "Planned",
-    title: "Delivery roadmap",
-  },
-  {
-    description: "Stable local-first foundation, supported downloads, upgrade requirements, and deferred parity.",
-    id: "release-2",
-    section: "releases",
-    source: release2Source,
-    sourcePath: "docs/releases/v2.0.0.md",
-    status: "Latest release",
-    title: "v2.0.0",
-  },
-  {
-    description: "Historical preview notes for operation-pack upgrade requirements and downloads.",
-    id: "release-preview-4",
-    section: "releases",
-    source: releasePreview4Source,
-    sourcePath: "docs/releases/v2.0.0-preview.4.md",
-    status: "Historical",
-    title: "v2.0.0-preview.4",
-  },
-  {
-    description: "Historical preview notes for enrichment, native capture, and hosted owner editing.",
-    id: "release-preview-3",
-    section: "releases",
-    source: releasePreview3Source,
-    sourcePath: "docs/releases/v2.0.0-preview.3.md",
-    status: "Historical",
-    title: "v2.0.0-preview.3",
-  },
-  {
-    description: "Historical preview notes for the first published V2 migration and sync release.",
-    id: "release-preview-2",
-    section: "releases",
-    source: releasePreview2Source,
-    sourcePath: "docs/releases/v2.0.0-preview.2.md",
-    status: "Historical",
-    title: "v2.0.0-preview.2",
+    description: "What changed, how to upgrade, and where to download verified builds.",
+    id: "release",
+    section: "release",
+    source: releaseSource,
+    sourcePath: "docs/releases/v2.0.1.md",
+    title: "ResearchPocket 2.0.1",
   },
 ];
 

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -4140,12 +4140,6 @@ kbd {
   line-height: var(--line-height-tight);
 }
 
-.docs-nav a small {
-  color: var(--color-text-soft);
-  font-size: var(--font-size-xs);
-  font-weight: 400;
-}
-
 .docs-search-empty {
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
@@ -4162,40 +4156,6 @@ kbd {
   margin: 0 auto;
   max-width: 58rem;
   padding: 1.75rem clamp(1.5rem, 5vw, 4rem) 4rem;
-}
-
-.docs-document-meta {
-  align-items: center;
-  border-bottom: var(--rule) solid var(--color-border);
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 1.75rem;
-  min-height: 2.5rem;
-}
-
-.docs-document-meta > div {
-  align-items: center;
-  display: flex;
-  gap: 0.75rem;
-}
-
-.docs-document-meta span,
-.docs-document-meta strong,
-.docs-document-meta a {
-  font-size: var(--font-size-xs);
-}
-
-.docs-document-meta span {
-  color: var(--color-text-muted);
-}
-
-.docs-document-meta strong {
-  color: var(--color-accent-strong);
-  font-weight: 700;
-}
-
-.docs-document-meta a {
-  color: var(--color-text-muted);
 }
 
 .docs-markdown {
@@ -4248,6 +4208,106 @@ kbd {
 
 .docs-markdown pre {
   max-width: 100%;
+}
+
+.docs-code-block {
+  background: var(--color-surface-muted);
+  border: var(--rule) solid var(--color-border);
+  border-radius: var(--radius);
+  margin: 0 0 1rem;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.docs-code-block figcaption {
+  align-items: center;
+  border-bottom: var(--rule) solid var(--color-border);
+  color: var(--color-text-muted);
+  display: flex;
+  font-size: var(--font-size-xs);
+  justify-content: space-between;
+  min-height: 2.25rem;
+  padding-left: 0.875rem;
+}
+
+.docs-code-block figcaption > span {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.docs-code-block button {
+  align-self: stretch;
+  background: transparent;
+  border: 0;
+  border-left: var(--rule) solid var(--color-border);
+  color: var(--color-text-soft);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  min-height: 2.25rem;
+  padding: 0 0.875rem;
+}
+
+.docs-code-block button:hover,
+.docs-code-block button:focus-visible {
+  background: var(--color-surface-raised);
+  color: var(--color-text);
+}
+
+.docs-code-block pre {
+  background: transparent;
+  border: 0;
+  margin: 0;
+  padding: 1rem;
+}
+
+.docs-code-block code {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-reader);
+  display: block;
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: var(--font-size-sm);
+  line-height: 1.65;
+  padding: 0;
+}
+
+.docs-code-block .hljs-comment,
+.docs-code-block .hljs-quote {
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+.docs-code-block .hljs-keyword,
+.docs-code-block .hljs-selector-tag,
+.docs-code-block .hljs-literal,
+.docs-code-block .hljs-built_in,
+.docs-code-block .hljs-type {
+  color: var(--color-accent-strong);
+  font-weight: 700;
+}
+
+.docs-code-block .hljs-string,
+.docs-code-block .hljs-attr,
+.docs-code-block .hljs-template-variable,
+.docs-code-block .hljs-regexp {
+  color: var(--color-accent);
+}
+
+.docs-code-block .hljs-title,
+.docs-code-block .hljs-section,
+.docs-code-block .hljs-name,
+.docs-code-block .hljs-selector-id,
+.docs-code-block .hljs-selector-class {
+  color: var(--color-text);
+  font-weight: 700;
+}
+
+.docs-code-block .hljs-number,
+.docs-code-block .hljs-symbol,
+.docs-code-block .hljs-variable,
+.docs-code-block .hljs-meta {
+  color: var(--color-text-soft);
 }
 
 .docs-markdown table {
@@ -4387,18 +4447,6 @@ kbd {
 
   .docs-article {
     padding: 1rem 1rem 3rem;
-  }
-
-  .docs-document-meta {
-    align-items: flex-start;
-    gap: 0.5rem;
-    margin-bottom: 1.25rem;
-  }
-
-  .docs-document-meta > div {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 0.125rem;
   }
 
   .docs-markdown {


### PR DESCRIPTION
Closes #108
Closes #110

## Summary

- publish the `research`, `research-domain`, and `research-store` crates in exact-version dependency order after the matching GitHub release is public
- document the Cargo distribution boundary and add `cargo install --locked research` as a supported installation path
- reduce the public docs catalog to six reader-focused pages while keeping ADRs and internal project material in the repository
- add bundled fenced-code syntax highlighting and an accessible copy control without third-party runtime requests
- prepare patch release 2.0.1 with no domain, CRDT, protocol, SQLite, or machine-output schema change

## User-visible impact

Users can install the stable CLI through Cargo beginning with 2.0.1. The public docs navigation and search no longer expose ADRs or governance/project pages, and fenced code is easier to scan and copy.

## Protocol and privacy impact

None. Exact internal crate versions preserve the reviewed native/WASM implementation. Documentation highlighting is bundled into the existing self-only static application and adds no runtime network boundary.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-targets --all-features`
- `cargo audit --deny warnings`
- `cargo build --locked --release`
- `./target/release/research --version` → `research 2.0.1`
- `cargo package --allow-dirty --locked --no-verify -p research-domain`
- `cd web && npm ci && npm run verify`
- staged v2.0.0 archives independently verified against `SHA256SUMS`; arm64 binary smoke-tested

`research-store` and `research` packaging requires the preceding exact-version crate to be visible on crates.io, so the tagged Cargo workflow performs those package gates in dependency order with bounded registry-propagation retries.
