### PR TITLE
Improve Reader images and mobile layout

### DIFF
--- a/docs/v2/ADR_0009_OPT_IN_MARKDOWN_IMAGES.md
+++ b/docs/v2/ADR_0009_OPT_IN_MARKDOWN_IMAGES.md
@@ -3,6 +3,7 @@
 - Status: accepted
 - Date: 2026-07-27
 - Issue: [#125](https://github.com/ResearchPocket/researchpocket.github.io/issues/125)
+- Follow-up: [#127](https://github.com/ResearchPocket/researchpocket.github.io/issues/127)
 
 ## Context
 
@@ -42,6 +43,18 @@ change. The public landing, overview, and documentation documents retain
 self-only image policies, and their Markdown renderer receives no image-loading
 action. Cross-origin image requests bypass the service worker and are never
 stored in ResearchPocket's shell cache.
+
+After an image is loaded, its inline rendering is a keyboard-accessible control
+that can open a contained full-screen viewer. Closing the viewer restores focus
+to that image control. The viewer reuses the already validated URL and the
+current item consent; it does not broaden the allowed source or persist image
+bytes.
+
+The owner may choose a solid image background color for transparent images.
+This browser-local Appearance preference applies to inline and expanded images
+and survives reload. It is separate from the item-scoped permission: the color
+does not authorize a request and is never canonical item, sync, export, or
+publication data.
 
 ## Consequences
 

--- a/docs/v2/WEB.md
+++ b/docs/v2/WEB.md
@@ -104,6 +104,19 @@ stay inert, and image requests carry no referrer. The permission is presentation
 state only: it is not persisted, synchronized, exported, or published. Public
 documentation Markdown never enables this owner-only path.
 
+Once loaded, an image is an accessible expansion control that opens a contained
+viewer. The viewer restores focus when closed and uses the same validated image
+URL, consent state, and no-referrer request policy. A browser-local Appearance
+preference controls the solid background behind inline and expanded images so
+transparent diagrams remain legible. That preference is ordinary local UI
+state; it does not enter item data, protocol updates, exports, or publications.
+
+On narrow viewports, the owner shell and Reader use document-level vertical
+scrolling. The bottom action row remains sticky, but it does not replace the
+document scroller; this lets mobile browsers respond normally to scroll gestures
+and collapse their own toolbar. The compact masthead keeps the Library identity,
+optional library selector, and local-state indicator on one row.
+
 The canonical deployment is the organization site at
 `https://researchpocket.github.io/`, with owner mode under `/app/`. Noindex
 compatibility documents at the former `/ResearchPocket/` paths preserve query

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,7 +7,10 @@ import {
   useRef,
   useState,
 } from "react";
-import { MarkdownDocument } from "./components/MarkdownDocument.tsx";
+import {
+  MarkdownDocument,
+  type MarkdownImage,
+} from "./components/MarkdownDocument.tsx";
 import {
   type LibraryState,
   type PendingSyncChange,
@@ -75,6 +78,8 @@ interface UndoNotice {
 
 const DENSITY_STORAGE_KEY = "researchpocket.ui.density";
 const THEME_STORAGE_KEY = "researchpocket.ui.theme";
+const IMAGE_BACKGROUND_STORAGE_KEY = "researchpocket.ui.image-background";
+const DEFAULT_IMAGE_BACKGROUND = "#ffffff";
 
 const DEFAULT_THEME: ThemeColors = {
   text: "#f5f1e9",
@@ -186,6 +191,9 @@ export function App() {
   const [sortMode, setSortMode] = useState<SortMode>("recent");
   const [density, setDensity] = useState<Density>(() => readDensityPreference());
   const [theme, setTheme] = useState<ThemeColors>(() => readThemePreference());
+  const [imageBackground, setImageBackground] = useState(
+    () => readImageBackgroundPreference(),
+  );
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [visibleLimit, setVisibleLimit] = useState(LIST_BATCH_SIZE);
   const [view, setView] = useState<WorkspaceView>(() => readWorkspaceView());
@@ -252,6 +260,25 @@ export function App() {
       // The preference remains active for this tab when storage is unavailable.
     }
   }, [theme]);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty(
+      "--reader-image-background",
+      imageBackground,
+    );
+    try {
+      if (imageBackground === DEFAULT_IMAGE_BACKGROUND) {
+        window.localStorage.removeItem(IMAGE_BACKGROUND_STORAGE_KEY);
+      } else {
+        window.localStorage.setItem(
+          IMAGE_BACKGROUND_STORAGE_KEY,
+          imageBackground,
+        );
+      }
+    } catch {
+      // The preference remains active for this tab when storage is unavailable.
+    }
+  }, [imageBackground]);
 
   useEffect(() => {
     function handleShortcut(event: KeyboardEvent) {
@@ -426,7 +453,7 @@ export function App() {
       () => libraryRepository.initialize(),
     );
     if (initialized) {
-      setView(targetView);
+      navigateToView(targetView);
     }
   }
 
@@ -843,7 +870,9 @@ export function App() {
           activeProfileId={activeProfileId}
           density={density}
           hidden={view !== "settings"}
+          imageBackground={imageBackground}
           onDensityChange={setDensity}
+          onImageBackgroundChange={setImageBackground}
           onProfilesChanged={refreshProfiles}
           onSwitchLibrary={switchLibrary}
           onThemeChange={setTheme}
@@ -1248,6 +1277,37 @@ function Welcome({
   onRestore: () => Promise<void>;
   restoreFirst: boolean;
 }) {
+  useEffect(() => {
+    if (busy) return;
+
+    function handleShortcut(event: KeyboardEvent) {
+      const target = event.target as HTMLElement | null;
+      const isInteractive =
+        target?.matches("button, a, input, textarea, select") ||
+        target?.isContentEditable;
+      if (
+        isInteractive ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.shiftKey
+      ) {
+        return;
+      }
+
+      if (event.key === "Enter") {
+        event.preventDefault();
+        void onInitialize();
+      } else if (event.key.toLowerCase() === "r") {
+        event.preventDefault();
+        void onRestore();
+      }
+    }
+
+    window.addEventListener("keydown", handleShortcut);
+    return () => window.removeEventListener("keydown", handleShortcut);
+  }, [busy, onInitialize, onRestore]);
+
   return (
     <main className="welcome-shell">
       <section aria-labelledby="welcome-heading" className="welcome-card">
@@ -1319,10 +1379,6 @@ function LibrarySettings({
     <div className="settings-group">
       <div>
         <h3>Libraries</h3>
-        <p>
-          Each library keeps its own saves, queue, and repository on this device.
-          Nothing is shared between them.
-        </p>
       </div>
 
       <div className="library-settings">
@@ -1425,7 +1481,9 @@ function SettingsPanel({
   activeProfileId,
   density,
   hidden,
+  imageBackground,
   onDensityChange,
+  onImageBackgroundChange,
   onProfilesChanged,
   onSwitchLibrary,
   onThemeChange,
@@ -1435,7 +1493,9 @@ function SettingsPanel({
   activeProfileId: string | null;
   density: Density;
   hidden: boolean;
+  imageBackground: string;
   onDensityChange: (density: Density) => void;
+  onImageBackgroundChange: (color: string) => void;
   onProfilesChanged: () => Promise<void>;
   onSwitchLibrary: (profileId: string) => Promise<void>;
   onThemeChange: (theme: ThemeColors) => void;
@@ -1455,7 +1515,6 @@ function SettingsPanel({
       <header className="settings-heading">
         <p className="eyebrow">Workspace</p>
         <h2 id="settings-heading">Settings</h2>
-        <p>Preferences stay in this browser and never become library data.</p>
       </header>
 
       <LibrarySettings
@@ -1468,13 +1527,11 @@ function SettingsPanel({
       <div className="settings-group">
         <div>
           <h3>Appearance</h3>
-          <p>Adjust list density and the colors used by this owner app.</p>
         </div>
         <div className="appearance-settings">
           <label className="setting-row" htmlFor="compact-mode">
             <span>
               <strong>Compact mode</strong>
-              <small>Fit more saves on screen by hiding previews and tightening rows.</small>
             </span>
             <input
               checked={density === "compact"}
@@ -1487,11 +1544,9 @@ function SettingsPanel({
           </label>
           <fieldset className="theme-editor">
             <legend>Color theme</legend>
-            <p>Choose a preset or customize its core palette. Supporting surfaces and borders adapt automatically.</p>
             <label className="theme-preset" htmlFor="theme-preset">
               <span>
                 <strong>Theme preset</strong>
-                <small>Start with a familiar editor palette.</small>
               </span>
               <select
                 id="theme-preset"
@@ -1536,13 +1591,37 @@ function SettingsPanel({
               Reset to default theme
             </button>
           </fieldset>
+          <fieldset className="theme-editor image-background-editor">
+            <legend>Transparent image background</legend>
+            <label htmlFor="image-background">
+              <span>Color</span>
+              <input
+                id="image-background"
+                onChange={(event) =>
+                  onImageBackgroundChange(event.target.value)
+                }
+                type="color"
+                value={imageBackground}
+              />
+              <code>{imageBackground}</code>
+            </label>
+            <button
+              className="secondary-button theme-reset"
+              disabled={imageBackground === DEFAULT_IMAGE_BACKGROUND}
+              onClick={() =>
+                onImageBackgroundChange(DEFAULT_IMAGE_BACKGROUND)
+              }
+              type="button"
+            >
+              Reset image background
+            </button>
+          </fieldset>
         </div>
       </div>
 
       <div className="settings-group">
         <div>
           <h3>Keyboard</h3>
-          <p>Shortcuts are available outside text fields.</p>
         </div>
         <dl className="shortcut-list">
           <div><dt>Command palette</dt><dd><kbd>Ctrl Shift P</kbd></dd></div>
@@ -1554,7 +1633,6 @@ function SettingsPanel({
       <div className="settings-group">
         <div>
           <h3>Local data</h3>
-          <p>Your library and this preference remain on this device unless you explicitly connect private sync.</p>
         </div>
         <p className="settings-status"><span aria-hidden="true" className="status-dot" /> Browser storage enabled</p>
       </div>
@@ -2078,16 +2156,47 @@ function ReaderView({
   const [itemsWithImages, setItemsWithImages] = useState<Set<string>>(
     () => new Set(),
   );
+  const [expandedImage, setExpandedImage] = useState<{
+    image: MarkdownImage;
+    opener: HTMLButtonElement;
+  } | null>(null);
+  const imageCloseRef = useRef<HTMLButtonElement | null>(null);
   const label = item.title?.trim() || item.url;
   const context = item.excerpt;
   const hasContext = Boolean(context?.trim());
   const imagesAllowed = itemsWithImages.has(item.id);
+
+  useEffect(() => {
+    setExpandedImage(null);
+  }, [item.id]);
+
+  useEffect(() => {
+    if (expandedImage) imageCloseRef.current?.focus();
+  }, [expandedImage]);
 
   function loadImagesForItem() {
     setItemsWithImages((current) => {
       const next = new Set(current);
       next.add(item.id);
       return next;
+    });
+  }
+
+  function closeExpandedImage() {
+    const opener = expandedImage?.opener;
+    const imageSrc = expandedImage?.image.src;
+    setExpandedImage(null);
+    window.requestAnimationFrame(() => {
+      if (opener?.isConnected) {
+        opener.focus();
+        return;
+      }
+      const matchingTrigger = [
+        ...document.querySelectorAll<HTMLButtonElement>(
+          ".reader-markdown-image-trigger",
+        ),
+      ].find((candidate) => candidate.dataset.imageSrc === imageSrc);
+      matchingTrigger?.focus();
     });
   }
 
@@ -2131,6 +2240,9 @@ function ReaderView({
                 imageBaseUrl={item.url}
                 imagesAllowed={imagesAllowed}
                 onLoadImages={loadImagesForItem}
+                onOpenImage={(image, opener) =>
+                  setExpandedImage({ image, opener })
+                }
                 source={context}
               />
             ) : (
@@ -2140,6 +2252,47 @@ function ReaderView({
           </div>
         </div>
       </article>
+      {expandedImage ? (
+        <div
+          aria-label={expandedImage.image.alt || "Expanded image"}
+          aria-modal="true"
+          className="reader-image-viewer"
+          onClick={(event) => {
+            if (event.target === event.currentTarget) closeExpandedImage();
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              event.preventDefault();
+              event.stopPropagation();
+              closeExpandedImage();
+            } else if (event.key === "Tab") {
+              event.preventDefault();
+              imageCloseRef.current?.focus();
+            }
+          }}
+          role="dialog"
+        >
+          <button
+            aria-label="Close expanded image"
+            className="reader-image-viewer-close"
+            onClick={closeExpandedImage}
+            ref={imageCloseRef}
+            type="button"
+          >
+            ×
+          </button>
+          <figure className="reader-image-viewer-stage">
+            <img
+              alt={expandedImage.image.alt}
+              referrerPolicy="no-referrer"
+              src={expandedImage.image.src}
+            />
+            {expandedImage.image.title ? (
+              <figcaption>{expandedImage.image.title}</figcaption>
+            ) : null}
+          </figure>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -2985,6 +3138,17 @@ function readThemePreference(): ThemeColors {
     // Invalid or unavailable storage falls back to the shipped theme.
   }
   return { ...DEFAULT_THEME };
+}
+
+function readImageBackgroundPreference() {
+  try {
+    const stored = window.localStorage.getItem(IMAGE_BACKGROUND_STORAGE_KEY);
+    return stored && /^#[0-9a-f]{6}$/i.test(stored)
+      ? stored
+      : DEFAULT_IMAGE_BACKGROUND;
+  } catch {
+    return DEFAULT_IMAGE_BACKGROUND;
+  }
 }
 
 function isThemeColors(value: unknown): value is ThemeColors {

--- a/web/src/components/MarkdownDocument.tsx
+++ b/web/src/components/MarkdownDocument.tsx
@@ -2,6 +2,12 @@ import { memo } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+export interface MarkdownImage {
+  alt: string;
+  src: string;
+  title?: string;
+}
+
 function inertImage(
   alt: string | undefined,
   title: string | undefined,
@@ -18,9 +24,14 @@ function inertImage(
       </span>
       {canLoad && onLoadImages ? (
         <span className="reader-markdown-image-consent">
-          Loading images contacts their hosts and can reveal your IP address.
-          <button onClick={onLoadImages} type="button">
-            Load images for this item
+          <span>Remote · shares IP when loaded</span>
+          <button
+            aria-label="Load images for this item. Loading contacts their hosts and can reveal your IP address."
+            onClick={onLoadImages}
+            title="Loading contacts image hosts and can reveal your IP address."
+            type="button"
+          >
+            Load item images
           </button>
         </span>
       ) : null}
@@ -48,6 +59,7 @@ export const MarkdownDocument = memo(function MarkdownDocument({
   imageBaseUrl,
   imagesAllowed = false,
   onLoadImages,
+  onOpenImage,
   source,
 }: {
   className?: string;
@@ -55,6 +67,7 @@ export const MarkdownDocument = memo(function MarkdownDocument({
   imageBaseUrl?: string;
   imagesAllowed?: boolean;
   onLoadImages?: () => void;
+  onOpenImage?: (image: MarkdownImage, opener: HTMLButtonElement) => void;
   source: string;
 }) {
   const safeMarkdownComponents: Components = {
@@ -68,16 +81,29 @@ export const MarkdownDocument = memo(function MarkdownDocument({
       if (!imagesAllowed || !imageUrl) {
         return inertImage(alt, title, Boolean(imageUrl), onLoadImages);
       }
+      const image = {
+        alt: alt ?? "",
+        src: imageUrl,
+        ...(title ? { title } : {}),
+      };
       return (
-        <img
-          alt={alt ?? ""}
-          className="reader-markdown-image"
-          decoding="async"
-          loading="lazy"
-          referrerPolicy="no-referrer"
-          src={imageUrl}
-          title={title}
-        />
+        <button
+          aria-label={`Expand image${alt ? `: ${alt}` : ""}`}
+          className="reader-markdown-image-trigger"
+          data-image-src={imageUrl}
+          onClick={(event) => onOpenImage?.(image, event.currentTarget)}
+          title={title ? `${title} — expand image` : "Expand image"}
+          type="button"
+        >
+          <img
+            alt={alt ?? ""}
+            className="reader-markdown-image"
+            decoding="async"
+            loading="lazy"
+            referrerPolicy="no-referrer"
+            src={imageUrl}
+          />
+        </button>
       );
     },
   };

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1851,6 +1851,18 @@ footer {
   flex: 0 0 auto;
 }
 
+.app-shell select {
+  font-size: var(--font-size-xs);
+  height: 2rem;
+  min-height: 2rem;
+  padding: 0 0.5rem;
+}
+
+.app-shell button {
+  font-size: var(--font-size-xs);
+  min-height: 2rem;
+}
+
 .masthead {
   min-height: 3.125rem;
   padding: 0 1.25rem;
@@ -2485,12 +2497,12 @@ kbd {
   border: 0;
   color: var(--color-text-soft);
   display: inline-flex;
-  font-size: 1.125rem;
-  height: 2.75rem;
+  font-size: 1rem;
+  height: 2.25rem;
   justify-content: center;
-  min-height: 2.75rem;
+  min-height: 2.25rem;
   text-decoration: none;
-  width: 2.75rem;
+  width: 2.25rem;
 }
 
 .reader-content h1 {
@@ -2678,11 +2690,13 @@ kbd {
 }
 
 .reader-markdown-image-placeholder {
+  align-items: center;
   border: var(--rule) solid var(--color-border);
   color: var(--color-text-muted);
-  display: grid;
-  gap: 0.5rem;
-  padding: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem 0.75rem;
+  padding: 0.5rem 0.625rem;
 }
 
 .reader-markdown-image-placeholder > [role="img"] {
@@ -2695,7 +2709,7 @@ kbd {
   display: flex;
   flex-wrap: wrap;
   font-size: var(--font-size-xs);
-  gap: 0.5rem 0.75rem;
+  gap: 0.375rem 0.75rem;
 }
 
 .reader-markdown-image-consent button {
@@ -2706,11 +2720,80 @@ kbd {
   padding: 0.25rem 0.625rem;
 }
 
-.reader-markdown-image {
+.reader-markdown-image-trigger {
+  background: var(--reader-image-background);
   border: var(--rule) solid var(--color-border);
+  cursor: zoom-in;
+  display: block;
+  max-width: 100%;
+  padding: 0;
+}
+
+.reader-markdown-image-trigger:focus-visible {
+  outline: 0.1875rem solid var(--color-accent-strong);
+  outline-offset: 0.1875rem;
+}
+
+.reader-markdown-image {
   display: block;
   height: auto;
   max-width: 100%;
+}
+
+.reader-image-viewer {
+  align-items: center;
+  background: var(--color-image-overlay);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding: clamp(3.5rem, 7vw, 6rem) clamp(1rem, 4vw, 4rem);
+  position: fixed;
+  z-index: 80;
+}
+
+.reader-image-viewer-close {
+  align-items: center;
+  background: var(--color-surface-raised);
+  border: var(--rule) solid var(--color-border-strong);
+  border-radius: var(--radius);
+  color: var(--color-text);
+  display: flex;
+  font-size: 1.5rem;
+  height: 2.25rem;
+  justify-content: center;
+  line-height: 1;
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+  width: 2.25rem;
+}
+
+.reader-image-viewer-stage {
+  align-items: center;
+  background: var(--reader-image-background);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0;
+  max-height: 100%;
+  max-width: 100%;
+  overflow: auto;
+}
+
+.reader-image-viewer-stage img {
+  display: block;
+  max-height: calc(100vh - 8rem);
+  max-width: calc(100vw - 4rem);
+  object-fit: contain;
+}
+
+.reader-image-viewer-stage figcaption {
+  background: var(--color-surface-raised);
+  color: var(--color-text);
+  max-width: min(100%, 60rem);
+  padding: 0.5rem 0.75rem;
+  text-align: center;
+  width: 100%;
 }
 
 .reader-source {
@@ -2780,9 +2863,9 @@ kbd {
 
 @media (max-width: 48rem) {
   .app-shell {
-    height: 100dvh;
-    min-height: 0;
-    overflow: hidden;
+    height: auto;
+    min-height: 100dvh;
+    overflow: visible;
     padding: 0;
   }
 
@@ -2822,17 +2905,22 @@ kbd {
     display: inline;
   }
 
-  /* The switcher takes its own full-width row so a library name is never
-     squeezed against the brand and the status indicator. */
   .masthead {
-    flex-wrap: wrap;
-    padding-bottom: var(--space-2);
+    flex-wrap: nowrap;
+    gap: 0.5rem;
+    padding-bottom: 0;
+  }
+
+  .brand-lockup {
+    flex: 0 1 auto;
+    min-width: 0;
   }
 
   .masthead-actions {
-    flex: 1 0 100%;
-    gap: var(--space-3);
-    justify-content: space-between;
+    flex: 1 1 auto;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    min-width: 0;
   }
 
   .library-switcher {
@@ -2841,15 +2929,20 @@ kbd {
   }
 
   .library-switcher select {
-    max-width: none;
+    max-width: 8rem;
+    min-width: 0;
     width: 100%;
+  }
+
+  .local-status {
+    flex: 0 0 auto;
   }
 
   .workspace-layout {
     display: flex;
     flex: 1 1 auto;
     flex-direction: column;
-    overflow: hidden;
+    overflow: visible;
   }
 
   .tag-rail {
@@ -2915,7 +3008,7 @@ kbd {
 
   #workspace {
     flex: 1 1 auto;
-    overflow: auto;
+    overflow: visible;
   }
 
   .library-section {
@@ -3071,13 +3164,13 @@ kbd {
     grid-template-columns: 1fr auto auto;
     left: 0;
     padding: 0.375rem 0.75rem max(0.5rem, env(safe-area-inset-bottom));
-    position: static;
+    position: sticky;
     right: 0;
     z-index: 9;
   }
 
   .mobile-actions button {
-    min-height: 2.75rem;
+    min-height: 2.25rem;
   }
 
   .sync-section {
@@ -3092,7 +3185,13 @@ kbd {
 
   .reader-view {
     display: block;
-    inset: 3.25rem 0 0;
+    inset: auto;
+    min-height: 100dvh;
+    position: static;
+  }
+
+  .app-shell:has(> .reader-view) > :not(.reader-view) {
+    display: none;
   }
 
   .reader-list {
@@ -3100,11 +3199,8 @@ kbd {
   }
 
   .reader-article {
-    height: 100%;
-    min-height: 0;
-    overflow-y: auto;
-    overscroll-behavior-y: contain;
-    -webkit-overflow-scrolling: touch;
+    min-height: 100dvh;
+    overflow: visible;
   }
 
   .reader-mobile-header {
@@ -3121,7 +3217,7 @@ kbd {
     border: 0;
     color: var(--color-text-soft);
     font-size: 1rem;
-    width: 2.75rem;
+    width: 2.25rem;
   }
 
   .reader-mobile-header span {
@@ -3153,8 +3249,9 @@ kbd {
   .reader-meta button,
   .reader-meta a {
     border: var(--rule) solid var(--color-border);
-    font-size: 1.25rem;
-    height: 3rem;
+    font-size: 1.125rem;
+    height: 2.5rem;
+    min-height: 2.5rem;
     width: auto;
   }
 
@@ -3384,6 +3481,36 @@ kbd {
 .theme-reset {
   margin-top: 1rem;
   width: 100%;
+}
+
+.image-background-editor > label {
+  align-items: center;
+  border: var(--rule) solid var(--color-border-subtle);
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 0.625rem;
+}
+
+.image-background-editor > label span {
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+}
+
+.image-background-editor input[type="color"] {
+  background: transparent;
+  border: var(--rule) solid var(--color-border-strong);
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  height: 2.5rem;
+  min-height: 2.5rem;
+  padding: 0.1875rem;
+  width: 3rem;
+}
+
+.image-background-editor code {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
 }
 
 .setting-row strong {

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -58,6 +58,8 @@
   --color-accent-soft: #243230;
   --color-reader-note: #20201a;
   --color-backdrop: color-mix(in srgb, var(--color-canvas) 52%, transparent);
+  --color-image-overlay: rgb(0 0 0 / 82%);
+  --reader-image-background: #ffffff;
   --color-danger: color-mix(in srgb, var(--primary) 62%, var(--accent));
   --color-danger-soft: color-mix(in srgb, var(--accent) 28%, var(--background));
   --color-focus: color-mix(in srgb, var(--accent) 62%, var(--text));


### PR DESCRIPTION
Closes #127

## Summary

- add accessible Reader image expansion and a local transparent-image background preference
- compact unloaded-image disclosure, Settings copy, dropdowns, ordinary buttons, and mobile bottom actions
- restore document-level mobile scrolling and keep the 320px multi-library masthead on one row
- make the welcome-screen Enter and R key hints perform their advertised create and restore actions

## Protocol and privacy impact

No domain, sync, export, or publication schema changes. Remote images remain HTTPS-only, inert by default, item-consented, no-referrer, and outside the service-worker cache. The background preference remains browser-local presentation state.

## Verification

- npm run verify
- mobile production build at 320px and 375px with a Firefox Android user agent
- document scrolling, sticky bottom actions, one-row two-library masthead, and no horizontal overflow
- 32px dropdowns and ordinary buttons; 36px mobile bottom-nav buttons
- image viewer keyboard/backdrop/Escape closure, focus restoration, custom background, and reload persistence
- compact unloaded-image and Settings copy
- fresh-browser Enter initialization and R initialization directly to #sync