### PR TITLE
Fix mobile UI navigation bar local status wrapping

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -679,7 +679,7 @@ export function App() {
       </a>
 
       <div className="workspace-chrome">
-        <header className="masthead">
+        <header className={`masthead${profiles.length > 1 ? " has-switcher" : ""}`}>
           <button
             aria-label={view === "library" ? "ResearchPocket library" : "Back to library"}
             className="brand-lockup"
@@ -695,7 +695,7 @@ export function App() {
             )}
           </button>
 
-          <div className="masthead-actions">
+          <div className={`masthead-actions${profiles.length > 1 ? " has-switcher" : ""}`}>
             {profiles.length > 1 ? (
               <div className="library-switcher">
                 <select

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2777,12 +2777,12 @@ kbd {
 
   /* The switcher takes its own full-width row so a library name is never
      squeezed against the brand and the status indicator. */
-  .masthead {
+  .masthead.has-switcher {
     flex-wrap: wrap;
     padding-bottom: var(--space-2);
   }
 
-  .masthead-actions {
+  .masthead-actions.has-switcher {
     flex: 1 0 100%;
     gap: var(--space-3);
     justify-content: space-between;


### PR DESCRIPTION
Adds conditional classes to `<header className="masthead">` and `<div className="masthead-actions">` in the React app depending on whether `profiles.length > 1` is true. Under mobile viewports, the full-width row wrapping styles are only applied if the `.has-switcher` class is present, allowing the brand lockup and the connection status indicator to remain nicely aligned on the same horizontal row when there is no profile switcher.

---
*PR created automatically by Jules for task [8106941753658149175](https://jules.google.com/task/8106941753658149175) started by @KorigamiK*