### PR TITLE
Restore mobile Reader edit dialog

### DIFF
--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -3190,7 +3190,9 @@ kbd {
     position: static;
   }
 
-  .app-shell:has(> .reader-view) > :not(.reader-view) {
+  .app-shell:has(> .reader-view) > .skip-link,
+  .app-shell:has(> .reader-view) > .workspace-chrome,
+  .app-shell:has(> .reader-view) > .workspace-layout {
     display: none;
   }
 


### PR DESCRIPTION
Closes #127

## Summary

Narrow the mobile Reader visibility rule so it hides only the underlying app shell. Direct-child dialogs and status overlays remain visible, restoring the Edit action in the Reader bottom bar.

## Verification

- npm run verify
- mobile production build at 320px
- opened Reader Edit from the bottom action bar
- changed and saved the title
- confirmed the modal closed and the Reader rendered the saved title