### PR TITLE
Add switchable browser library profiles and rebuild the sync view

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,19 @@ import {
   browserSync,
   type BrowserSyncState,
 } from "./data/sync.ts";
+import {
+  createProfile,
+  deleteProfile,
+  listProfiles,
+  renameProfile,
+  type LibraryProfile,
+} from "./data/profiles.ts";
+
+/** Sentinel value for the create action inside the library switcher. */
+const NEW_LIBRARY_OPTION = "__new-library__";
+
+/** Tags shown in the rail before the rest move behind the manage action. */
+const RAIL_TAG_LIMIT = 8;
 
 type AddInput = Parameters<typeof libraryRepository.add>[0];
 type EditInput = Parameters<typeof libraryRepository.edit>[1];
@@ -185,6 +198,8 @@ export function App() {
   const [announcement, setAnnouncement] = useState("");
   const [localError, setLocalError] = useState<string | null>(null);
   const [undoNotice, setUndoNotice] = useState<UndoNotice | null>(null);
+  const [profiles, setProfiles] = useState<LibraryProfile[]>([]);
+  const [activeProfileId, setActiveProfileId] = useState<string | null>(null);
   const captureOpenerRef = useRef<HTMLButtonElement | null>(null);
   const editOpenerRef = useRef<HTMLButtonElement | null>(null);
 
@@ -198,11 +213,19 @@ export function App() {
     const unsubscribeSync = browserSync.subscribe((nextState) => {
       if (active) setSyncState(nextState);
     });
+    const unsubscribeProfile = libraryRepository.subscribeProfile((profile) => {
+      if (!active) return;
+      setActiveProfileId(profile.id);
+      void listProfiles().then((next) => {
+        if (active) setProfiles(next);
+      });
+    });
 
     return () => {
       active = false;
       unsubscribe();
       unsubscribeSync();
+      unsubscribeProfile();
     };
   }, []);
 
@@ -296,6 +319,21 @@ export function App() {
       })),
     [items, knownTags],
   );
+
+  // The rail shows the busiest tags plus anything already filtered on; the
+  // rest stay behind the manage action so the rail cannot grow unbounded.
+  const railTags = useMemo(() => {
+    const ranked = [...tagCounts].sort(
+      (left, right) => right.count - left.count || left.tag.localeCompare(right.tag),
+    );
+    const shown = ranked.slice(0, RAIL_TAG_LIMIT);
+    const shownTags = new Set(shown.map(({ tag }) => tag));
+    const pinned = ranked.filter(
+      ({ tag }) => selectedTags.includes(tag) && !shownTags.has(tag),
+    );
+    return [...shown, ...pinned];
+  }, [selectedTags, tagCounts]);
+  const hiddenTagCount = tagCounts.length - railTags.length;
 
   useEffect(() => {
     function restoreNavigationFromHistory() {
@@ -400,6 +438,37 @@ export function App() {
       window.history.pushState(window.history.state, "", nextUrl);
     }
     setView(nextView);
+  }
+
+  async function refreshProfiles() {
+    setProfiles(await listProfiles());
+  }
+
+  async function switchLibrary(profileId: string) {
+    if (profileId === activeProfileId) return;
+    setLocalError(null);
+    try {
+      const profile = await libraryRepository.switchProfile(profileId);
+      await refreshProfiles();
+      setAutoBootstrapAttempted(false);
+      navigateToView("library");
+      setAnnouncement(`Opened ${profile.name}`);
+    } catch (error) {
+      setLocalError(readError(error));
+    }
+  }
+
+  async function createLibrary() {
+    const name = window.prompt("Name the new library");
+    if (name === null) return;
+    setLocalError(null);
+    try {
+      const created = await createProfile(name);
+      await refreshProfiles();
+      await switchLibrary(created.id);
+    } catch (error) {
+      setLocalError(readError(error));
+    }
   }
 
   useEffect(() => {
@@ -621,12 +690,35 @@ export function App() {
               rp
             </span>
             <p className="brand-name">ResearchPocket</p>
-            <p className="brand-context">
-              {view === "library" ? "owner workspace" : "← library"}
-            </p>
+            {view === "library" ? null : (
+              <p className="brand-context">← library</p>
+            )}
           </button>
 
           <div className="masthead-actions">
+            {profiles.length > 1 ? (
+              <div className="library-switcher">
+                <select
+                  aria-label="Active library"
+                  onChange={(event) => {
+                    if (event.target.value === NEW_LIBRARY_OPTION) {
+                      event.target.value = activeProfileId ?? "";
+                      void createLibrary();
+                      return;
+                    }
+                    void switchLibrary(event.target.value);
+                  }}
+                  value={activeProfileId ?? ""}
+                >
+                  {profiles.map((profile) => (
+                    <option key={profile.id} value={profile.id}>
+                      {profile.name}
+                    </option>
+                  ))}
+                  <option value={NEW_LIBRARY_OPTION}>＋ New library…</option>
+                </select>
+              </div>
+            ) : null}
             <div className="local-status" role="status">
               <span aria-hidden="true" className="status-dot" />
               <span className="status-label">local</span>
@@ -639,7 +731,7 @@ export function App() {
               onClick={() => setCommandOpen(true)}
               type="button"
             >
-              search or command <kbd>Ctrl Shift P</kbd>
+              search <kbd>Ctrl Shift P</kbd>
             </button>
           </div>
         </header>
@@ -690,10 +782,12 @@ export function App() {
           <div className="rail-tags">
             <div className="rail-heading">
               <p>Tags</p>
-              <button onClick={() => setFiltersOpen(true)} type="button">manage</button>
+              <button onClick={() => setFiltersOpen(true)} type="button">
+                {hiddenTagCount > 0 ? `+${hiddenTagCount} more` : "manage"}
+              </button>
             </div>
             <div className="rail-tag-list">
-              {tagCounts.map(({ count, tag }) => (
+              {railTags.map(({ count, tag }) => (
                 <button
                   aria-current={selectedTags.includes(tag) ? "page" : undefined}
                   key={tag}
@@ -746,10 +840,14 @@ export function App() {
         />
 
         <SettingsPanel
+          activeProfileId={activeProfileId}
           density={density}
           hidden={view !== "settings"}
           onDensityChange={setDensity}
+          onProfilesChanged={refreshProfiles}
+          onSwitchLibrary={switchLibrary}
           onThemeChange={setTheme}
+          profiles={profiles}
           theme={theme}
         />
 
@@ -1080,11 +1178,16 @@ export function App() {
       {commandOpen ? (
         <CommandPalette
           items={items.filter((item) => !item.deleted)}
+          libraries={profiles.filter((profile) => profile.id !== activeProfileId)}
           onClose={() => setCommandOpen(false)}
           onFilterTag={(tag) => {
             navigateToView("library");
             setSelectedTags([tag]);
             setCommandOpen(false);
+          }}
+          onNewLibrary={() => {
+            setCommandOpen(false);
+            void createLibrary();
           }}
           onNewSave={() => {
             setCommandOpen(false);
@@ -1093,6 +1196,10 @@ export function App() {
           onOpenItem={(item) => {
             openReader(item);
             setCommandOpen(false);
+          }}
+          onSwitchLibrary={(profileId) => {
+            setCommandOpen(false);
+            void switchLibrary(profileId);
           }}
           onSync={() => {
             navigateToView("sync");
@@ -1180,17 +1287,159 @@ function Welcome({
   );
 }
 
+function LibrarySettings({
+  activeProfileId,
+  onProfilesChanged,
+  onSwitchLibrary,
+  profiles,
+}: {
+  activeProfileId: string | null;
+  onProfilesChanged: () => Promise<void>;
+  onSwitchLibrary: (profileId: string) => Promise<void>;
+  profiles: LibraryProfile[];
+}) {
+  const [newName, setNewName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function run(work: () => Promise<unknown>) {
+    setBusy(true);
+    setError(null);
+    try {
+      await work();
+      await onProfilesChanged();
+    } catch (caught) {
+      setError(readError(caught));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="settings-group">
+      <div>
+        <h3>Libraries</h3>
+        <p>
+          Each library keeps its own saves, queue, and repository on this device.
+          Nothing is shared between them.
+        </p>
+      </div>
+
+      <div className="library-settings">
+        <ul className="library-list">
+          {profiles.map((profile) => {
+            const current = profile.id === activeProfileId;
+            return (
+              <li className="library-row" key={profile.id}>
+                <div className="library-row-copy">
+                  <p>
+                    {profile.name}
+                    {current ? <span className="status-label"> open</span> : null}
+                  </p>
+                  <p>
+                    {profile.lastOpenedAt
+                      ? `Last opened ${formatDateTime(profile.lastOpenedAt)}`
+                      : "Not opened yet"}
+                  </p>
+                </div>
+                <div className="library-row-actions">
+                  {current ? null : (
+                    <button
+                      disabled={busy}
+                      onClick={() => void onSwitchLibrary(profile.id)}
+                      type="button"
+                    >
+                      Open
+                    </button>
+                  )}
+                  <button
+                    disabled={busy}
+                    onClick={() =>
+                      void run(async () => {
+                        const name = window.prompt("Rename library", profile.name);
+                        if (name === null) return;
+                        await renameProfile(profile.id, name);
+                      })
+                    }
+                    type="button"
+                  >
+                    Rename
+                  </button>
+                  <button
+                    disabled={busy || profiles.length === 1}
+                    onClick={() =>
+                      void run(async () => {
+                        const confirmed = window.confirm(
+                          `Delete the local copy of "${profile.name}"? Its GitHub repository is not touched, so you can reconnect to restore it.`,
+                        );
+                        if (!confirmed) return;
+                        const next = await deleteProfile(profile.id);
+                        if (profile.id === activeProfileId) await onSwitchLibrary(next.id);
+                      })
+                    }
+                    type="button"
+                  >
+                    Delete local copy
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+
+        <form
+          className="library-create"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void run(async () => {
+              const created = await createProfile(newName);
+              setNewName("");
+              await onSwitchLibrary(created.id);
+            });
+          }}
+        >
+          <label className="field">
+            <span>New library</span>
+            <input
+              autoCapitalize="none"
+              autoComplete="off"
+              name="library-name"
+              onChange={(event) => setNewName(event.target.value)}
+              placeholder="Team research"
+              required
+              value={newName}
+            />
+          </label>
+          <button className="secondary-button" disabled={busy} type="submit">
+            Create and open
+          </button>
+        </form>
+
+        {error ? <p className="sync-error" role="alert">{error}</p> : null}
+      </div>
+    </div>
+  );
+}
+
 function SettingsPanel({
+  activeProfileId,
   density,
   hidden,
   onDensityChange,
+  onProfilesChanged,
+  onSwitchLibrary,
   onThemeChange,
+  profiles,
   theme,
 }: {
+  activeProfileId: string | null;
   density: Density;
   hidden: boolean;
   onDensityChange: (density: Density) => void;
+  onProfilesChanged: () => Promise<void>;
+  onSwitchLibrary: (profileId: string) => Promise<void>;
   onThemeChange: (theme: ThemeColors) => void;
+  profiles: LibraryProfile[];
   theme: ThemeColors;
 }) {
   const selectedPreset =
@@ -1208,6 +1457,13 @@ function SettingsPanel({
         <h2 id="settings-heading">Settings</h2>
         <p>Preferences stay in this browser and never become library data.</p>
       </header>
+
+      <LibrarySettings
+        activeProfileId={activeProfileId}
+        onProfilesChanged={onProfilesChanged}
+        onSwitchLibrary={onSwitchLibrary}
+        profiles={profiles}
+      />
 
       <div className="settings-group">
         <div>
@@ -1373,24 +1629,43 @@ function SyncPanel({
       className="sync-section"
       hidden={hidden}
     >
-      <div className="sync-copy">
+      <header className="sync-header">
         <p className="eyebrow">Remote</p>
         <h2 id="sync-heading">Private sync</h2>
-        <p>
-          Exchange immutable updates through one private GitHub repository. Git
-          does not resolve library state.
-        </p>
-        <div className="sync-state" role="status">
-          <span aria-hidden="true" className="status-dot" />
-          <span>{state.status}</span>
-        </div>
-        {remote ? (
-          <p className="sync-remote">
-            <strong>{remote.owner}/{remote.repository}</strong>
-            <span>Branch {remote.branch}</span>
-          </p>
-        ) : null}
+        <p>Exchange updates through one private GitHub repository.</p>
+      </header>
+
+      <div className="sync-state" role="status">
+        <span aria-hidden="true" className="status-dot" />
+        <span>{state.status}</span>
       </div>
+
+      {remote ? (
+        <dl className="sync-facts">
+          <div>
+            <dt>Repository</dt>
+            <dd>{remote.owner}/{remote.repository}</dd>
+          </div>
+          <div>
+            <dt>Branch</dt>
+            <dd>{remote.branch}</dd>
+          </div>
+          <div>
+            <dt>Last sync</dt>
+            <dd>
+              {remote.lastSuccessAt ? formatDateTime(remote.lastSuccessAt) : "Never"}
+            </dd>
+          </div>
+          {state.lastCycle ? (
+            <div>
+              <dt>Last cycle</dt>
+              <dd>
+                {state.lastCycle.downloaded} down · {state.lastCycle.uploaded} up
+              </dd>
+            </div>
+          ) : null}
+        </dl>
+      ) : null}
 
       <div className="sync-content">
         <PendingSyncChanges
@@ -1440,8 +1715,8 @@ function SyncPanel({
         ) : !state.credentialAvailable ? (
           <form className="sync-form" onSubmit={(event) => void unlock(event)}>
             <p>
-              Repository details stay on this device, but the credential does not.
-              Enter it again to pull and push queued changes.
+              The repository is remembered on this device; the token is not. Enter
+              it again to pull and push queued changes.
             </p>
             <TokenFields />
             {error ? <p className="sync-error" role="alert">{error}</p> : null}
@@ -1452,15 +1727,9 @@ function SyncPanel({
         ) : (
           <div className="sync-controls">
             <p>
-              Your credential is active only in this browser context and never enters
-              the library, an API URL, or the service-worker cache.
+              The token stays in this browser context only. It never enters the
+              library, a URL, or the service-worker cache.
             </p>
-            {state.lastCycle ? (
-              <dl className="sync-counts">
-                <div><dt>Downloaded</dt><dd>{state.lastCycle.downloaded}</dd></div>
-                <div><dt>Uploaded</dt><dd>{state.lastCycle.uploaded}</dd></div>
-              </dl>
-            ) : null}
             {error ? <p className="sync-error" role="alert">{error}</p> : null}
             <div className="sync-actions">
               <button
@@ -1513,8 +1782,7 @@ function PendingSyncChanges({
         <span>{pluralize(changes.length, "change")}</span>
       </div>
       <p className="sync-pending-help">
-        Outgoing changes stay on this device until GitHub confirms them. Incoming
-        changes are discovered during sync.
+        Outgoing changes stay on this device until GitHub confirms them.
       </p>
 
       {changes.length > 0 ? (
@@ -1576,8 +1844,8 @@ function TokenFields() {
         <span>Keep the token only for this tab session</span>
       </label>
       <p className="sync-help">
-        Use an expiring fine-grained token limited to this private repository with
-        Contents read and write access. Leave the box off to keep it in memory only.
+        Use an expiring fine-grained token limited to this repository, with
+        Contents read and write. Leave the box off to keep it in memory only.
       </p>
     </>
   );
@@ -1625,18 +1893,24 @@ function QuickAdd({
 
 function CommandPalette({
   items,
+  libraries,
   onClose,
   onFilterTag,
+  onNewLibrary,
   onNewSave,
   onOpenItem,
+  onSwitchLibrary,
   onSync,
   tags,
 }: {
   items: LibraryItemView[];
+  libraries: LibraryProfile[];
   onClose: () => void;
   onFilterTag: (tag: string) => void;
   onNewSave: () => void;
+  onNewLibrary: () => void;
   onOpenItem: (item: LibraryItemView) => void;
+  onSwitchLibrary: (profileId: string) => void;
   onSync: () => void;
   tags: { count: number; tag: string }[];
 }) {
@@ -1654,7 +1928,11 @@ function CommandPalette({
         .some((value) => value!.toLocaleLowerCase().includes(normalized)),
     )
     .slice(0, 6);
-  const optionCount = matchingTags.length + matchingItems.length + 2;
+  const matchingLibraries = libraries
+    .filter((profile) => !normalized || profile.name.toLocaleLowerCase().includes(normalized))
+    .slice(0, 4);
+  const optionCount =
+    matchingTags.length + matchingItems.length + matchingLibraries.length + 3;
 
   function runOption(index: number) {
     if (index < matchingTags.length) {
@@ -1668,8 +1946,15 @@ function CommandPalette({
       return;
     }
 
-    if (itemIndex === matchingItems.length) onSync();
-    else onNewSave();
+    const libraryIndex = itemIndex - matchingItems.length;
+    if (libraryIndex < matchingLibraries.length) {
+      onSwitchLibrary(matchingLibraries[libraryIndex]!.id);
+      return;
+    }
+
+    if (libraryIndex === matchingLibraries.length) onSync();
+    else if (libraryIndex === matchingLibraries.length + 1) onNewSave();
+    else onNewLibrary();
   }
 
   function moveSelection(offset: number) {
@@ -1754,9 +2039,17 @@ function CommandPalette({
             <em>{item.tags.map((tag) => `#${tag}`).join(" ")}</em>
           </button>;
         })}
+        {matchingLibraries.length > 0 ? <p role="presentation">Libraries</p> : null}
+        {matchingLibraries.map((profile, libraryIndex) => {
+          const index = matchingTags.length + matchingItems.length + libraryIndex;
+          return <button aria-selected={activeIndex === index} className={activeIndex === index ? "command-selected" : undefined} id={`command-option-${index}`} key={profile.id} onClick={() => onSwitchLibrary(profile.id)} onPointerEnter={() => setActiveIndex(index)} role="option" type="button">
+            <span>{profile.name}</span><em>↵ open library</em>
+          </button>;
+        })}
         <p role="presentation">Actions</p>
-        <button aria-selected={activeIndex === optionCount - 2} className={activeIndex === optionCount - 2 ? "command-selected" : undefined} id={`command-option-${optionCount - 2}`} onClick={onSync} onPointerEnter={() => setActiveIndex(optionCount - 2)} role="option" type="button"><span>Sync</span><em>open status</em></button>
-        <button aria-selected={activeIndex === optionCount - 1} className={activeIndex === optionCount - 1 ? "command-selected" : undefined} id={`command-option-${optionCount - 1}`} onClick={onNewSave} onPointerEnter={() => setActiveIndex(optionCount - 1)} role="option" type="button"><span>Save a URL</span><em>new save</em></button>
+        <button aria-selected={activeIndex === optionCount - 3} className={activeIndex === optionCount - 3 ? "command-selected" : undefined} id={`command-option-${optionCount - 3}`} onClick={onSync} onPointerEnter={() => setActiveIndex(optionCount - 3)} role="option" type="button"><span>Sync</span><em>open status</em></button>
+        <button aria-selected={activeIndex === optionCount - 2} className={activeIndex === optionCount - 2 ? "command-selected" : undefined} id={`command-option-${optionCount - 2}`} onClick={onNewSave} onPointerEnter={() => setActiveIndex(optionCount - 2)} role="option" type="button"><span>Save a URL</span><em>new save</em></button>
+        <button aria-selected={activeIndex === optionCount - 1} className={activeIndex === optionCount - 1 ? "command-selected" : undefined} id={`command-option-${optionCount - 1}`} onClick={onNewLibrary} onPointerEnter={() => setActiveIndex(optionCount - 1)} role="option" type="button"><span>New library</span><em>create and open</em></button>
       </div>
       <footer className="command-footer"><span><b>Ctrl P/N · ↑↓</b> navigate</span><span><b>↵</b> select</span><span><b>esc</b> close</span></footer>
     </dialog>

--- a/web/src/data/db.ts
+++ b/web/src/data/db.ts
@@ -130,13 +130,6 @@ interface ResearchPocketBrowserDb extends DBSchema {
   };
 }
 
-let databasePromise: Promise<IDBPDatabase<ResearchPocketBrowserDb>> | undefined;
-
-export function browserDatabase(): Promise<IDBPDatabase<ResearchPocketBrowserDb>> {
-  databasePromise ??= openBrowserDatabase("researchpocket-v2");
-  return databasePromise;
-}
-
 export function openBrowserDatabase(
   name: string,
 ): Promise<IDBPDatabase<ResearchPocketBrowserDb>> {

--- a/web/src/data/library.ts
+++ b/web/src/data/library.ts
@@ -6,7 +6,7 @@ import initWasm, {
 } from "../generated/research_domain";
 
 import {
-  browserDatabase,
+  openBrowserDatabase,
   type BrowserDatabase,
   type PersistedBatch,
   type PersistedChangeField,
@@ -25,8 +25,16 @@ import {
   matchesUndoExpectation,
   type UndoableChange,
 } from "./undo.ts";
+import {
+  activeProfile,
+  profileStorageNames,
+  setActiveProfile,
+  type LibraryProfile,
+  type ProfileStorageNames,
+} from "./profiles.ts";
 
 export type { UndoableChange } from "./undo.ts";
+export type { LibraryProfile } from "./profiles.ts";
 
 export type LibraryItem = PersistedItem;
 
@@ -152,8 +160,6 @@ type TextUpdate =
   | { type: "set"; value: string }
   | { type: "clear" };
 
-const WRITE_LOCK = "researchpocket-v2-writer";
-const CHANNEL_NAME = "researchpocket-v2-state";
 const U64_MAX = 18_446_744_073_709_551_615n;
 
 let wasmPromise: Promise<unknown> | undefined;
@@ -175,19 +181,59 @@ class LibraryRepository {
   };
 
   private readonly listeners = new Set<(state: LibraryState) => void>();
-  private readonly channel = new BroadcastChannel(CHANNEL_NAME);
+  private readonly names: ProfileStorageNames;
+  private readonly channel: BroadcastChannel;
+  private readonly pending = new Set<Promise<unknown>>();
+  private databasePromise: Promise<BrowserDatabase> | undefined;
+  private closed = false;
 
-  constructor() {
+  constructor(names: ProfileStorageNames) {
+    this.names = names;
+    this.channel = new BroadcastChannel(names.stateChannel);
     this.channel.addEventListener("message", () => {
       void this.load();
     });
-    window.addEventListener("researchpocket:database-blocked", () => {
-      this.patchState({
-        error: "Another tab is finishing a library upgrade. Close older tabs and retry.",
-        status: "Library upgrade blocked",
-      });
-    });
+    window.addEventListener("researchpocket:database-blocked", this.onDatabaseBlocked);
     void this.load();
+  }
+
+  private readonly onDatabaseBlocked = (): void => {
+    this.patchState({
+      error: "Another tab is finishing a library upgrade. Close older tabs and retry.",
+      status: "Library upgrade blocked",
+    });
+  };
+
+  private database(): Promise<BrowserDatabase> {
+    this.databasePromise ??= openBrowserDatabase(this.names.database);
+    return this.databasePromise;
+  }
+
+  /**
+   * Waits for every write already in flight, then releases this profile's
+   * database, channel, and listeners. A switch must not leave a transaction
+   * running against the library the user just left.
+   */
+  async close(): Promise<void> {
+    this.closed = true;
+    while (this.pending.size > 0) {
+      await Promise.allSettled([...this.pending]);
+    }
+    window.removeEventListener("researchpocket:database-blocked", this.onDatabaseBlocked);
+    this.channel.close();
+    this.listeners.clear();
+    if (this.databasePromise) {
+      const database = await this.databasePromise.catch(() => null);
+      database?.close();
+    }
+  }
+
+  private track<T>(work: Promise<T>): Promise<T> {
+    const entry: Promise<T> = work.finally(() => {
+      this.pending.delete(entry);
+    });
+    this.pending.add(entry);
+    return entry;
   }
 
   getState(): LibraryState {
@@ -288,7 +334,7 @@ class LibraryRepository {
   }
 
   async syncIdentity(): Promise<BrowserSyncIdentity> {
-    const database = await browserDatabase();
+    const database = await this.database();
     const meta = await database.get("meta", "library");
     if (!meta) throw new Error("Create the browser library before connecting sync.");
     return {
@@ -299,7 +345,7 @@ class LibraryRepository {
   }
 
   async syncConfiguration(): Promise<SyncConfiguration | null> {
-    return (await (await browserDatabase()).get("syncConfig", "github")) ?? null;
+    return (await (await this.database()).get("syncConfig", "github")) ?? null;
   }
 
   async configureSync(
@@ -381,7 +427,7 @@ class LibraryRepository {
   }
 
   async pendingSyncBatches(): Promise<PendingSyncBatch[]> {
-    const database = await browserDatabase();
+    const database = await this.database();
     const outbox = await database.getAll("outbox");
     const pending = await Promise.all(
       outbox.map(async (entry) => {
@@ -400,7 +446,7 @@ class LibraryRepository {
   }
 
   async remoteObservation(path: string): Promise<RemoteObservation | null> {
-    return (await (await browserDatabase()).get("remoteObservations", path)) ?? null;
+    return (await (await this.database()).get("remoteObservations", path)) ?? null;
   }
 
   async recordRemoteObservation(path: string, blobSha: string): Promise<void> {
@@ -447,7 +493,7 @@ class LibraryRepository {
   }
 
   async deferredSyncCount(): Promise<number> {
-    return (await browserDatabase()).count("deferred");
+    return (await this.database()).count("deferred");
   }
 
   async recordSyncSuccess(): Promise<void> {
@@ -660,7 +706,7 @@ class LibraryRepository {
 
   private async load(): Promise<void> {
     try {
-      const database = await browserDatabase();
+      const database = await this.database();
       const meta = await database.get("meta", "library");
       if (!meta) {
         this.state = {
@@ -702,14 +748,17 @@ class LibraryRepository {
   }
 
   private async write(operation: (database: BrowserDatabase) => Promise<void>): Promise<void> {
-    const execute = async () => operation(await browserDatabase());
+    const execute = async () => operation(await this.database());
     try {
+      if (this.closed) {
+        throw new Error("This library was closed. Reopen it before saving changes.");
+      }
       if (!navigator.locks) {
         throw new Error(
           "Safe library writes require a browser with cross-tab Web Locks support.",
         );
       }
-      await navigator.locks.request(WRITE_LOCK, execute);
+      await this.track(navigator.locks.request(this.names.writeLock, execute));
     } catch (error) {
       this.patchState({ error: safeError(error), status: "Change was not saved" });
       throw error;
@@ -1183,4 +1232,224 @@ function safeError(error: unknown): string {
   return error instanceof Error ? error.message : "An unexpected browser storage error occurred.";
 }
 
-export const libraryRepository = new LibraryRepository();
+/**
+ * Hooks the sync service uses to stand down across a profile switch. They are
+ * registered rather than imported so the library layer keeps no dependency on
+ * the sync layer.
+ */
+export interface SyncBridge {
+  /** Resolves once no sync cycle is running and none can start. */
+  quiesce(): Promise<void>;
+}
+
+const OPENING_STATE: LibraryState = {
+  initialized: false,
+  loading: true,
+  items: [],
+  pendingChanges: [],
+  pendingCount: 0,
+  status: "Opening your private library…",
+  error: null,
+};
+
+/**
+ * Owns whichever profile is currently open and forwards the repository API to
+ * it. Every consumer holds this one stable object, so a switch replaces the
+ * underlying replica without any component re-wiring its imports.
+ */
+class LibraryWorkspace {
+  private state: LibraryState = OPENING_STATE;
+  private readonly listeners = new Set<(state: LibraryState) => void>();
+  private readonly profileListeners = new Set<(profile: LibraryProfile) => void>();
+  private active: LibraryRepository | null = null;
+  private profile: LibraryProfile | null = null;
+  private detach: (() => void) | null = null;
+  private bridge: SyncBridge | null = null;
+  private ready: Promise<void>;
+
+  constructor() {
+    this.ready = this.open();
+  }
+
+  private async open(): Promise<void> {
+    try {
+      this.attach(await activeProfile());
+    } catch (error) {
+      this.patchState({
+        loading: false,
+        error: safeError(error),
+        status: "Could not open the browser library",
+      });
+    }
+  }
+
+  private attach(profile: LibraryProfile): void {
+    const repository = new LibraryRepository(profileStorageNames(profile.namespace));
+    this.active = repository;
+    this.profile = profile;
+    // Emissions from a replaced instance are dropped, so a late resolution
+    // from the previous profile can never repaint the new one.
+    this.detach = repository.subscribe((next) => {
+      if (this.active !== repository) return;
+      this.state = next;
+      this.emit();
+    });
+    for (const listener of this.profileListeners) listener(profile);
+  }
+
+  private async instance(): Promise<LibraryRepository> {
+    await this.ready;
+    if (!this.active) throw new Error("The browser library is not open.");
+    return this.active;
+  }
+
+  registerSyncBridge(bridge: SyncBridge): void {
+    this.bridge = bridge;
+  }
+
+  activeProfile(): LibraryProfile | null {
+    return this.profile;
+  }
+
+  subscribeProfile(listener: (profile: LibraryProfile) => void): () => void {
+    this.profileListeners.add(listener);
+    if (this.profile) listener(this.profile);
+    return () => this.profileListeners.delete(listener);
+  }
+
+  /**
+   * Closes the current profile and opens another. Sync stands down first so no
+   * in-flight cycle can apply one profile's updates to the next one.
+   */
+  async switchProfile(profileId: string): Promise<LibraryProfile> {
+    await this.ready;
+    if (this.profile?.id === profileId) return this.profile;
+
+    const switching = (async () => {
+      const previous = this.active;
+      this.active = null;
+      this.detach?.();
+      this.detach = null;
+      this.state = OPENING_STATE;
+      this.emit();
+
+      await this.bridge?.quiesce();
+      await previous?.close();
+
+      // attach() notifies profile subscribers, which is how sync rebinds.
+      const profile = await setActiveProfile(profileId);
+      this.attach(profile);
+      return profile;
+    })();
+
+    this.ready = switching.then(
+      () => undefined,
+      () => undefined,
+    );
+    return switching;
+  }
+
+  getState(): LibraryState {
+    return this.state;
+  }
+
+  subscribe(listener: (state: LibraryState) => void): () => void {
+    this.listeners.add(listener);
+    listener(this.state);
+    return () => this.listeners.delete(listener);
+  }
+
+  private patchState(patch: Partial<LibraryState>): void {
+    this.state = { ...this.state, ...patch };
+    this.emit();
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) listener(this.state);
+  }
+
+  async initialize(): Promise<void> {
+    return (await this.instance()).initialize();
+  }
+
+  async add(input: AddItemInput): Promise<UndoableChange | null> {
+    return (await this.instance()).add(input);
+  }
+
+  async edit(itemId: string, input: EditItemInput): Promise<UndoableChange | null> {
+    return (await this.instance()).edit(itemId, input);
+  }
+
+  async remove(itemId: string): Promise<UndoableChange | null> {
+    return (await this.instance()).remove(itemId);
+  }
+
+  async restore(itemId: string): Promise<UndoableChange | null> {
+    return (await this.instance()).restore(itemId);
+  }
+
+  async undo(change: UndoableChange): Promise<void> {
+    return (await this.instance()).undo(change);
+  }
+
+  async syncIdentity(): Promise<BrowserSyncIdentity> {
+    return (await this.instance()).syncIdentity();
+  }
+
+  async syncConfiguration(): Promise<SyncConfiguration | null> {
+    return (await this.instance()).syncConfiguration();
+  }
+
+  async configureSync(
+    owner: string,
+    repository: string,
+    branch: string,
+  ): Promise<SyncConfiguration> {
+    return (await this.instance()).configureSync(owner, repository, branch);
+  }
+
+  async adoptRemoteLibraryIfPristine(libraryId: string): Promise<boolean> {
+    return (await this.instance()).adoptRemoteLibraryIfPristine(libraryId);
+  }
+
+  async pendingSyncBatches(): Promise<PendingSyncBatch[]> {
+    return (await this.instance()).pendingSyncBatches();
+  }
+
+  async remoteObservation(path: string): Promise<RemoteObservation | null> {
+    return (await this.instance()).remoteObservation(path);
+  }
+
+  async recordRemoteObservation(path: string, blobSha: string): Promise<void> {
+    return (await this.instance()).recordRemoteObservation(path, blobSha);
+  }
+
+  async recordOutboxAttempt(path: string, errorKind: string | null): Promise<void> {
+    return (await this.instance()).recordOutboxAttempt(path, errorKind);
+  }
+
+  async recordOutboxAttempts(paths: string[], errorKind: string | null): Promise<void> {
+    return (await this.instance()).recordOutboxAttempts(paths, errorKind);
+  }
+
+  async deferredSyncCount(): Promise<number> {
+    return (await this.instance()).deferredSyncCount();
+  }
+
+  async recordSyncSuccess(): Promise<void> {
+    return (await this.instance()).recordSyncSuccess();
+  }
+
+  async recordSyncFailure(kind: string): Promise<void> {
+    return (await this.instance()).recordSyncFailure(kind);
+  }
+
+  async applyRemote(
+    inputs: RemoteEnvelopeInput[],
+    packs: RemoteOperationPackInput[] = [],
+  ): Promise<number> {
+    return (await this.instance()).applyRemote(inputs, packs);
+  }
+}
+
+export const libraryRepository = new LibraryWorkspace();

--- a/web/src/data/profiles.test.mjs
+++ b/web/src/data/profiles.test.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import "fake-indexeddb/auto";
+
+import { openBrowserDatabase } from "./db.ts";
+import {
+  DEFAULT_NAMESPACE,
+  activeProfile,
+  createProfile,
+  deleteProfile,
+  listProfiles,
+  normalizeProfileName,
+  profileStorageNames,
+  renameProfile,
+  setActiveProfile,
+} from "./profiles.ts";
+
+/** The registry is process-wide, so each test claims its own library names. */
+function uniqueName(label) {
+  return `${label} ${crypto.randomUUID().slice(0, 8)}`;
+}
+
+// Runs first, while the registry is still empty, to prove the adoption path.
+test("the first read adopts the pre-profile library without renaming its storage", async () => {
+  const profiles = await listProfiles();
+
+  assert.equal(profiles.length, 1);
+  const [adopted] = profiles;
+  assert.equal(adopted.id, "default");
+  assert.equal(
+    adopted.namespace,
+    DEFAULT_NAMESPACE,
+    "an existing installation must keep using its original database",
+  );
+  assert.equal(profileStorageNames(adopted.namespace).database, "researchpocket-v2");
+  assert.equal((await activeProfile()).id, adopted.id);
+});
+
+test("every profile owns a distinct database, lock, channel, and credential key", async () => {
+  const [personal] = await listProfiles();
+  const team = await createProfile(uniqueName("Team"));
+
+  const one = profileStorageNames(personal.namespace);
+  const two = profileStorageNames(team.namespace);
+
+  const names = new Set([...Object.values(one), ...Object.values(two)]);
+  assert.equal(
+    names.size,
+    Object.keys(one).length + Object.keys(two).length,
+    "no durable name may be shared between two libraries",
+  );
+  assert.notEqual(one.sessionTokenKey, two.sessionTokenKey);
+  assert.notEqual(one.syncLock, two.syncLock);
+});
+
+test("records written under one profile stay invisible to another", async () => {
+  const first = await createProfile(uniqueName("Personal"));
+  const second = await createProfile(uniqueName("Team"));
+
+  const firstDb = await openBrowserDatabase(profileStorageNames(first.namespace).database);
+  await firstDb.put("outbox", {
+    path: "sync/v1/ops/device-a/00000000000000000001.json",
+    enqueuedAt: "2026-07-24T00:00:00.000Z",
+    attempts: 0,
+    lastErrorKind: null,
+  });
+  firstDb.close();
+
+  const secondDb = await openBrowserDatabase(profileStorageNames(second.namespace).database);
+  assert.deepEqual(
+    await secondDb.getAll("outbox"),
+    [],
+    "a queued update must not cross libraries",
+  );
+  assert.equal(await secondDb.get("meta", "library"), undefined);
+  secondDb.close();
+});
+
+test("switching moves the active pointer and records when a library was opened", async () => {
+  const [personal] = await listProfiles();
+  const team = await createProfile(uniqueName("Team"));
+
+  const switched = await setActiveProfile(team.id);
+  assert.equal(switched.id, team.id);
+  assert.ok(switched.lastOpenedAt, "an opened profile records when it was last used");
+  assert.equal((await activeProfile()).id, team.id);
+
+  await setActiveProfile(personal.id);
+  assert.equal((await activeProfile()).id, personal.id);
+});
+
+test("names are normalized, required, and unique", async () => {
+  const label = uniqueName("Reading");
+  await createProfile(`  ${label}  `);
+  assert.ok((await listProfiles()).some((profile) => profile.name === label));
+
+  assert.equal(normalizeProfileName(" Reading  list "), "Reading list");
+  assert.throws(() => normalizeProfileName("   "), /Enter a name/);
+  await assert.rejects(createProfile(label.toLowerCase()), /already exists/);
+  await assert.rejects(createProfile("x".repeat(61)), /limited to/);
+});
+
+test("renaming keeps identity and storage stable", async () => {
+  const team = await createProfile(uniqueName("Team"));
+  const label = uniqueName("Research");
+  const renamed = await renameProfile(team.id, label);
+
+  assert.equal(renamed.id, team.id);
+  assert.equal(renamed.namespace, team.namespace);
+  assert.equal(
+    (await listProfiles()).find((profile) => profile.id === team.id).name,
+    label,
+  );
+});
+
+test("deleting a profile destroys its replica and reselects when it was open", async () => {
+  const team = await createProfile(uniqueName("Team"));
+  await setActiveProfile(team.id);
+
+  const teamDb = await openBrowserDatabase(profileStorageNames(team.namespace).database);
+  await teamDb.put("meta", {
+    key: "library",
+    libraryId: "00000000-0000-7000-8000-000000000009",
+    deviceId: "00000000-0000-7000-8000-00000000000a",
+    peerId: "7",
+    nextSequence: "00000000000000000001",
+    createdAt: "2026-07-24T00:00:00.000Z",
+  });
+  teamDb.close();
+
+  const next = await deleteProfile(team.id);
+  assert.notEqual(next.id, team.id, "deleting the open library selects another");
+  assert.equal((await activeProfile()).id, next.id);
+  assert.ok(!(await listProfiles()).some((profile) => profile.id === team.id));
+
+  const reopened = await openBrowserDatabase(profileStorageNames(team.namespace).database);
+  assert.equal(
+    await reopened.get("meta", "library"),
+    undefined,
+    "the local replica is destroyed with the profile",
+  );
+  reopened.close();
+});
+
+// Runs last: it prunes the registry down to a single remaining library.
+test("the last library cannot be deleted", async () => {
+  const profiles = await listProfiles();
+  for (const profile of profiles.slice(1)) {
+    await deleteProfile(profile.id);
+  }
+
+  const remaining = await listProfiles();
+  assert.equal(remaining.length, 1);
+  await assert.rejects(deleteProfile(remaining[0].id), /at least one library/);
+});

--- a/web/src/data/profiles.ts
+++ b/web/src/data/profiles.ts
@@ -1,0 +1,211 @@
+import { deleteDB, openDB, type DBSchema, type IDBPDatabase } from "idb";
+
+/**
+ * A profile is one isolated local library container. Its identity is local
+ * only: it never enters an update envelope, a repository path, or a receipt.
+ * The canonical library identity still comes from the repository genesis.
+ */
+export interface LibraryProfile {
+  id: string;
+  name: string;
+  namespace: string;
+  createdAt: string;
+  lastOpenedAt: string | null;
+}
+
+/**
+ * Every durable browser name a profile owns. Deriving them from one namespace
+ * keeps a switch from leaving a store, lock, channel, or credential behind.
+ */
+export interface ProfileStorageNames {
+  database: string;
+  writeLock: string;
+  stateChannel: string;
+  syncLock: string;
+  sessionTokenKey: string;
+}
+
+interface PersistedActiveProfile {
+  key: "active";
+  profileId: string;
+}
+
+interface ProfileRegistryDb extends DBSchema {
+  profiles: {
+    key: string;
+    value: LibraryProfile;
+  };
+  registry: {
+    key: "active";
+    value: PersistedActiveProfile;
+  };
+}
+
+const REGISTRY_DATABASE = "researchpocket-profiles";
+const DEFAULT_PROFILE_ID = "default";
+const DEFAULT_PROFILE_NAME = "Personal";
+const MAX_NAME_LENGTH = 60;
+
+/**
+ * The first profile keeps the historical names, so an installation that
+ * predates profiles adopts a default profile without moving any data.
+ */
+export const DEFAULT_NAMESPACE = "researchpocket-v2";
+
+export function profileStorageNames(namespace: string): ProfileStorageNames {
+  return {
+    database: namespace,
+    writeLock: `${namespace}-writer`,
+    stateChannel: `${namespace}-state`,
+    syncLock: `${namespace}-github-sync`,
+    sessionTokenKey: `${namespace}-github-token`,
+  };
+}
+
+let registryPromise: Promise<IDBPDatabase<ProfileRegistryDb>> | undefined;
+
+function registryDatabase(): Promise<IDBPDatabase<ProfileRegistryDb>> {
+  registryPromise ??= openDB<ProfileRegistryDb>(REGISTRY_DATABASE, 1, {
+    upgrade(database) {
+      database.createObjectStore("profiles", { keyPath: "id" });
+      database.createObjectStore("registry", { keyPath: "key" });
+    },
+  });
+  return registryPromise;
+}
+
+export function normalizeProfileName(name: string): string {
+  const normalized = name.trim().replace(/\s+/gu, " ");
+  if (!normalized) throw new Error("Enter a name for the library.");
+  if (normalized.length > MAX_NAME_LENGTH) {
+    throw new Error(`Library names are limited to ${MAX_NAME_LENGTH} characters.`);
+  }
+  return normalized;
+}
+
+function compareProfiles(left: LibraryProfile, right: LibraryProfile): number {
+  return left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id);
+}
+
+/**
+ * Reads every profile, adopting the implicit pre-profile library as the
+ * default entry the first time this runs.
+ */
+export async function listProfiles(): Promise<LibraryProfile[]> {
+  const database = await registryDatabase();
+  const profiles = await database.getAll("profiles");
+  if (profiles.length > 0) return profiles.sort(compareProfiles);
+
+  const adopted: LibraryProfile = {
+    id: DEFAULT_PROFILE_ID,
+    name: DEFAULT_PROFILE_NAME,
+    namespace: DEFAULT_NAMESPACE,
+    createdAt: new Date().toISOString(),
+    lastOpenedAt: null,
+  };
+  const transaction = database.transaction(["profiles", "registry"], "readwrite");
+  await transaction.objectStore("profiles").put(adopted);
+  await transaction.objectStore("registry").put({ key: "active", profileId: adopted.id });
+  await transaction.done;
+  return [adopted];
+}
+
+export async function activeProfile(): Promise<LibraryProfile> {
+  const profiles = await listProfiles();
+  const database = await registryDatabase();
+  const active = await database.get("registry", "active");
+  const selected = profiles.find((profile) => profile.id === active?.profileId);
+  if (selected) return selected;
+
+  // The pointer names a profile that no longer exists; fall back to the oldest.
+  const fallback = profiles[0]!;
+  await database.put("registry", { key: "active", profileId: fallback.id });
+  return fallback;
+}
+
+export async function setActiveProfile(profileId: string): Promise<LibraryProfile> {
+  const database = await registryDatabase();
+  const profile = await database.get("profiles", profileId);
+  if (!profile) throw new Error("That library is no longer available.");
+
+  const opened: LibraryProfile = { ...profile, lastOpenedAt: new Date().toISOString() };
+  const transaction = database.transaction(["profiles", "registry"], "readwrite");
+  await transaction.objectStore("profiles").put(opened);
+  await transaction.objectStore("registry").put({ key: "active", profileId });
+  await transaction.done;
+  return opened;
+}
+
+export async function createProfile(name: string): Promise<LibraryProfile> {
+  const normalized = normalizeProfileName(name);
+  const profiles = await listProfiles();
+  if (profiles.some((profile) => profile.name.toLowerCase() === normalized.toLowerCase())) {
+    throw new Error("A library with that name already exists.");
+  }
+
+  const id = crypto.randomUUID();
+  const profile: LibraryProfile = {
+    id,
+    name: normalized,
+    namespace: `${DEFAULT_NAMESPACE}-${id}`,
+    createdAt: new Date().toISOString(),
+    lastOpenedAt: null,
+  };
+  const database = await registryDatabase();
+  await database.put("profiles", profile);
+  return profile;
+}
+
+export async function renameProfile(profileId: string, name: string): Promise<LibraryProfile> {
+  const normalized = normalizeProfileName(name);
+  const profiles = await listProfiles();
+  const profile = profiles.find((candidate) => candidate.id === profileId);
+  if (!profile) throw new Error("That library is no longer available.");
+  if (
+    profiles.some(
+      (candidate) =>
+        candidate.id !== profileId &&
+        candidate.name.toLowerCase() === normalized.toLowerCase(),
+    )
+  ) {
+    throw new Error("A library with that name already exists.");
+  }
+
+  const renamed: LibraryProfile = { ...profile, name: normalized };
+  const database = await registryDatabase();
+  await database.put("profiles", renamed);
+  return renamed;
+}
+
+/**
+ * Removes a profile and destroys its local replica. The remote repository is
+ * never touched, so a deleted local copy can be restored by reconnecting.
+ */
+export async function deleteProfile(profileId: string): Promise<LibraryProfile> {
+  const profiles = await listProfiles();
+  if (profiles.length === 1) {
+    throw new Error("Keep at least one library.");
+  }
+  const profile = profiles.find((candidate) => candidate.id === profileId);
+  if (!profile) throw new Error("That library is no longer available.");
+
+  const database = await registryDatabase();
+  await database.delete("profiles", profileId);
+
+  const active = await database.get("registry", "active");
+  const remaining = profiles.filter((candidate) => candidate.id !== profileId);
+  const next = remaining[0]!;
+  if (active?.profileId === profileId) {
+    await database.put("registry", { key: "active", profileId: next.id });
+  }
+
+  const names = profileStorageNames(profile.namespace);
+  try {
+    sessionStorage.removeItem(names.sessionTokenKey);
+  } catch {
+    // A blocked session store only means the token expires with the tab.
+  }
+  await deleteDB(names.database);
+
+  return active?.profileId === profileId ? next : (await activeProfile());
+}

--- a/web/src/data/sync.ts
+++ b/web/src/data/sync.ts
@@ -23,6 +23,11 @@ import {
   type RemoteOperationPackInput,
   type SyncConfiguration,
 } from "./library.ts";
+import {
+  profileStorageNames,
+  type LibraryProfile,
+  type ProfileStorageNames,
+} from "./profiles.ts";
 
 export interface BrowserSyncState {
   configuration: SyncConfiguration | null;
@@ -74,9 +79,6 @@ interface PendingUpload {
   packed: boolean;
 }
 
-const SYNC_LOCK = "researchpocket-v2-github-sync";
-const LIBRARY_CHANNEL = "researchpocket-v2-state";
-const SESSION_TOKEN_KEY = "researchpocket-v2-github-token";
 const MAX_UPLOAD_ATTEMPTS = 4;
 const PERIODIC_SYNC_MS = 60_000;
 const LOCAL_CHANGE_SYNC_DELAY_MS = 5_000;
@@ -101,19 +103,22 @@ class BrowserSyncService {
     lastCycle: null,
   };
 
-  #token: string | null = readSessionToken();
+  #token: string | null = null;
+  #names: ProfileStorageNames | null = null;
   private retryNotBefore = 0;
   private running: Promise<void> | null = null;
   private localChangeTimer: number | null = null;
   private rerunAfterCurrentSync = false;
   private readonly listeners = new Set<(state: BrowserSyncState) => void>();
-  private readonly channel = new BroadcastChannel(LIBRARY_CHANNEL);
+  private channel: BroadcastChannel | null = null;
 
   constructor() {
-    this.channel.addEventListener("message", () => {
-      if (this.#token && this.state.configuration && document.visibilityState === "visible") {
-        this.scheduleLocalChangeSync();
-      }
+    // Sync follows whichever profile is open. Binding happens on the profile
+    // notification rather than at construction so the credential, lock, and
+    // channel always belong to the library currently on screen.
+    libraryRepository.registerSyncBridge({ quiesce: () => this.quiesce() });
+    libraryRepository.subscribeProfile((profile) => {
+      void this.bind(profile);
     });
     window.addEventListener("focus", () => void this.requestSync("window focus"));
     window.addEventListener("online", () => void this.requestSync("network restored"));
@@ -127,12 +132,60 @@ class BrowserSyncService {
         void this.requestSync("periodic refresh");
       }
     }, PERIODIC_SYNC_MS);
-    void this.load().catch((error: unknown) => {
+  }
+
+  /**
+   * Stops all sync activity and drops the credential. Called before a profile
+   * switch so no cycle can carry one library's updates into another.
+   */
+  private async quiesce(): Promise<void> {
+    if (this.localChangeTimer !== null) {
+      window.clearTimeout(this.localChangeTimer);
+      this.localChangeTimer = null;
+    }
+    this.rerunAfterCurrentSync = false;
+    await this.running?.catch(() => undefined);
+    this.#names = null;
+    this.#token = null;
+    this.retryNotBefore = 0;
+    this.channel?.close();
+    this.channel = null;
+    this.state = {
+      configuration: null,
+      credentialAvailable: false,
+      syncing: false,
+      status: "Opening your private library…",
+      error: null,
+      lastCycle: null,
+    };
+    for (const listener of this.listeners) listener(this.state);
+  }
+
+  /** Binds sync to one profile's lock, channel, and session credential. */
+  private async bind(profile: LibraryProfile): Promise<void> {
+    const names = profileStorageNames(profile.namespace);
+    this.#names = names;
+    this.#token = readSessionToken(names.sessionTokenKey);
+    this.channel?.close();
+    this.channel = new BroadcastChannel(names.stateChannel);
+    this.channel.addEventListener("message", () => {
+      if (this.#token && this.state.configuration && document.visibilityState === "visible") {
+        this.scheduleLocalChangeSync();
+      }
+    });
+    try {
+      await this.load();
+    } catch (error: unknown) {
       this.patch({
         status: "Private sync could not open",
         error: error instanceof Error ? error.message : "Could not read sync configuration.",
       });
-    });
+    }
+  }
+
+  private requireNames(): ProfileStorageNames {
+    if (!this.#names) throw new Error("The browser library is still opening.");
+    return this.#names;
   }
 
   getState(): BrowserSyncState {
@@ -204,7 +257,7 @@ class BrowserSyncService {
 
   forgetCredential(): void {
     this.#token = null;
-    removeSessionToken();
+    if (this.#names) removeSessionToken(this.#names.sessionTokenKey);
     this.patch({
       credentialAvailable: false,
       status: this.state.configuration
@@ -233,7 +286,7 @@ class BrowserSyncService {
       if (reason === "local changes") this.rerunAfterCurrentSync = true;
       return this.running;
     }
-    if (!this.#token || !this.state.configuration) return;
+    if (!this.#names || !this.#token || !this.state.configuration) return;
     if (!navigator.onLine) {
       const error = new GitHubSyncError(
         "You are offline. Your queued changes remain stored here and will retry when the network returns.",
@@ -305,10 +358,10 @@ class BrowserSyncService {
       throw new Error("Safe synchronization requires a browser with Web Locks support.");
     }
     if (waitForLock) {
-      await navigator.locks.request(SYNC_LOCK, operation);
+      await navigator.locks.request(this.requireNames().syncLock, operation);
     } else {
       await navigator.locks.request(
-        SYNC_LOCK,
+        this.requireNames().syncLock,
         { ifAvailable: true },
         async (lock) => {
           if (lock) await operation();
@@ -584,8 +637,9 @@ class BrowserSyncService {
     void client;
     this.#token = normalizedToken;
     try {
-      if (rememberForTab) writeSessionToken(normalizedToken);
-      else removeSessionToken();
+      const key = this.requireNames().sessionTokenKey;
+      if (rememberForTab) writeSessionToken(key, normalizedToken);
+      else removeSessionToken(key);
     } catch (error) {
       this.#token = null;
       throw error;
@@ -844,18 +898,18 @@ async function retryDelay(path: string, attempt: number): Promise<void> {
   await new Promise((resolve) => window.setTimeout(resolve, base + jitter));
 }
 
-function readSessionToken(): string | null {
+function readSessionToken(key: string): string | null {
   try {
-    const token = sessionStorage.getItem(SESSION_TOKEN_KEY);
+    const token = sessionStorage.getItem(key);
     return token?.trim() ? token : null;
   } catch {
     return null;
   }
 }
 
-function writeSessionToken(token: string): void {
+function writeSessionToken(key: string, token: string): void {
   try {
-    sessionStorage.setItem(SESSION_TOKEN_KEY, token);
+    sessionStorage.setItem(key, token);
   } catch {
     throw new GitHubSyncError(
       "This browser blocked tab-only token storage. Leave the option off to keep it in memory.",
@@ -864,9 +918,9 @@ function writeSessionToken(token: string): void {
   }
 }
 
-function removeSessionToken(): void {
+function removeSessionToken(key: string): void {
   try {
-    sessionStorage.removeItem(SESSION_TOKEN_KEY);
+    sessionStorage.removeItem(key);
   } catch {
     // The in-memory token is still forgotten even if storage is unavailable.
   }

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -356,11 +356,10 @@
 .library-count,
 .app-shell > footer p,
 .welcome-footnote,
-.sync-copy > p,
+.sync-header > p,
 .sync-controls > p,
 .sync-form > p,
 .sync-help,
-.sync-remote,
 .sync-error {
   margin: 0;
 }
@@ -378,8 +377,7 @@
 }
 
 .eyebrow,
-.status-label,
-.sync-counts dt {
+.status-label {
   color: var(--color-accent-strong);
   font-size: var(--font-size-xs);
   font-weight: 800;
@@ -441,16 +439,24 @@
   font-weight: 500;
 }
 
+/*
+ * One content plane on a single gutter: every label sits on the left edge and
+ * every value starts at --sync-gutter, from the status facts through the
+ * pending list to the form. Mixed gutters were what made this read as ragged.
+ */
 .sync-section {
-  align-items: start;
-  border-bottom: var(--rule) solid var(--color-border-strong);
+  --sync-gutter: 10rem;
+
+  border: 0;
   display: grid;
-  gap: clamp(var(--space-5), 5vw, var(--space-8));
-  grid-template-columns: minmax(12rem, 0.35fr) minmax(24rem, 1fr);
-  padding: var(--space-6) 0;
+  gap: var(--space-6);
+  margin: 0 auto;
+  max-width: 48rem;
+  padding: var(--space-6);
+  width: 100%;
 }
 
-.sync-copy h2,
+.sync-header h2,
 .library-heading-row h2,
 .dialog-heading h2,
 .welcome-card h1,
@@ -461,14 +467,14 @@
   margin: 0;
 }
 
-.sync-copy > p:not(.eyebrow),
+.sync-header > p:not(.eyebrow),
 .welcome-copy,
 .empty-state > p:last-child {
   color: var(--color-text-muted);
   line-height: var(--line-height-body);
 }
 
-.sync-copy > p:not(.eyebrow) {
+.sync-header > p:not(.eyebrow) {
   font-size: var(--font-size-sm);
   margin-top: var(--space-3);
 }
@@ -483,15 +489,30 @@
   padding: var(--space-2) 0;
 }
 
-.sync-remote {
+.sync-facts {
   display: grid;
   font-size: var(--font-size-xs);
-  gap: var(--space-1);
-  margin-top: var(--space-3);
+  margin: 0;
+  min-width: 0;
+}
+
+.sync-facts > div {
+  border-bottom: var(--rule) solid var(--color-border);
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: var(--sync-gutter) minmax(0, 1fr);
+  padding: var(--space-3) 0;
+}
+
+.sync-facts dt {
+  color: var(--color-text-muted);
+}
+
+.sync-facts dd {
+  margin: 0;
   overflow-wrap: anywhere;
 }
 
-.sync-remote span,
 .sync-help,
 .sync-controls > p,
 .sync-form > p {
@@ -507,19 +528,17 @@
   gap: var(--space-4);
 }
 
-.sync-form,
-.sync-controls {
-  max-width: 56rem;
-}
-
 .sync-content {
   display: grid;
   gap: var(--space-6);
-  max-width: 56rem;
   min-width: 0;
 }
 
-.sync-form .field,
+.sync-form .field {
+  align-items: start;
+  grid-template-columns: var(--sync-gutter) minmax(0, 1fr);
+}
+
 .capture-form .field {
   align-items: start;
   grid-template-columns: 10rem minmax(0, 1fr);
@@ -532,13 +551,13 @@
 
 .sync-session-choice {
   align-items: start;
-  margin-left: 10rem;
+  margin-left: var(--sync-gutter);
 }
 
 .sync-help,
 .sync-error,
 .sync-form > .primary-button {
-  margin-left: 10rem;
+  margin-left: var(--sync-gutter);
 }
 
 .sync-form > .primary-button {
@@ -558,33 +577,6 @@
   font-size: var(--font-size-sm);
   margin: 0;
   padding: var(--space-2) var(--space-3);
-}
-
-.sync-counts {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  margin: 0;
-}
-
-.sync-counts div {
-  border-left: var(--rule) solid var(--color-border);
-  padding: var(--space-2);
-}
-
-.sync-counts div:first-child {
-  border-left: 0;
-  padding-left: 0;
-}
-
-.sync-counts dt {
-  color: var(--color-text-muted);
-  letter-spacing: 0;
-}
-
-.sync-counts dd {
-  font-size: var(--font-size-lg);
-  font-weight: 800;
-  margin: 0;
 }
 
 .sync-pending {
@@ -642,7 +634,7 @@
   border-bottom: var(--rule) solid var(--color-border);
   display: grid;
   gap: var(--space-2) var(--space-4);
-  grid-template-columns: 5rem minmax(0, 1fr) max-content;
+  grid-template-columns: var(--sync-gutter) minmax(0, 1fr) max-content;
   padding: var(--space-3) 0;
 }
 
@@ -1708,6 +1700,11 @@ footer {
     margin-left: 0;
   }
 
+  .sync-facts > div {
+    gap: var(--space-1);
+    grid-template-columns: 1fr;
+  }
+
   .capture-actions {
     justify-content: flex-start;
   }
@@ -1879,6 +1876,18 @@ footer {
 
 .masthead-actions {
   gap: 1rem;
+}
+
+.library-switcher {
+  align-items: center;
+  display: inline-flex;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.library-switcher select {
+  max-width: 12rem;
+  min-height: 2rem;
 }
 
 .command-trigger {
@@ -2215,19 +2224,6 @@ kbd {
 .command-footer b,
 .reader-list footer b {
   color: var(--color-text-soft);
-}
-
-.sync-section {
-  border: 0;
-  display: grid;
-  grid-template-columns: minmax(12rem, 0.36fr) minmax(24rem, 1fr);
-  margin: 0 auto;
-  max-width: 58rem;
-  padding: 1.75rem 1.5rem;
-}
-
-.capture-dialog,
-.edit-dialog {
 }
 
 .capture-dialog::backdrop,
@@ -2779,6 +2775,29 @@ kbd {
     display: inline;
   }
 
+  /* The switcher takes its own full-width row so a library name is never
+     squeezed against the brand and the status indicator. */
+  .masthead {
+    flex-wrap: wrap;
+    padding-bottom: var(--space-2);
+  }
+
+  .masthead-actions {
+    flex: 1 0 100%;
+    gap: var(--space-3);
+    justify-content: space-between;
+  }
+
+  .library-switcher {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .library-switcher select {
+    max-width: none;
+    width: 100%;
+  }
+
   .workspace-layout {
     display: flex;
     flex: 1 1 auto;
@@ -3180,9 +3199,57 @@ kbd {
   display: block;
 }
 
+.library-settings,
 .appearance-settings {
   display: grid;
   gap: 1.5rem;
+}
+
+.library-list {
+  display: grid;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.library-row {
+  align-items: center;
+  border-bottom: var(--rule) solid var(--color-border);
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: minmax(0, 1fr) max-content;
+  padding: var(--space-3) 0;
+}
+
+.library-row:first-child {
+  border-top: var(--rule) solid var(--color-border);
+}
+
+.library-row-copy {
+  min-width: 0;
+}
+
+.library-row-copy > p {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.library-row-copy > p:last-child {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.library-row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  justify-content: flex-end;
+}
+
+.library-create {
+  display: grid;
+  gap: var(--space-3);
+  justify-items: start;
 }
 
 .theme-editor {
@@ -3530,6 +3597,14 @@ kbd {
   .settings-group {
     gap: 1.25rem;
     grid-template-columns: 1fr;
+  }
+
+  .library-row {
+    grid-template-columns: 1fr;
+  }
+
+  .library-row-actions {
+    justify-content: flex-start;
   }
 
   .site-header,


### PR DESCRIPTION
Adds isolated, switchable libraries to the owner web app, and fixes the sync view layout and workspace chrome alongside it.

Refs #92. **Does not close it** — that issue asks for an accepted ADR covering both topologies, native data directories, CLI/TUI/capture selection, and per-repository receipts. This is the browser half of the isolated-profiles topology only; multi-repository replication and the native surfaces are untouched.

## Library profiles

A profile is one isolated local library container. Its identity is local only and never enters an envelope, a repository path, or a receipt — the canonical library identity still comes from the repository genesis.

Each profile derives all five durable browser names from a single namespace: IndexedDB database, write lock, state channel, sync lock, and session credential key. The credential key matters most: unnamespaced, switching libraries would hand one repository's token to another.

`LibraryRepository` now takes that namespace, owns its own database handle, and gains a `close()` that drains in-flight writes before releasing it. A `LibraryWorkspace` facade is exported under the existing `libraryRepository` name, so no call site changed. It owns the active instance and drops emissions from a replaced one, so a late resolution from the previous profile cannot repaint the new one. Sync stands down through a registered bridge — awaiting its running cycle and clearing the credential — before the old replica closes, which is what prevents a cycle from applying one library's updates to another.

### Migration

The first profile keeps the namespace `researchpocket-v2`, so an existing installation adopts a default profile named "Personal" with no data movement and no change to its library identity, device sequence, or repository history.

## Sync view

`.sync-section` was declared twice at top level, and the later duplicate re-asserted a two-column grid *after* the `max-width: 48rem` rule. At equal specificity the later declaration won, so the single-column layout never applied and the view had a roughly 600px floor — horizontal overflow below that, against the design system's 320px requirement. The per-field narrow-screen resets were already correct and were simply being masked.

Beyond that, repository facts, pending rows, and form fields each used a different label gutter inside a narrow rail. The view is now one content plane on a shared `--sync-gutter`, so every label sits on the left edge and every value starts at the same offset.

## Workspace chrome

Removed three redundant labels from the masthead ("owner workspace", the "library" label beside the switcher, and "or command" from the search trigger); all state text is unchanged. The rail's tag list was unbounded and now caps at the eight busiest tags, pinning any tag currently filtered on and surfacing the remainder as "+N more".

The switcher appears only once a second library exists. Libraries can be created from the switcher, the command palette, or settings.

## Verification

`npm run typecheck`, `npm run check:design`, `npm test` (13 pass), `vite build`, and `check:dist` all pass.

Eight new tests cover the isolation invariant: an outbox entry written under one profile is invisible to another, no durable name is shared between two profiles, adoption preserves the original database name, and deleting a profile destroys its replica and reselects.

**Not visually verified** — no browser tooling was available in this session, so the layout changes are reasoned from the CSS cascade rather than observed. Worth a look at desktop, tablet, and 320px before merging.