### PR TITLE
Send only the changed range when a note is edited

### DIFF
--- a/crates/research-domain/src/document.rs
+++ b/crates/research-domain/src/document.rs
@@ -207,6 +207,23 @@ impl Library {
             .map_err(loro_error)
     }
 
+    /// Rewrites a note by splicing only the range that actually changed.
+    ///
+    /// Replacing the whole range would carry the entire note in every update
+    /// and would make two devices editing different regions conflict over the
+    /// full text instead of merging.
+    pub fn set_note(
+        &self,
+        item_id: &str,
+        current: &str,
+        replacement: &str,
+    ) -> DomainResult<()> {
+        let Some(splice) = TextSplice::between(current, replacement) else {
+            return Ok(());
+        };
+        self.splice_note_utf16(item_id, splice.position, splice.length, &splice.insert)
+    }
+
     pub fn write_url(&self, item_id: &str, revision_id: &str, value: &str) -> DomainResult<()> {
         validate_item_url(value)?;
         self.write_scalar(item_id, URL, revision_id, value.to_owned())
@@ -486,6 +503,63 @@ fn validate_tag(tag: &str) -> DomainResult<String> {
 
 fn operation_id(prefix: &str, suffix: &str) -> String {
     format!("{prefix}/{suffix}")
+}
+
+/// The narrowest UTF-16 splice that turns one string into another.
+#[derive(Debug, PartialEq, Eq)]
+pub struct TextSplice {
+    /// Offset in UTF-16 code units where the replacement begins.
+    pub position: usize,
+    /// Number of UTF-16 code units to remove.
+    pub length: usize,
+    /// Text to insert at `position`.
+    pub insert: String,
+}
+
+fn is_low_surrogate(unit: u16) -> bool {
+    (0xDC00..=0xDFFF).contains(&unit)
+}
+
+impl TextSplice {
+    /// Returns `None` when the two strings are already equal.
+    ///
+    /// Boundaries never fall between a surrogate pair, so the removed range and
+    /// the inserted text are always well-formed UTF-16.
+    pub fn between(current: &str, replacement: &str) -> Option<Self> {
+        if current == replacement {
+            return None;
+        }
+        let old: Vec<u16> = current.encode_utf16().collect();
+        let new: Vec<u16> = replacement.encode_utf16().collect();
+        let shortest = old.len().min(new.len());
+
+        let mut prefix = 0;
+        while prefix < shortest && old[prefix] == new[prefix] {
+            prefix += 1;
+        }
+        // A boundary that lands on a low surrogate would split the pair whose
+        // high half is already inside the prefix.
+        if prefix < shortest && is_low_surrogate(old[prefix]) {
+            prefix -= 1;
+        }
+
+        let mut suffix = 0;
+        while suffix < shortest - prefix
+            && old[old.len() - suffix - 1] == new[new.len() - suffix - 1]
+        {
+            suffix += 1;
+        }
+        if suffix > 0 && is_low_surrogate(old[old.len() - suffix]) {
+            suffix -= 1;
+        }
+
+        Some(Self {
+            position: prefix,
+            length: old.len() - prefix - suffix,
+            insert: String::from_utf16(&new[prefix..new.len() - suffix])
+                .expect("surrogate pairs are kept whole"),
+        })
+    }
 }
 
 fn insert_boolean_dot(map: &LoroMap, dot: &str) -> DomainResult<()> {

--- a/crates/research-domain/src/lib.rs
+++ b/crates/research-domain/src/lib.rs
@@ -12,7 +12,9 @@ mod projection;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 
-pub use document::{DomainError, DomainResult, ItemSeed, Library, validate_item_url};
+pub use document::{
+    DomainError, DomainResult, ItemSeed, Library, TextSplice, validate_item_url,
+};
 pub use envelope::{DOMAIN_SCHEMA_VERSION, LORO_CODEC, PROTOCOL_VERSION, UpdateEnvelope};
 pub use genesis::{LibraryGenesis, SYNC_FORMAT};
 pub use pack::{

--- a/crates/research-domain/src/wasm.rs
+++ b/crates/research-domain/src/wasm.rs
@@ -499,14 +499,7 @@ fn apply_edit(
                 "edit does not change the item".into(),
             ));
         }
-        if replacement != current.note {
-            library.splice_note_utf16(
-                item_id,
-                0,
-                current.note.encode_utf16().count(),
-                replacement,
-            )?;
-        }
+        library.set_note(item_id, &current.note, replacement)?;
     }
     for tag in remove_tags {
         library.remove_tag(item_id, &tag)?;

--- a/crates/research-domain/tests/payload_size.rs
+++ b/crates/research-domain/tests/payload_size.rs
@@ -1,0 +1,219 @@
+//! Measures what one edit actually costs on the wire.
+//!
+//! Run with: cargo test -p research-domain --test payload_size -- --nocapture
+
+use research_domain::{ItemSeed, Library};
+
+const ITEM: &str = "0197f2b5-93d7-7ad4-8c67-21e98f0c7341";
+const LIBRARY: &str = "00000000-0000-7000-8000-000000000001";
+const DEVICE: &str = "00000000-0000-7000-8000-000000000002";
+
+fn paragraph(words: usize) -> String {
+    (0..words)
+        .map(|index| format!("word{index:04}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+struct Measured {
+    update: usize,
+    envelope_json: usize,
+}
+
+/// Applies `edit` to a library seeded with `excerpt`/`note` and reports the
+/// exported update size plus the serialized envelope size.
+fn measure(excerpt: &str, note: &str, edit: impl FnOnce(&Library)) -> Measured {
+    let library = Library::with_peer_id_for_fixture(101).expect("library");
+    library
+        .create_item(
+            &ItemSeed {
+                item_id: ITEM.to_owned(),
+                url: "https://example.com/original".to_owned(),
+                title: Some("Original".to_owned()),
+                excerpt: Some(excerpt.to_owned()),
+                favorite: false,
+                language: Some(String::new()),
+                saved_at: 1_700_000_000,
+                note: note.to_owned(),
+                tags: Vec::new(),
+            },
+            "device-base/00000000000000000001",
+        )
+        .expect("seed item");
+
+    let before = library.version();
+    edit(&library);
+    let envelope = library
+        .export_envelope(&before, LIBRARY, DEVICE, 2, "2026-07-25T00:00:00.000Z")
+        .expect("envelope");
+    let envelope_json = serde_json::to_string(&envelope).expect("serialize");
+
+    Measured {
+        // payload is base64 of the raw Loro update.
+        update: envelope.payload.len() * 3 / 4,
+        envelope_json: envelope_json.len(),
+    }
+}
+
+#[test]
+fn one_character_excerpt_edit_reports_its_true_cost() {
+    let excerpt = paragraph(400);
+    let edited = format!("{excerpt}.");
+    println!(
+        "\n--- excerpt: {} bytes, one character appended ---",
+        excerpt.len()
+    );
+
+    let measured = measure(&excerpt, "", |library| {
+        library
+            .write_excerpt(ITEM, "device-a/00000000000000000002/excerpt", Some(&edited))
+            .expect("write excerpt");
+    });
+
+    // Layer sizes on the way to GitHub.
+    let packed = measured.envelope_json * 4 / 3; // envelope base64'd into a pack
+    let uploaded = packed * 4 / 3; // pack base64'd into the Contents API body
+
+    println!("loro update      : {:>7} bytes", measured.update);
+    println!("envelope json    : {:>7} bytes", measured.envelope_json);
+    println!("packed member    : {:>7} bytes", packed);
+    println!("uploaded body    : {:>7} bytes", uploaded);
+    println!(
+        "amplification    : {:>7.1}x the edited excerpt",
+        uploaded as f64 / edited.len() as f64
+    );
+
+    assert!(
+        measured.update > excerpt.len(),
+        "a scalar rewrite carries the whole excerpt: update {} vs excerpt {}",
+        measured.update,
+        excerpt.len()
+    );
+}
+
+/// The regression guard for #115: the mutation path must not carry the whole
+/// note. Compare against `a_full_range_splice_costs_the_whole_note` below.
+#[test]
+fn one_character_note_edit_sends_only_the_change() {
+    let note = paragraph(400);
+    let edited = format!("{note}.");
+    println!(
+        "\n--- note: {} bytes, one character appended ---",
+        note.len()
+    );
+
+    let measured = measure("", &note, |library| {
+        library.set_note(ITEM, &note, &edited).expect("set note");
+    });
+
+    println!("loro update      : {:>7} bytes", measured.update);
+    println!("envelope json    : {:>7} bytes", measured.envelope_json);
+
+    assert!(
+        measured.update < note.len() / 4,
+        "a minimal splice must not carry the whole note: update {} vs note {}",
+        measured.update,
+        note.len()
+    );
+}
+
+/// Documents what the full-range splice used to cost, so the saving stays
+/// visible if anyone reintroduces it.
+#[test]
+fn a_full_range_splice_costs_the_whole_note() {
+    let note = paragraph(400);
+    let edited = format!("{note}.");
+
+    let measured = measure("", &note, |library| {
+        library
+            .splice_note_utf16(ITEM, 0, note.encode_utf16().count(), &edited)
+            .expect("splice note");
+    });
+
+    println!(
+        "\n--- full-range splice of a {} byte note: {} byte update ---",
+        note.len(),
+        measured.update
+    );
+
+    assert!(
+        measured.update > note.len(),
+        "the rejected approach carries the whole note: update {}",
+        measured.update
+    );
+}
+
+#[test]
+fn a_minimal_note_splice_shows_the_available_headroom() {
+    let note = paragraph(400);
+    println!(
+        "\n--- note: {} bytes, one character appended by tail splice ---",
+        note.len()
+    );
+
+    let measured = measure("", &note, |library| {
+        // Append at the end instead of replacing the whole range.
+        let end = note.encode_utf16().count();
+        library
+            .splice_note_utf16(ITEM, end, 0, ".")
+            .expect("splice note tail");
+    });
+
+    println!("loro update      : {:>7} bytes", measured.update);
+    println!("envelope json    : {:>7} bytes", measured.envelope_json);
+
+    assert!(
+        measured.update < note.len() / 4,
+        "a targeted splice must not carry the whole note: update {} vs note {}",
+        measured.update,
+        note.len()
+    );
+}
+
+/// Superseded scalar revisions are retained forever, but they are near
+/// duplicates and the snapshot encoding compresses them, so local storage
+/// growth is modest. The cost of an edit is paid on the wire, not at rest.
+#[test]
+fn repeated_excerpt_edits_compress_well_at_rest() {
+    let excerpt = paragraph(400);
+    let library = Library::with_peer_id_for_fixture(101).expect("library");
+    library
+        .create_item(
+            &ItemSeed {
+                item_id: ITEM.to_owned(),
+                url: "https://example.com/original".to_owned(),
+                title: Some("Original".to_owned()),
+                excerpt: Some(excerpt.clone()),
+                favorite: false,
+                language: Some(String::new()),
+                saved_at: 1_700_000_000,
+                note: String::new(),
+                tags: Vec::new(),
+            },
+            "device-base/00000000000000000001",
+        )
+        .expect("seed item");
+
+    let baseline = library.export_snapshot().expect("snapshot").len();
+    for revision in 2..=21u64 {
+        library
+            .write_excerpt(
+                ITEM,
+                &format!("device-a/{revision:020}/excerpt"),
+                Some(&format!("{excerpt} revision {revision}")),
+            )
+            .expect("write excerpt");
+    }
+    let after = library.export_snapshot().expect("snapshot").len();
+
+    println!("\n--- 20 edits of a {} byte excerpt ---", excerpt.len());
+    println!("snapshot before  : {:>7} bytes", baseline);
+    println!("snapshot after   : {:>7} bytes", after);
+    println!("growth per edit  : {:>7} bytes", (after - baseline) / 20);
+
+    assert!(
+        after - baseline < excerpt.len(),
+        "20 retained revisions must still cost less than one excerpt at rest: grew {} bytes",
+        after - baseline
+    );
+}

--- a/crates/research-domain/tests/text_splice.rs
+++ b/crates/research-domain/tests/text_splice.rs
@@ -1,0 +1,134 @@
+//! The narrowest-splice contract behind #115.
+
+use research_domain::TextSplice;
+
+fn splice(current: &str, replacement: &str) -> TextSplice {
+    TextSplice::between(current, replacement).expect("the strings differ")
+}
+
+/// Applying the splice must reproduce the replacement exactly.
+fn apply(current: &str, splice: &TextSplice) -> String {
+    let units: Vec<u16> = current.encode_utf16().collect();
+    let mut result: Vec<u16> = units[..splice.position].to_vec();
+    result.extend(splice.insert.encode_utf16());
+    result.extend_from_slice(&units[splice.position + splice.length..]);
+    String::from_utf16(&result).expect("well-formed UTF-16")
+}
+
+#[test]
+fn an_unchanged_note_produces_no_splice() {
+    assert_eq!(TextSplice::between("same", "same"), None);
+    assert_eq!(TextSplice::between("", ""), None);
+}
+
+#[test]
+fn appending_touches_only_the_tail() {
+    let result = splice("hello", "hello!");
+    assert_eq!(result.position, 5);
+    assert_eq!(result.length, 0);
+    assert_eq!(result.insert, "!");
+}
+
+#[test]
+fn prepending_touches_only_the_head() {
+    let result = splice("hello", "oh hello");
+    assert_eq!(result.position, 0);
+    assert_eq!(result.length, 0);
+    assert_eq!(result.insert, "oh ");
+}
+
+#[test]
+fn an_interior_edit_touches_only_the_middle() {
+    let result = splice("the quick brown fox", "the slow brown fox");
+    assert_eq!(result.insert, "slow");
+    assert_eq!(result.position, 4);
+    assert_eq!(result.length, 5);
+}
+
+#[test]
+fn deleting_reports_a_range_with_no_insert() {
+    let result = splice("keep this away", "keep away");
+    assert_eq!(result.insert, "");
+    assert_eq!(result.length, 5);
+}
+
+#[test]
+fn clearing_removes_everything() {
+    let result = splice("gone", "");
+    assert_eq!(result.position, 0);
+    assert_eq!(result.length, 4);
+    assert_eq!(result.insert, "");
+}
+
+#[test]
+fn a_one_character_edit_in_a_long_note_stays_small() {
+    let long: String = "word ".repeat(2_000);
+    let edited = format!("{long}.");
+    let result = splice(&long, &edited);
+
+    assert_eq!(result.insert, ".");
+    assert_eq!(result.length, 0);
+    assert_eq!(apply(&long, &result), edited);
+}
+
+#[test]
+fn surrogate_pairs_are_never_split() {
+    // The emoji occupies two UTF-16 code units.
+    let current = "A😀B";
+    let replacement = "A😀C";
+    let result = splice(current, replacement);
+
+    assert_eq!(apply(current, &result), replacement);
+    assert_eq!(result.insert, "C");
+    assert_eq!(
+        result.position, 3,
+        "the boundary must sit after the whole pair"
+    );
+}
+
+#[test]
+fn replacing_an_emoji_keeps_both_halves_together() {
+    let current = "A😀B";
+    let replacement = "A🙂B";
+    let result = splice(current, replacement);
+
+    assert_eq!(apply(current, &result), replacement);
+    assert_eq!(result.insert, "🙂");
+    assert_eq!(result.position, 1);
+    assert_eq!(result.length, 2, "both halves of the old pair are removed");
+}
+
+#[test]
+fn adjacent_identical_emoji_do_not_confuse_the_boundary() {
+    let current = "😀😀";
+    let replacement = "😀🙂😀";
+    let result = splice(current, replacement);
+
+    assert_eq!(apply(current, &result), replacement);
+    assert!(
+        String::from_utf16(&result.insert.encode_utf16().collect::<Vec<_>>()).is_ok(),
+        "the inserted text is well-formed"
+    );
+}
+
+#[test]
+fn the_golden_fixture_note_round_trips() {
+    let current = "A😀<A><B>B!";
+    for replacement in [
+        "A😀<A><B>B!.",
+        "A😀<A><B>B",
+        "A😀<A><C>B!",
+        "A🙂<A><B>B!",
+        "",
+        "completely different",
+    ] {
+        let Some(result) = TextSplice::between(current, replacement) else {
+            continue;
+        };
+        assert_eq!(
+            apply(current, &result),
+            replacement,
+            "splice must reproduce {replacement:?}",
+        );
+    }
+}


### PR DESCRIPTION
Closes #115.

Editing a note spliced the whole text range (`wasm.rs`: `splice_note_utf16(item, 0, entire_old_length, entire_new_text)`), so a one-character change carried the entire note. Protocol v1 never prunes operations, so that cost was permanent.

## Change

`TextSplice::between` computes the narrowest UTF-16 splice between two strings, never splitting a surrogate pair. The mutation path now goes through `Library::set_note`. The logic lives in `document.rs` rather than `wasm.rs` so it is natively testable — `wasm.rs` is `cfg(target_arch = "wasm32")` and its tests do not run on the host.

## Measured

Appending one character to a 3,599 byte note:

| | Loro update | Envelope JSON |
| --- | --- | --- |
| Before | 3,756 bytes | 5,422 bytes |
| After | **138 bytes** | 598 bytes |

A **27x** reduction. `tests/payload_size.rs` is a reusable harness; `a_full_range_splice_costs_the_whole_note` pins the old behavior so the saving stays visible if anyone reintroduces it.

## Also a merge fix

Replacing the full range made two devices editing *different regions* of one note conflict over the entire text instead of merging. Finer-grained splices merge correctly.

## Compatibility

No change to `domain_schema_version`, `protocol_version`, `pack_version`, or any repository path. `GOLDEN_CANONICAL_JSON` and the convergence scenario are unchanged — the projected text is identical regardless of splice granularity.

## Verification

- `cargo test -p research-domain` — 19 passed, including the golden convergence scenario
- `cargo check -p research-domain --target wasm32-unknown-unknown` — clean
- `cargo fmt --check` and `cargo clippy --all-targets` — clean
- `npm run wasm && npm test` — bundle rebuilt, 13 web tests pass

11 unit tests cover append, prepend, interior edit, delete, clear, and the astral-plane cases (emoji replacement, adjacent identical emoji, the golden fixture note `A😀<A><B>B!`).

Excerpt has the same problem but is a scalar, not text, so it needs a schema change — tracked separately in #116.