### PR TITLE
Hide internal references from the public docs

### DIFF
--- a/docs/releases/v2.0.1.md
+++ b/docs/releases/v2.0.1.md
@@ -22,9 +22,9 @@ release and check it against `SHA256SUMS`.
   the same release.
 - The public docs show only getting started, usage, migration, browser,
   data/sync/security, and current-release material.
-- Internal ADRs, governance/project material, design-system documentation, and
-  historical preview notes remain in the repository but no longer crowd the
-  reader guide or its search results.
+- Internal engineering records, project material, and historical preview notes
+  remain in the repository but no longer crowd the reader guide or its search
+  results.
 - Fenced code blocks have bundled language-aware highlighting and an accessible
   copy button with visible and announced feedback.
 

--- a/docs/v2/CLI.md
+++ b/docs/v2/CLI.md
@@ -195,9 +195,7 @@ bounded retries and a sanitized category; page bodies and credentials are never
 stored in a job. Successful bounded Firecrawl Markdown is stored only through
 the normal excerpt mutation, not duplicated in the job. A successful result is
 one V2 edit/outbox update only when at least one eligible field is applied. Raw
-HTML, PDF, and attachment storage remains outside this feature; see
-[ADR 0002](./ADR_0002_LINK_ENRICHMENT.md) and
-[ADR 0004](./ADR_0004_BOUNDED_FIRECRAWL_MARKDOWN.md).
+HTML, PDF, and attachment storage remains outside this feature.
 
 ## Browser capture through the URL scheme
 
@@ -363,9 +361,6 @@ owner remembers external-protocol permission may attempt unwanted captures. URI
 validation limits that risk to bounded save spam: the transport cannot read or
 edit the library, execute commands, select a database, obtain credentials, or
 start sync. See [THREAT_MODEL.md](./THREAT_MODEL.md#native-bookmarklet-capture).
-The custom-handler tradeoff is recorded in
-[ADR 0001](./ADR_0001_NATIVE_BROWSER_CAPTURE.md); the post-save enrichment
-boundary is recorded in [ADR 0002](./ADR_0002_LINK_ENRICHMENT.md).
 
 ## Edit and lifecycle
 

--- a/docs/v2/WEB.md
+++ b/docs/v2/WEB.md
@@ -19,8 +19,7 @@ WASM and IndexedDB transaction boundary; it never deletes an outbox row or
 rewrites immutable history. The token records the exact resulting item
 projection and fails stale if any later local or remote item change intervenes.
 Only the latest action is retained in memory. Delete remains recoverable through
-the archive after dismissal or reload. See
-[ADR 0005](./ADR_0005_COMPENSATING_UNDO.md).
+the archive after dismissal or reload.
 
 First run offers two explicit paths. Starting locally creates an empty browser
 library. Restoring prepares the same empty local shell and opens private sync


### PR DESCRIPTION
Refs #110

## Summary

- remove the remaining inline ADR links from the two reader-facing guides
- describe the release-note change without exposing internal record categories
- keep every canonical ADR and engineering document unchanged in the repository

## Verification

- `cd web && npm run verify`
- scanned the built docs bundle for `ADR_000`, `ADR 000`, `Consolidation ADR`, and `Governance`; none remain
