### PR TITLE
Allow per-item Markdown images

### DIFF
--- a/docs/v2/ADR_0009_OPT_IN_MARKDOWN_IMAGES.md
+++ b/docs/v2/ADR_0009_OPT_IN_MARKDOWN_IMAGES.md
@@ -1,0 +1,61 @@
+# ADR 0009: Load remote Markdown images only after per-item consent
+
+- Status: accepted
+- Date: 2026-07-27
+- Issue: [#125](https://github.com/ResearchPocket/researchpocket.github.io/issues/125)
+
+## Context
+
+Firecrawl may retain bounded cleaned Markdown in an item's excerpt. That
+Markdown can reference diagrams, screenshots, and other images useful to the
+owner, but fetching them automatically would disclose a library-reading event
+to arbitrary third-party hosts. The existing Reader therefore rendered every
+image as inert text and the owner CSP denied remote images.
+
+An image proxy would hide the owner's address from the source host, but it would
+introduce a hosted backend, transfer private browsing choices to that service,
+and weaken the offline/local-first boundary. Downloading image bytes into the
+library would create an attachment and archive system outside V2 scope.
+
+## Decision
+
+Markdown images remain inert by default. Each inert image explains that loading
+contacts its host and may reveal the owner's IP address. Choosing **Load images
+for this item** enables valid HTTPS image sources only for that item while the
+current Reader remains open.
+
+The permission is React presentation state keyed by item UUID. It is not a
+domain field, IndexedDB preference, protocol operation, export field, or
+publication setting. Moving to another item does not grant that item
+permission; returning to an already allowed item in the same Reader session
+retains it. Closing the Reader unmounts the state and forgets every grant.
+
+Relative image sources resolve against the saved item's URL. Only HTTPS URLs
+without embedded credentials render. Images use lazy loading, asynchronous
+decoding, useful alternative text, and `Referrer-Policy: no-referrer`. Raw HTML
+remains disabled. Invalid, malformed, HTTP, data, blob, file, JavaScript, and
+credential-bearing sources stay inert.
+
+The owner document permits `img-src 'self' https:` so an opted-in image can
+load. Script, style, font, frame, object, worker, and connection policies do not
+change. The public landing, overview, and documentation documents retain
+self-only image policies, and their Markdown renderer receives no image-loading
+action. Cross-origin image requests bypass the service worker and are never
+stored in ResearchPocket's shell cache.
+
+## Consequences
+
+The image host learns the owner's IP address, user agent, request timing, and
+any cookies the browser elects to attach. Omitting the referrer prevents
+disclosure of the ResearchPocket URL but cannot hide the network request
+itself. Browser HTTP caches may retain image bytes outside ResearchPocket's
+application storage controls.
+
+The CSP can no longer independently prove that owner mode never fetches a
+remote image. Safety instead depends on inert-by-default Markdown components,
+explicit item-scoped consent, HTTPS URL validation, the owner-only CSP
+exception, and production checks that keep public documents self-only.
+
+Images are not available offline unless the browser independently retained
+them, and ResearchPocket makes no promise about that cache. Broken, blocked, or
+tracking-protected images do not affect the saved Markdown or local library.

--- a/docs/v2/DESIGN_SYSTEM.md
+++ b/docs/v2/DESIGN_SYSTEM.md
@@ -57,8 +57,10 @@ or a pointer device.
 Use the bundled Berkeley Mono WOFF2 webfonts with `ui-monospace` and `monospace`
 as local fallbacks. Use semantic HTML, native controls where practical, and
 first-party text instead of icon packages. Owner mode may load the reviewed
-font files only from the same-origin Vite artifact; external font hosts, images,
-analytics, and runtime assets remain prohibited.
+font files only from the same-origin Vite artifact; external font hosts,
+analytics, and runtime assets remain prohibited. The one image exception is an
+explicit, transient per-item action in the private Markdown Reader, as recorded
+in ADR 0009; public surfaces never load Markdown images from remote hosts.
 
 ## Source architecture
 

--- a/docs/v2/THREAT_MODEL.md
+++ b/docs/v2/THREAT_MODEL.md
@@ -286,9 +286,15 @@ sanitized before entering retry state or diagnostics.
 
 The owner Reader treats retained Markdown as untrusted input. It renders parsed
 Markdown through React without raw HTML support, converts image syntax to inert
-text instead of issuing third-party requests, and opens explicit links in a new
-non-referring browsing context. The owner application's content security policy
-continues to deny arbitrary scripts, frames, objects, and remote images.
+text by default, and opens explicit links in a new non-referring browsing
+context. An owner may explicitly load HTTPS images for one item during the
+current Reader session. Relative sources resolve against the saved URL;
+malformed, credential-bearing, and non-HTTPS sources remain inert. Requests use
+lazy loading and `Referrer-Policy: no-referrer`, but the image host still learns
+the owner's IP address, user agent, request timing, and any cookies the browser
+chooses to attach. The UI discloses that network boundary before loading.
+Permission is forgotten when the Reader closes and never enters library state,
+sync, export, publication, or the service-worker cache.
 
 Custom protocol schemes do not authenticate their caller. A browser may ask
 before handing an external link to an application, but a permission remembered
@@ -316,7 +322,7 @@ Owner mode uses a self-only CSP equivalent to:
 default-src 'none';
 script-src 'self';
 style-src 'self';
-img-src 'self' data:;
+img-src 'self' https:;
 font-src 'self';
 connect-src https://api.github.com;
 worker-src 'self';
@@ -328,10 +334,12 @@ manifest-src 'self';
 upgrade-insecure-requests
 ```
 
-No inline/evaluated script, remote module, CDN asset, remotely hosted font, or
-runtime package download is permitted. Dependencies and licensed webfont assets
-are locked, bundled, and reviewed in the application repository. Production
-builds omit public source maps and disable console logging.
+No inline/evaluated script, remote module, CDN script, remotely hosted font, or
+runtime package download is permitted. The `https:` image exception applies only
+to owner-initiated Markdown images in the private Reader; public documents keep
+their self-only image policy. Dependencies and licensed webfont assets are
+locked, bundled, and reviewed in the application repository. Production builds
+omit public source maps and disable console logging.
 
 When the host cannot set a CSP response header, a CSP `meta` element must be the
 first applicable element in `<head>`. This is weaker: CSP Level 3 specifies that

--- a/docs/v2/WEB.md
+++ b/docs/v2/WEB.md
@@ -97,6 +97,13 @@ It explicitly bypasses all GitHub API
 traffic, cross-origin traffic, and non-GET requests, so it cannot cache a token,
 private API response, or upload body.
 
+Retained Markdown images are inert by default. Inside the owner Reader, an
+explicit action may load HTTPS images for one item until that Reader closes.
+Relative sources resolve against the saved URL, invalid and non-HTTPS sources
+stay inert, and image requests carry no referrer. The permission is presentation
+state only: it is not persisted, synchronized, exported, or published. Public
+documentation Markdown never enables this owner-only path.
+
 The canonical deployment is the organization site at
 `https://researchpocket.github.io/`, with owner mode under `/app/`. Noindex
 compatibility documents at the former `/ResearchPocket/` paths preserve query

--- a/web/app/index.html
+++ b/web/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; base-uri 'none'; connect-src 'self' https://api.github.com; font-src 'self'; form-action 'none'; frame-src 'none'; img-src 'self'; manifest-src 'self'; object-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; worker-src 'self'; upgrade-insecure-requests"
+      content="default-src 'none'; base-uri 'none'; connect-src 'self' https://api.github.com; font-src 'self'; form-action 'none'; frame-src 'none'; img-src 'self' https:; manifest-src 'self'; object-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; worker-src 'self'; upgrade-insecure-requests"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark" />

--- a/web/scripts/check-dist.mjs
+++ b/web/scripts/check-dist.mjs
@@ -208,6 +208,19 @@ if (existsSync(appPath)) {
   if (!app.includes('name="robots" content="noindex, nofollow"')) {
     failures.push("The private owner application is missing its noindex policy");
   }
+  if (!app.includes("img-src 'self' https:")) {
+    failures.push("The owner application does not permit opted-in HTTPS images");
+  }
+}
+
+for (const document of ["index.html", "docs/index.html", "overview/index.html"]) {
+  const path = resolve(distRoot, document);
+  if (
+    existsSync(path) &&
+    readFileSync(path, "utf8").includes("img-src 'self' https:")
+  ) {
+    failures.push(`${document} unexpectedly permits remote images`);
+  }
 }
 
 const manifestPath = resolve(distRoot, "manifest.webmanifest");

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2075,9 +2075,21 @@ function ReaderView({
   onFavorite: (item: LibraryItemView) => Promise<void>;
   onSelect: (item: LibraryItemView) => void;
 }) {
+  const [itemsWithImages, setItemsWithImages] = useState<Set<string>>(
+    () => new Set(),
+  );
   const label = item.title?.trim() || item.url;
   const context = item.excerpt;
   const hasContext = Boolean(context?.trim());
+  const imagesAllowed = itemsWithImages.has(item.id);
+
+  function loadImagesForItem() {
+    setItemsWithImages((current) => {
+      const next = new Set(current);
+      next.add(item.id);
+      return next;
+    });
+  }
 
   return (
     <div className="reader-view" role="dialog" aria-modal="true" aria-labelledby="reader-title">
@@ -2114,7 +2126,16 @@ function ReaderView({
           {item.tags.length > 0 ? <p className="reader-tags">{item.tags.map((tag) => <span key={tag}>#{tag}</span>)}</p> : null}
           {item.note?.trim() ? <aside className="reader-note"><strong>Your note</strong><p>{item.note}</p></aside> : null}
           <div className="reader-body">
-            {hasContext && context ? <MarkdownDocument source={context} /> : <p>This save has no extracted preview yet. Open the original to read the full page, or add a private note to keep the context that matters.</p>}
+            {hasContext && context ? (
+              <MarkdownDocument
+                imageBaseUrl={item.url}
+                imagesAllowed={imagesAllowed}
+                onLoadImages={loadImagesForItem}
+                source={context}
+              />
+            ) : (
+              <p>This save has no extracted preview yet. Open the original to read the full page, or add a private note to keep the context that matters.</p>
+            )}
             <p className="reader-source">ResearchPocket keeps the URL and your authored context locally. The original page remains at <a href={item.url} rel="noreferrer" target="_blank">{readHostname(item.url)}</a>.</p>
           </div>
         </div>

--- a/web/src/components/MarkdownDocument.tsx
+++ b/web/src/components/MarkdownDocument.tsx
@@ -2,37 +2,90 @@ import { memo } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-const SAFE_MARKDOWN_COMPONENTS: Components = {
-  a: ({ children, href, title }) => (
-    <a href={href} rel="noreferrer" target="_blank" title={title}>
-      {children}
-    </a>
-  ),
-  img: ({ alt, title }) => (
+function inertImage(
+  alt: string | undefined,
+  title: string | undefined,
+  canLoad: boolean,
+  onLoadImages: (() => void) | undefined,
+) {
+  return (
     <span
-      aria-label={alt || "Referenced image"}
-      className="reader-markdown-image"
-      role="img"
+      className="reader-markdown-image-placeholder"
       title={title}
     >
-      [Image: {alt || "unlabeled"}]
+      <span aria-label={alt || "Referenced image"} role="img">
+        [Image: {alt || "unlabeled"}]
+      </span>
+      {canLoad && onLoadImages ? (
+        <span className="reader-markdown-image-consent">
+          Loading images contacts their hosts and can reveal your IP address.
+          <button onClick={onLoadImages} type="button">
+            Load images for this item
+          </button>
+        </span>
+      ) : null}
     </span>
-  ),
-};
+  );
+}
+
+function safeImageUrl(
+  source: string | undefined,
+  baseUrl: string | undefined,
+): string | null {
+  if (!source || !baseUrl) return null;
+  try {
+    const url = new URL(source, baseUrl);
+    if (url.protocol !== "https:" || url.username || url.password) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
 
 export const MarkdownDocument = memo(function MarkdownDocument({
   className = "reader-markdown",
   components,
+  imageBaseUrl,
+  imagesAllowed = false,
+  onLoadImages,
   source,
 }: {
   className?: string;
   components?: Components;
+  imageBaseUrl?: string;
+  imagesAllowed?: boolean;
+  onLoadImages?: () => void;
   source: string;
 }) {
+  const safeMarkdownComponents: Components = {
+    a: ({ children, href, title }) => (
+      <a href={href} rel="noreferrer" target="_blank" title={title}>
+        {children}
+      </a>
+    ),
+    img: ({ alt, src, title }) => {
+      const imageUrl = safeImageUrl(src, imageBaseUrl);
+      if (!imagesAllowed || !imageUrl) {
+        return inertImage(alt, title, Boolean(imageUrl), onLoadImages);
+      }
+      return (
+        <img
+          alt={alt ?? ""}
+          className="reader-markdown-image"
+          decoding="async"
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          src={imageUrl}
+          title={title}
+        />
+      );
+    },
+  };
+
   return (
     <div className={className}>
       <ReactMarkdown
-        components={{ ...SAFE_MARKDOWN_COMPONENTS, ...components }}
+        components={{ ...safeMarkdownComponents, ...components }}
         remarkPlugins={[remarkGfm]}
         skipHtml
       >

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2459,8 +2459,12 @@ kbd {
 }
 
 .reader-content {
-  max-width: 66ch;
+  box-sizing: border-box;
+  margin-inline: auto;
+  max-width: 80rem;
+  min-width: 0;
   padding: 2.25rem 3rem;
+  width: 100%;
 }
 
 .reader-meta {
@@ -2534,6 +2538,8 @@ kbd {
   font-size: 0.875rem;
   gap: 1rem;
   line-height: 1.75;
+  min-width: 0;
+  width: 100%;
 }
 
 .reader-body p {
@@ -2541,8 +2547,17 @@ kbd {
 }
 
 .reader-markdown {
+  max-width: 100%;
+  min-width: 0;
   overflow-wrap: anywhere;
+  width: 100%;
   word-break: break-word;
+}
+
+.reader-markdown > * {
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .reader-markdown > :first-child {
@@ -2621,6 +2636,7 @@ kbd {
   background: var(--color-surface-muted);
   border: var(--rule) solid var(--color-border);
   border-radius: var(--radius);
+  max-width: 100%;
   overflow-x: auto;
   padding: 0.875rem;
   white-space: pre;
@@ -2637,7 +2653,7 @@ kbd {
   display: block;
   max-width: 100%;
   overflow-x: auto;
-  width: max-content;
+  width: 100%;
 }
 
 .reader-markdown th,
@@ -2661,9 +2677,40 @@ kbd {
   color: var(--color-accent-strong);
 }
 
-.reader-markdown-image {
+.reader-markdown-image-placeholder {
+  border: var(--rule) solid var(--color-border);
+  color: var(--color-text-muted);
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.75rem;
+}
+
+.reader-markdown-image-placeholder > [role="img"] {
   color: var(--color-text-muted);
   font-style: italic;
+}
+
+.reader-markdown-image-consent {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: var(--font-size-xs);
+  gap: 0.5rem 0.75rem;
+}
+
+.reader-markdown-image-consent button {
+  background: transparent;
+  border: var(--rule) solid var(--color-border-strong);
+  color: var(--color-text);
+  min-height: 2.25rem;
+  padding: 0.25rem 0.625rem;
+}
+
+.reader-markdown-image {
+  border: var(--rule) solid var(--color-border);
+  display: block;
+  height: auto;
+  max-width: 100%;
 }
 
 .reader-source {


### PR DESCRIPTION
## Outcome

- keeps retained Markdown images inert by default and explains the network privacy boundary
- lets the owner load valid HTTPS images for one saved item during the current Reader session
- resolves relative sources against the saved URL, blocks invalid/non-HTTPS/credential-bearing sources, and sends no referrer
- makes Reader Markdown width consistent while containing wide tables, code, links, and images
- keeps public Markdown surfaces image-inert and self-only

Closes #125

## User-visible and protocol impact

The private owner Reader gains a **Load images for this item** action beside inert image placeholders. Grants are transient per-item React state and disappear when the Reader closes. No CRDT field, IndexedDB schema, sync envelope, export, publication projection, or service-worker cache changes.

The owner document CSP adds `https:` to `img-src` only. Scripts, styles, fonts, frames, objects, workers, and GitHub API connections are unchanged. ADR 0009 records the residual disclosure to the image host.

## Verification

- `npm run verify`
- production artifact check proving only `app/index.html` permits HTTPS images
- clean headless-Chrome owner flow with two items:
  - zero remote image requests before consent
  - one relative HTTPS image resolved and requested after consent
  - `loading=lazy`, `decoding=async`, and `referrerPolicy=no-referrer`
  - HTTP image remained inert
  - second item remained blocked
  - closing and reopening the Reader forgot the grant
- 1440px Reader layout check:
  - document and article scroll widths equal their client widths
  - long URL wraps
  - wide table remains contained
  - 8,288px code line scrolls inside its 1,002px code block

## UI evidence

The reviewed production build shows a bordered inert image block with the disclosure and explicit action. On wide screens the Markdown body now fills the article pane consistently; exceptional code width is isolated to the code block rather than overflowing the Reader.
