### PR TITLE
Render Markdown math with KaTeX

### DIFF
--- a/docs/v2/WEB.md
+++ b/docs/v2/WEB.md
@@ -90,6 +90,24 @@ loads a remote third-party runtime script, font, image, analytics, or error
 reporter.
 Production builds omit source maps.
 
+The shared Markdown component parses `$...$` and `\(...\)` inline math plus
+`$$...$$` and `\[...\]` display math, then renders them with KaTeX. It also
+recognizes escaped vector sequences retained by Firecrawl, such as
+`\\x\_1, \\x\_2, \\ldots, \\x\_t`, without requiring a user to rewrite the
+excerpt. Source-specific color macros degrade to uncolored notation. For
+example, $E = mc^2$ remains in the text flow, while a display expression is
+contained horizontally on narrow screens:
+
+$$
+\int_0^1 x^2\,dx = \frac{1}{3}
+$$
+
+KaTeX emits semantic MathML for the browser to lay out with its native math
+support. Rendering therefore adds no KaTeX font payload or inline positioning
+styles and never loads a CDN, script, font, or service. Malformed expressions
+remain visible as source text instead of crashing the Reader. Code spans and
+fenced code blocks retain literal dollar signs and TeX.
+
 The document CSP allows only same-origin application resources and future
 connections to `https://api.github.com`. The service worker handles only GETs
 from pages controlled beneath `/app/` for same-origin shell resources and WASM.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,10 +10,13 @@
       "dependencies": {
         "highlight.js": "11.11.1",
         "idb": "8.0.3",
+        "katex": "0.18.1",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-markdown": "10.1.0",
-        "remark-gfm": "4.0.1"
+        "rehype-katex": "7.0.1",
+        "remark-gfm": "4.0.1",
+        "remark-math": "6.0.0"
       },
       "devDependencies": {
         "@types/react": "19.2.17",
@@ -415,6 +418,12 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
@@ -898,6 +907,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -964,6 +982,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1037,6 +1067,101 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -1064,6 +1189,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -1071,6 +1212,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1162,6 +1320,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.18.1.tgz",
+      "integrity": "sha512-Td8GCYSxDAoMhHOlKmCFMJ/hz5qlAAb71n66Dryw9nfCVfumLo7nhuotbvKom/XPADmrYC3O5QR71EPq4DarJQ==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/lightningcss": {
@@ -1598,6 +1772,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx-expression": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
@@ -1915,6 +2108,41 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math/node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -2340,6 +2568,18 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2447,6 +2687,41 @@
         "react": ">=18"
       }
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-katex/node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -2458,6 +2733,22 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -2704,6 +2995,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -2724,6 +3029,20 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2780,6 +3099,20 @@
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2876,6 +3209,16 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/zwitch": {

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "check:design": "node ./scripts/check-design-system.mjs",
     "check:dist": "node ./scripts/check-dist.mjs",
     "typecheck": "tsc --noEmit",
-    "test": "node --experimental-strip-types --test src/data/*.test.mjs",
+    "test": "node --experimental-strip-types --test src/data/*.test.mjs src/components/*.test.mjs",
     "build": "npm run wasm && npm run typecheck && npm run check:design && vite build && npm run check:dist",
     "verify": "npm test && npm run build",
     "preview": "vite preview"
@@ -17,10 +17,13 @@
   "dependencies": {
     "highlight.js": "11.11.1",
     "idb": "8.0.3",
+    "katex": "0.18.1",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-markdown": "10.1.0",
-    "remark-gfm": "4.0.1"
+    "rehype-katex": "7.0.1",
+    "remark-gfm": "4.0.1",
+    "remark-math": "6.0.0"
   },
   "devDependencies": {
     "@types/react": "19.2.17",

--- a/web/scripts/check-dist.mjs
+++ b/web/scripts/check-dist.mjs
@@ -45,6 +45,15 @@ if (sourceMaps.length > 0) {
   );
 }
 
+const katexFonts = files.filter((file) =>
+  /KaTeX_[^/]*\.(?:ttf|woff2?)$/i.test(file),
+);
+if (katexFonts.length > 0) {
+  failures.push(
+    `MathML rendering must not ship KaTeX fonts: ${katexFonts.map((file) => relative(distRoot, file)).join(", ")}`,
+  );
+}
+
 const artifacts = files.map((file) => ({ file, bytes: readFileSync(file) }));
 const htmlArtifacts = artifacts.filter(({ file }) => extname(file) === ".html");
 const textExtensions = new Set([
@@ -61,6 +70,10 @@ const text = artifacts
   .filter(({ file }) => textExtensions.has(extname(file)))
   .map(({ bytes }) => bytes.toString("utf8"))
   .join("\n");
+
+if (!/\.katex-display\b/.test(text)) {
+  failures.push("The production build is missing KaTeX display styles");
+}
 
 for (const [name, pattern] of [
   ["source map reference", /sourceMappingURL=/i],

--- a/web/src/components/MarkdownDocument.tsx
+++ b/web/src/components/MarkdownDocument.tsx
@@ -1,6 +1,30 @@
 import { memo } from "react";
+import rehypeKatex from "rehype-katex";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import {
+  markdownMathMacros,
+  normalizeMarkdownMathDelimiters,
+  remarkBareMath,
+} from "./markdownMath.ts";
+
+interface MarkdownTreeNode {
+  children?: MarkdownTreeNode[];
+  properties?: Record<string, unknown>;
+}
+
+function removeKatexInlineStyles() {
+  return (tree: MarkdownTreeNode) => {
+    const visit = (node: MarkdownTreeNode) => {
+      if (node.properties && "style" in node.properties) {
+        delete node.properties.style;
+      }
+      node.children?.forEach(visit);
+    };
+    visit(tree);
+  };
+}
 
 export interface MarkdownImage {
   alt: string;
@@ -112,10 +136,17 @@ export const MarkdownDocument = memo(function MarkdownDocument({
     <div className={className}>
       <ReactMarkdown
         components={{ ...safeMarkdownComponents, ...components }}
-        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[
+          [
+            rehypeKatex,
+            { macros: markdownMathMacros, output: "mathml" },
+          ],
+          removeKatexInlineStyles,
+        ]}
+        remarkPlugins={[remarkGfm, remarkMath, remarkBareMath]}
         skipHtml
       >
-        {source}
+        {normalizeMarkdownMathDelimiters(source)}
       </ReactMarkdown>
     </div>
   );

--- a/web/src/components/markdownMath.test.mjs
+++ b/web/src/components/markdownMath.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  normalizeMarkdownMathDelimiters,
+  splitBareMathText,
+} from "./markdownMath.ts";
+
+test("alternate TeX delimiters become Markdown math outside code", () => {
+  const source = [
+    String.raw`Inline \(\x_1 + \x_2\) and escaped \\(\x_3\\).`,
+    "Code: `\\\\(\\x_4\\\\)`.",
+    "```tex",
+    String.raw`\[\x_5\]`,
+    "```",
+    String.raw`\[\sum_i \x_i\]`,
+  ].join("\n");
+
+  assert.equal(
+    normalizeMarkdownMathDelimiters(source),
+    [
+      String.raw`Inline $\x_1 + \x_2$ and escaped $\x_3$.`,
+      "Code: `\\\\(\\x_4\\\\)`.",
+      "```tex",
+      String.raw`\[\x_5\]`,
+      "```",
+      String.raw`$$\sum_i \x_i$$`,
+    ].join("\n"),
+  );
+});
+
+test("escaped Firecrawl vector sequences become one inline expression", () => {
+  const nodes = splitBareMathText(
+    String.raw`Inputs \x_1, \x_2, \ldots, \x_t and outputs \y_1.`,
+  );
+  assert.deepEqual(
+    nodes.map(({ type, value }) => ({ type, value })),
+    [
+      { type: "text", value: "Inputs " },
+      {
+        type: "inlineMath",
+        value: String.raw`\x_1, \x_2, \ldots, \x_t`,
+      },
+      { type: "text", value: " and outputs " },
+      { type: "inlineMath", value: String.raw`\y_1` },
+      { type: "text", value: "." },
+    ],
+  );
+});
+
+test("ordinary backslashes and standalone standard commands remain text", () => {
+  assert.deepEqual(splitBareMathText(String.raw`C:\Users\ori and \ldots`), [
+    { type: "text", value: String.raw`C:\Users\ori and \ldots` },
+  ]);
+});

--- a/web/src/components/markdownMath.ts
+++ b/web/src/components/markdownMath.ts
@@ -1,0 +1,249 @@
+interface MarkdownNode {
+  children?: MarkdownNode[];
+  data?: {
+    hChildren: Array<{ type: "text"; value: string }>;
+    hName: "code";
+    hProperties: { className: ["language-math", "math-inline"] };
+  };
+  type: string;
+  value?: string;
+}
+
+const vectorMacroNames = [
+  "a",
+  "A",
+  "b",
+  "B",
+  "c",
+  "C",
+  "d",
+  "D",
+  "e",
+  "E",
+  "I",
+  "k",
+  "L",
+  "m",
+  "M",
+  "P",
+  "q",
+  "Q",
+  "r",
+  "R",
+  "s",
+  "S",
+  "Sig",
+  "t",
+  "T",
+  "u",
+  "U",
+  "v",
+  "V",
+  "w",
+  "W",
+  "x",
+  "X",
+  "y",
+  "Y",
+  "z",
+  "Z",
+] as const;
+
+export const markdownMathMacros: Record<string, string> = Object.fromEntries([
+  ...vectorMacroNames.map((name) => [`\\${name}`, `\\mathbf{${name}}`]),
+  ["\\bp", "\\mathbf{p}"],
+  ["\\Sig", "\\mathbf{\\Sigma}"],
+  ["\\p", "\\,\\text{.}"],
+  ["\\sp", "^{\\prime}"],
+  ["\\tab", "\\hspace{0.7cm}"],
+  ["\\deg", "^{\\circ}"],
+  ["\\argmin", "\\underset{#1}{\\operatorname{argmin}}"],
+  ["\\argmax", "\\underset{#1}{\\operatorname{argmax}}"],
+  ["\\co", "\\;\\cos"],
+  ["\\si", "\\;\\sin"],
+  ["\\mR", "\\mathbb{R}"],
+  ["\\mC", "\\mathbb{C}"],
+  ["\\mN", "\\mathbb{N}"],
+  ["\\mZ", "\\mathbb{Z}"],
+  ["\\rc", "#1"],
+  ["\\gc", "#1"],
+  ["\\bc", "#1"],
+  ["\\kc", "#1"],
+  ["\\oc", "#1"],
+  ["\\lrc", "#1"],
+  ["\\lgc", "#1"],
+  ["\\lbc", "#1"],
+  ["\\loc", "#1"],
+]);
+
+const bareMathStarts = new Set(vectorMacroNames);
+
+function normalizeEscapedTex(value: string) {
+  return value.replace(/\\\\(?=[A-Za-z])/gu, "\\").replace(/\\_/gu, "_");
+}
+
+function replaceDelimitedMath(value: string) {
+  return value
+    .replace(
+      /\\{1,2}\[([\s\S]*?)\\{1,2}\]/gu,
+      (_, math: string) => `$$${normalizeEscapedTex(math)}$$`,
+    )
+    .replace(
+      /\\{1,2}\(([\s\S]*?)\\{1,2}\)/gu,
+      (_, math: string) => `$${normalizeEscapedTex(math)}$`,
+    );
+}
+
+function mapOutsideInlineCode(line: string) {
+  let output = "";
+  let cursor = 0;
+
+  while (cursor < line.length) {
+    const opening = line.indexOf("`", cursor);
+    if (opening === -1) return output + replaceDelimitedMath(line.slice(cursor));
+
+    output += replaceDelimitedMath(line.slice(cursor, opening));
+    let ticks = 1;
+    while (line[opening + ticks] === "`") ticks += 1;
+    const delimiter = "`".repeat(ticks);
+    const closing = line.indexOf(delimiter, opening + ticks);
+    if (closing === -1) return output + line.slice(opening);
+
+    output += line.slice(opening, closing + ticks);
+    cursor = closing + ticks;
+  }
+
+  return output;
+}
+
+export function normalizeMarkdownMathDelimiters(source: string) {
+  let fence: { marker: string; size: number } | null = null;
+
+  return source
+    .split("\n")
+    .map((line) => {
+      const fenceMatch = /^\s{0,3}(`{3,}|~{3,})/u.exec(line);
+      if (fenceMatch) {
+        const delimiter = fenceMatch[1];
+        if (!delimiter) return line;
+        const marker = delimiter[0];
+        const size = delimiter.length;
+        if (!marker) return line;
+        if (!fence) {
+          fence = { marker, size };
+        } else if (marker === fence.marker && size >= fence.size) {
+          fence = null;
+        }
+        return line;
+      }
+      return fence ? line : mapOutsideInlineCode(line);
+    })
+    .join("\n");
+}
+
+function readBareMath(value: string, start: number) {
+  let cursor = start;
+  let braceDepth = 0;
+  let sawStart = false;
+
+  while (cursor < value.length) {
+    const rest = value.slice(cursor);
+    const command = /^\\([A-Za-z]+)/u.exec(rest);
+    const commandName = command?.[1];
+    if (command && commandName) {
+      if (!sawStart && !bareMathStarts.has(commandName as (typeof vectorMacroNames)[number])) {
+        return null;
+      }
+      sawStart = true;
+      cursor += command[0].length;
+      continue;
+    }
+
+    const escapedPunctuation = /^\\([_{}%&#])/u.exec(rest);
+    if (escapedPunctuation) {
+      cursor += escapedPunctuation[0].length;
+      continue;
+    }
+
+    const character = value[cursor];
+    if (!character) break;
+    if (character === "{") braceDepth += 1;
+    if (character === "}") braceDepth = Math.max(0, braceDepth - 1);
+    if (/[\d_{}[\](),;:+\-=*/^|<>!']/u.test(character)) {
+      cursor += 1;
+      continue;
+    }
+
+    if (/\s/u.test(character)) {
+      cursor += 1;
+      continue;
+    }
+
+    const word = /^[A-Za-z]+/u.exec(rest);
+    const wordValue = word?.[0];
+    if (wordValue && (braceDepth > 0 || wordValue.length === 1)) {
+      cursor += wordValue.length;
+      continue;
+    }
+    break;
+  }
+
+  const math = value.slice(start, cursor).trimEnd();
+  return sawStart && math ? { end: start + math.length, math } : null;
+}
+
+export function splitBareMathText(value: string): MarkdownNode[] {
+  const nodes: MarkdownNode[] = [];
+  let textStart = 0;
+  let cursor = 0;
+
+  while (cursor < value.length) {
+    if (value[cursor] !== "\\") {
+      cursor += 1;
+      continue;
+    }
+
+    const match = readBareMath(value, cursor);
+    if (!match) {
+      cursor += 1;
+      continue;
+    }
+
+    if (textStart < cursor) {
+      nodes.push({ type: "text", value: value.slice(textStart, cursor) });
+    }
+    const math = normalizeEscapedTex(match.math);
+    nodes.push({
+      data: {
+        hChildren: [{ type: "text", value: math }],
+        hName: "code",
+        hProperties: { className: ["language-math", "math-inline"] },
+      },
+      type: "inlineMath",
+      value: math,
+    });
+    cursor = match.end;
+    textStart = cursor;
+  }
+
+  if (textStart < value.length) {
+    nodes.push({ type: "text", value: value.slice(textStart) });
+  }
+  return nodes.length > 0 ? nodes : [{ type: "text", value }];
+}
+
+export function remarkBareMath() {
+  return (tree: MarkdownNode) => {
+    const visit = (node: MarkdownNode) => {
+      if (!node.children) return;
+      node.children = node.children.flatMap((child) => {
+        if (child.type === "text" && child.value) {
+          return splitBareMathText(child.value);
+        }
+        visit(child);
+        return [child];
+      });
+    };
+    visit(tree);
+  };
+}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2689,6 +2689,24 @@ kbd {
   color: var(--color-accent-strong);
 }
 
+.reader-markdown .katex-display {
+  display: block;
+  margin: 1em 0;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 0.125rem 0;
+  text-align: center;
+}
+
+.reader-markdown .katex-display math {
+  margin: 0 auto;
+}
+
+.reader-markdown .katex-error {
+  color: var(--color-danger);
+}
+
 .reader-markdown-image-placeholder {
   align-items: center;
   border: var(--rule) solid var(--color-border);


### PR DESCRIPTION
Closes #130

## Summary

- render inline and display Markdown math through the shared Reader component with KaTeX-generated semantic MathML
- accept `$...$`, `$$...$$`, MathJax-style `\(...\)` / `\[...\]`, and conservative escaped vector sequences retained by Firecrawl
- preserve common vector macros and degrade page-specific color wrappers to uncolored notation
- keep code spans and fences literal, contain display math on narrow screens, and preserve malformed source text
- enforce the local MathML artifact boundary and document supported syntax

## Protocol and privacy impact

No CRDT, IndexedDB, sync, export, publication, capture, or service-worker schema changes. Math rendering is presentation-only. KaTeX emits MathML without runtime CDN requests, third-party scripts, inline positioning styles, or KaTeX font assets, so the self-only CSP remains unchanged. Existing remote-image consent and validation behavior is untouched.

## Verification

- `npm run verify`
- 16 focused Node contracts, including alternate delimiters, the exact escaped Firecrawl vector sequence, code preservation, and ordinary-backslash rejection
- server-rendered shared-component check proving escaped sequences and alternate delimiters produce semantic MathML, common vectors expand in bold, code remains literal, and output contains no inline styles or KaTeX HTML layer
- production artifact check proving KaTeX display styles are present, no KaTeX font payload ships, and existing CSP/runtime-asset scans pass
- 320px production Reader check confirming inline flow, centered display math, horizontal containment, and no page overflow

## UI evidence

The production reference Reader renders inline `E = mc²` in the surrounding paragraph and a centered integral display at 320px without horizontal page overflow. The shared owner Reader uses the same component and pipeline.