### PR TITLE
Remove footer tagline from the library view

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1008,7 +1008,6 @@ export function App() {
             <span><b>/</b> search</span>
             <span><b>⏎</b> reader</span>
             <span><b>↗</b> open</span>
-            <span className="keyboard-footer-note">local-first · private · no tracking</span>
           </footer>
           </section>
         </main>

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2217,10 +2217,6 @@ kbd {
   color: var(--color-text-soft);
 }
 
-.keyboard-footer-note {
-  margin-left: auto;
-}
-
 .sync-section {
   border: 0;
   display: grid;


### PR DESCRIPTION
Removes the "local-first · private · no tracking" note from the keyboard footer and the now-unused `.keyboard-footer-note` CSS rule.