### PR TITLE
Bound large-library synchronization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ Do not expand V2 into:
 - a multi-user collaboration or real-time team product;
 - a general notes/wiki application or a store for standalone notes;
 - a general-purpose webpage archive, file/PDF store, highlighting system, or
-  attachment manager beyond the bounded Firecrawl Markdown retained in an
-  item's existing excerpt register;
+  attachment manager beyond bounded content-addressed Firecrawl Markdown
+  referenced by an item;
 - a hosted account service or an application backend that must stay online;
 - a native mobile application;
 - end-to-end encrypted remote storage or encrypted sharing; or
@@ -230,8 +230,8 @@ an identical hash is an idempotent success; different content is an integrity
 error that must stop sync without discarding local data.
 
 Each installation receives its own device UUID and persists its next sequence
-before upload. Create immutable checkpoints after either 1,000 update batches or
-10 MiB of unapplied tail data. Checkpoints accelerate bootstrap but do not alter
+before upload. Create immutable checkpoints after either 100 update batches or
+2 MiB of unapplied tail data. Checkpoints accelerate bootstrap but do not alter
 merge semantics. V2 does not prune update history; secure erasure requires a
 documented repository-history rewrite or migration to a new data repository.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "research"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "research-domain"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2809,8 +2809,9 @@ dependencies = [
 
 [[package]]
 name = "research-store"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
+ "base64",
  "chrono",
  "research-domain",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2024"
 rust-version = "1.94"
 keywords = ["bookmarks", "reading-list", "local-first", "knowledge", "cli"]
@@ -22,8 +22,8 @@ crossterm = "0.29.0"
 directories = "6.0.0"
 ratatui = { version = "0.30.2", default-features = false, features = ["crossterm_0_29"] }
 reqwest = { version = "0.13.4", features = ["json"] }
-research-domain = { version = "=2.0.1", path = "crates/research-domain" }
-research-store = { version = "=2.0.1", path = "crates/research-store" }
+research-domain = { version = "=2.1.0", path = "crates/research-domain" }
+research-store = { version = "=2.1.0", path = "crates/research-store" }
 scraper = "0.27.0"
 serde = "1.0.228"
 serde_json = "1.0.150"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ accept one, install [Rust](https://www.rust-lang.org/tools/install) and build th
 matching release tag from source instead of weakening system-wide security:
 
 ```sh
-git clone --branch v2.0.1 --depth 1 \
+git clone --branch v2.1.0 --depth 1 \
   https://github.com/ResearchPocket/researchpocket.github.io.git
 cd researchpocket.github.io
 cargo build --locked --release

--- a/crates/research-domain/Cargo.toml
+++ b/crates/research-domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research-domain"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2024"
 rust-version = "1.94"
 authors = ["KorigamiK <korigamik.is-a.dev>"]

--- a/crates/research-domain/src/aggregate.rs
+++ b/crates/research-domain/src/aggregate.rs
@@ -1,0 +1,611 @@
+use std::collections::BTreeMap;
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use chrono::{DateTime, FixedOffset};
+use loro::VersionVector;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    CanonicalItem, CanonicalProjection, DOMAIN_SCHEMA_VERSION, DomainError, DomainResult,
+    ItemSeed, LORO_CODEC, Library, LifecycleState, identity::validate_uuid_v7,
+};
+
+pub const AGGREGATE_PROTOCOL_VERSION: u8 = 2;
+pub const ITEM_AGGREGATES_FEATURE: &str = "item-aggregates-v2";
+pub const AGGREGATE_GENESIS_PATH: &str = "sync/v2/library.json";
+pub const ITEM_OPS_PREFIX: &str = "sync/v2/ops/items/";
+pub const ITEM_CHECKPOINTS_PREFIX: &str = "sync/v2/checkpoints/items/";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AggregateKind {
+    Item,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AggregateEnvelope {
+    pub protocol_version: u8,
+    pub domain_schema_version: u16,
+    pub loro_codec: String,
+    pub required_features: Vec<String>,
+    pub aggregate_kind: AggregateKind,
+    pub aggregate_id: String,
+    pub library_id: String,
+    pub device_id: String,
+    pub sequence: String,
+    pub causal_frontier: BTreeMap<String, i32>,
+    pub created_at: String,
+    pub payload: String,
+    pub payload_sha256: String,
+}
+
+impl AggregateEnvelope {
+    pub fn path(&self) -> String {
+        format!(
+            "{ITEM_OPS_PREFIX}{}/{}/{}.json",
+            self.aggregate_id, self.device_id, self.sequence
+        )
+    }
+
+    pub fn validate(
+        &self,
+        path: &str,
+        expected_library_id: &str,
+        expected_aggregate_id: &str,
+    ) -> DomainResult<Vec<u8>> {
+        if self.protocol_version != AGGREGATE_PROTOCOL_VERSION {
+            return Err(DomainError::UnsupportedProtocol(self.protocol_version));
+        }
+        if self.domain_schema_version > DOMAIN_SCHEMA_VERSION {
+            return Err(DomainError::UnsupportedDomainSchema(
+                self.domain_schema_version,
+            ));
+        }
+        if self.loro_codec != LORO_CODEC {
+            return Err(DomainError::UnsupportedCodec(self.loro_codec.clone()));
+        }
+        if self.required_features != [ITEM_AGGREGATES_FEATURE] {
+            return Err(DomainError::UnsupportedFeature(
+                self.required_features
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| "missing-item-aggregates-v2".into()),
+            ));
+        }
+        if self.aggregate_kind != AggregateKind::Item {
+            return Err(DomainError::InvalidState(
+                "unsupported aggregate kind".into(),
+            ));
+        }
+        for (value, label) in [
+            (self.aggregate_id.as_str(), "aggregate ID"),
+            (self.library_id.as_str(), "library ID"),
+            (self.device_id.as_str(), "device ID"),
+            (expected_library_id, "expected library ID"),
+            (expected_aggregate_id, "expected aggregate ID"),
+        ] {
+            validate_uuid_v7(value, label)?;
+        }
+        if self.library_id != expected_library_id || self.aggregate_id != expected_aggregate_id
+        {
+            return Err(DomainError::Integrity {
+                path: path.to_owned(),
+                expected: format!("{expected_library_id}/{expected_aggregate_id}"),
+                actual: format!("{}/{}", self.library_id, self.aggregate_id),
+            });
+        }
+        if path != self.path() {
+            return Err(DomainError::Integrity {
+                path: path.to_owned(),
+                expected: self.path(),
+                actual: path.to_owned(),
+            });
+        }
+        validate_sequence(&self.sequence)?;
+        validate_utc(&self.created_at, "aggregate operation creation time")?;
+        validate_frontier(&self.causal_frontier)?;
+        let payload = STANDARD.decode(&self.payload)?;
+        let actual = sha256_hex(&payload);
+        if actual != self.payload_sha256 {
+            return Err(DomainError::Integrity {
+                path: path.to_owned(),
+                expected: self.payload_sha256.clone(),
+                actual,
+            });
+        }
+        Ok(payload)
+    }
+}
+
+pub struct ItemAggregate {
+    item_id: String,
+    library: Library,
+}
+
+impl ItemAggregate {
+    pub fn from_snapshot(item_id: &str, snapshot: &[u8], peer_id: u64) -> DomainResult<Self> {
+        validate_uuid_v7(item_id, "item aggregate ID")?;
+        let library = Library::from_snapshot(snapshot, peer_id)?;
+        validate_single_item(&library, item_id)?;
+        Ok(Self {
+            item_id: item_id.to_owned(),
+            library,
+        })
+    }
+
+    pub fn from_canonical(
+        item_id: &str,
+        item: &CanonicalItem,
+        migration_checkpoint_id: &str,
+        peer_id: u64,
+    ) -> DomainResult<Self> {
+        validate_uuid_v7(item_id, "item aggregate ID")?;
+        validate_sha256(migration_checkpoint_id, "migration checkpoint ID")?;
+        let library = Library::with_peer_id(peer_id)?;
+        let prefix = format!("migration/{migration_checkpoint_id}/{item_id}");
+        library.create_item(
+            &ItemSeed {
+                item_id: item_id.to_owned(),
+                url: item.url.value.clone(),
+                title: item.title.value.clone(),
+                excerpt: (!item.excerpt.is_empty()).then(|| item.excerpt.clone()),
+                favorite: item.favorite.value,
+                language: item.language.value.clone(),
+                saved_at: item.saved_at.value,
+                note: item.note.clone(),
+                tags: item.tags.clone(),
+            },
+            &prefix,
+        )?;
+        if let Some(reference) = item
+            .captured_document
+            .as_ref()
+            .and_then(|view| view.value.as_ref())
+        {
+            library.write_captured_document(
+                item_id,
+                &format!("{prefix}/captured-document"),
+                Some(reference),
+            )?;
+        }
+        if item.lifecycle.state == LifecycleState::Deleted {
+            library.transition_lifecycle(
+                item_id,
+                &format!("{prefix}/deleted"),
+                LifecycleState::Deleted,
+            )?;
+        }
+        Ok(Self {
+            item_id: item_id.to_owned(),
+            library,
+        })
+    }
+
+    pub fn item_id(&self) -> &str {
+        &self.item_id
+    }
+
+    pub fn library(&self) -> &Library {
+        &self.library
+    }
+
+    pub fn version(&self) -> VersionVector {
+        self.library.version()
+    }
+
+    pub fn export_snapshot(&self) -> DomainResult<Vec<u8>> {
+        self.library.export_snapshot()
+    }
+
+    pub fn canonical_item(&self) -> DomainResult<CanonicalItem> {
+        self.library
+            .canonical_projection()?
+            .items
+            .remove(&self.item_id)
+            .ok_or_else(|| DomainError::InvalidState("item aggregate body is missing".into()))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn export_envelope(
+        &self,
+        from: &VersionVector,
+        library_id: &str,
+        device_id: &str,
+        sequence: u64,
+        created_at: &str,
+    ) -> DomainResult<AggregateEnvelope> {
+        validate_uuid_v7(library_id, "library ID")?;
+        validate_uuid_v7(device_id, "device ID")?;
+        validate_utc(created_at, "aggregate operation creation time")?;
+        if sequence == 0 {
+            return Err(DomainError::InvalidState(
+                "aggregate operation sequence cannot be zero".into(),
+            ));
+        }
+        let update = self.library.export_update(from)?;
+        let envelope = AggregateEnvelope {
+            protocol_version: AGGREGATE_PROTOCOL_VERSION,
+            domain_schema_version: DOMAIN_SCHEMA_VERSION,
+            loro_codec: LORO_CODEC.to_owned(),
+            required_features: vec![ITEM_AGGREGATES_FEATURE.to_owned()],
+            aggregate_kind: AggregateKind::Item,
+            aggregate_id: self.item_id.clone(),
+            library_id: library_id.to_owned(),
+            device_id: device_id.to_owned(),
+            sequence: format!("{sequence:020}"),
+            causal_frontier: from
+                .iter()
+                .map(|(peer, counter)| (peer.to_string(), *counter))
+                .collect(),
+            created_at: created_at.to_owned(),
+            payload: STANDARD.encode(&update),
+            payload_sha256: sha256_hex(&update),
+        };
+        envelope.validate(&envelope.path(), library_id, &self.item_id)?;
+        Ok(envelope)
+    }
+
+    pub fn import_envelope(
+        &self,
+        path: &str,
+        envelope: &AggregateEnvelope,
+        expected_library_id: &str,
+    ) -> DomainResult<bool> {
+        let payload = envelope.validate(path, expected_library_id, &self.item_id)?;
+        self.library.import_update(&payload)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ItemAggregateCheckpoint {
+    pub aggregate_id: String,
+    pub snapshot_sha256: String,
+    pub snapshot_base64: String,
+}
+
+impl ItemAggregateCheckpoint {
+    pub fn path(&self) -> String {
+        format!(
+            "{ITEM_CHECKPOINTS_PREFIX}{}/{}.json",
+            self.aggregate_id, self.snapshot_sha256
+        )
+    }
+
+    pub fn validate(&self, path: &str, peer_id: u64) -> DomainResult<ItemAggregate> {
+        validate_uuid_v7(&self.aggregate_id, "item aggregate ID")?;
+        validate_sha256(&self.snapshot_sha256, "item snapshot SHA-256")?;
+        if path != self.path() {
+            return Err(DomainError::Integrity {
+                path: path.to_owned(),
+                expected: self.path(),
+                actual: path.to_owned(),
+            });
+        }
+        let snapshot = STANDARD.decode(&self.snapshot_base64)?;
+        let actual = sha256_hex(&snapshot);
+        if actual != self.snapshot_sha256 {
+            return Err(DomainError::Integrity {
+                path: path.to_owned(),
+                expected: self.snapshot_sha256.clone(),
+                actual,
+            });
+        }
+        ItemAggregate::from_snapshot(&self.aggregate_id, &snapshot, peer_id)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CatalogueEntry {
+    pub aggregate_id: String,
+    pub saved_at: i64,
+    pub state: LifecycleState,
+    pub checkpoint_path: String,
+    pub snapshot_sha256: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AggregateCatalogue {
+    pub protocol_version: u8,
+    pub library_id: String,
+    pub migrated_from_v1_checkpoint: String,
+    pub entries: Vec<CatalogueEntry>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AggregateGenesis {
+    pub protocol_version: u8,
+    pub required_features: Vec<String>,
+    pub library_id: String,
+    pub created_at: String,
+    pub migrated_from_v1_checkpoint: String,
+    pub catalogue_sha256: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AggregateMigration {
+    pub genesis_json: String,
+    pub catalogue_json: String,
+    pub catalogue_sha256: String,
+    pub checkpoints: Vec<(String, String)>,
+}
+
+pub fn create_aggregate_migration(
+    projection: &CanonicalProjection,
+    library_id: &str,
+    v1_checkpoint_id: &str,
+    created_at: &str,
+    peer_id: u64,
+) -> DomainResult<AggregateMigration> {
+    validate_uuid_v7(library_id, "library ID")?;
+    validate_sha256(v1_checkpoint_id, "v1 checkpoint ID")?;
+    validate_utc(created_at, "aggregate genesis creation time")?;
+    let mut entries = Vec::with_capacity(projection.items.len());
+    let mut checkpoints = Vec::with_capacity(projection.items.len());
+    for (item_id, item) in &projection.items {
+        let aggregate =
+            ItemAggregate::from_canonical(item_id, item, v1_checkpoint_id, peer_id)?;
+        let snapshot = aggregate.export_snapshot()?;
+        let checkpoint = ItemAggregateCheckpoint {
+            aggregate_id: item_id.clone(),
+            snapshot_sha256: sha256_hex(&snapshot),
+            snapshot_base64: STANDARD.encode(snapshot),
+        };
+        let checkpoint_path = checkpoint.path();
+        entries.push(CatalogueEntry {
+            aggregate_id: item_id.clone(),
+            saved_at: item.saved_at.value,
+            state: item.lifecycle.state,
+            checkpoint_path: checkpoint_path.clone(),
+            snapshot_sha256: checkpoint.snapshot_sha256.clone(),
+        });
+        checkpoints.push((checkpoint_path, serde_json::to_string(&checkpoint)?));
+    }
+    let catalogue = AggregateCatalogue {
+        protocol_version: AGGREGATE_PROTOCOL_VERSION,
+        library_id: library_id.to_owned(),
+        migrated_from_v1_checkpoint: v1_checkpoint_id.to_owned(),
+        entries,
+    };
+    let catalogue_json = serde_json::to_string(&catalogue)?;
+    let catalogue_sha256 = sha256_hex(catalogue_json.as_bytes());
+    let genesis = AggregateGenesis {
+        protocol_version: AGGREGATE_PROTOCOL_VERSION,
+        required_features: vec![ITEM_AGGREGATES_FEATURE.to_owned()],
+        library_id: library_id.to_owned(),
+        created_at: created_at.to_owned(),
+        migrated_from_v1_checkpoint: v1_checkpoint_id.to_owned(),
+        catalogue_sha256: catalogue_sha256.clone(),
+    };
+    Ok(AggregateMigration {
+        genesis_json: serde_json::to_string(&genesis)?,
+        catalogue_json,
+        catalogue_sha256,
+        checkpoints,
+    })
+}
+
+fn validate_single_item(library: &Library, item_id: &str) -> DomainResult<()> {
+    let projection = library.canonical_projection()?;
+    if projection.items.len() != 1 || !projection.items.contains_key(item_id) {
+        return Err(DomainError::InvalidState(
+            "item aggregate snapshot does not contain exactly its declared item".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_sequence(value: &str) -> DomainResult<()> {
+    if value.len() != 20
+        || !value.bytes().all(|byte| byte.is_ascii_digit())
+        || value == "00000000000000000000"
+        || value.parse::<u64>().is_err()
+    {
+        return Err(DomainError::InvalidState(
+            "aggregate sequence is not a nonzero fixed-width u64".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_frontier(frontier: &BTreeMap<String, i32>) -> DomainResult<()> {
+    for (peer, counter) in frontier {
+        if peer.parse::<u64>().is_err() || *counter < 0 {
+            return Err(DomainError::InvalidState(
+                "aggregate causal frontier is invalid".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_utc(value: &str, label: &str) -> DomainResult<()> {
+    let parsed = DateTime::<FixedOffset>::parse_from_rfc3339(value)
+        .map_err(|_| DomainError::InvalidState(format!("{label} is not RFC 3339")))?;
+    if parsed.offset().local_minus_utc() != 0 {
+        return Err(DomainError::InvalidState(format!("{label} is not UTC")));
+    }
+    Ok(())
+}
+
+fn validate_sha256(value: &str, label: &str) -> DomainResult<()> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(DomainError::InvalidState(format!(
+            "{label} is not lowercase SHA-256"
+        )));
+    }
+    Ok(())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CapturedDocumentProvenance, CapturedDocumentRef, ScalarRevision, ScalarView};
+
+    const LIBRARY: &str = "00000000-0000-7000-8000-000000000001";
+    const DEVICE: &str = "00000000-0000-7000-8000-000000000002";
+    const ITEM: &str = "0197f2b5-93d7-7ad4-8c67-21e98f0c7341";
+    const CHECKPOINT: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    fn scalar<T: Clone>(value: T, suffix: &str) -> ScalarView<T> {
+        let winner = format!("migration/{suffix}");
+        ScalarView {
+            value: value.clone(),
+            winner: winner.clone(),
+            heads: vec![winner.clone()],
+            revisions: BTreeMap::from([(
+                winner,
+                ScalarRevision {
+                    parents: Vec::new(),
+                    value,
+                },
+            )]),
+        }
+    }
+
+    fn item() -> CanonicalItem {
+        CanonicalItem {
+            url: scalar("https://example.com".to_owned(), "url"),
+            title: scalar(Some("Title".to_owned()), "title"),
+            excerpt: "Authored summary".into(),
+            favorite: scalar(false, "favorite"),
+            language: scalar(Some("en".to_owned()), "language"),
+            saved_at: scalar(1_700_000_000, "saved-at"),
+            captured_document: Some(scalar(
+                Some(CapturedDocumentRef {
+                    sha256: "b".repeat(64),
+                    byte_length: 1_000_000,
+                    media_type: "text/markdown; charset=utf-8".into(),
+                    provenance: CapturedDocumentProvenance {
+                        provider: "firecrawl".into(),
+                        source_url: "https://example.com".into(),
+                        captured_at: "2026-07-28T00:00:00Z".into(),
+                    },
+                }),
+                "captured",
+            )),
+            note: "Private note".into(),
+            tags: vec!["reference".into()],
+            lifecycle: crate::LifecycleView {
+                state: LifecycleState::Active,
+                generation: 0,
+                heads: vec!["migration/lifecycle".into()],
+                revisions: BTreeMap::from([(
+                    "migration/lifecycle".into(),
+                    crate::LifecycleRevision {
+                        generation: 0,
+                        parents: Vec::new(),
+                        state: LifecycleState::Active,
+                    },
+                )]),
+            },
+        }
+    }
+
+    #[test]
+    fn item_envelopes_are_scoped_and_converge_without_document_bytes() {
+        let aggregate =
+            ItemAggregate::from_canonical(ITEM, &item(), CHECKPOINT, 11).expect("aggregate");
+        let base_snapshot = aggregate.export_snapshot().expect("base snapshot");
+        let before = aggregate.version();
+        aggregate
+            .library()
+            .write_title(ITEM, "device/1/title", Some("Changed"))
+            .expect("edit title");
+        let envelope = aggregate
+            .export_envelope(&before, LIBRARY, DEVICE, 1, "2026-07-28T00:00:01Z")
+            .expect("envelope");
+        assert!(envelope.path().contains(ITEM));
+        assert!(
+            !serde_json::to_string(&envelope)
+                .unwrap()
+                .contains(&"x".repeat(100))
+        );
+
+        let base = ItemAggregate::from_snapshot(ITEM, &base_snapshot, 22).expect("base");
+        base.import_envelope(&envelope.path(), &envelope, LIBRARY)
+            .expect("apply");
+        assert_eq!(
+            base.canonical_item().unwrap().title.value.as_deref(),
+            Some("Changed")
+        );
+    }
+
+    #[test]
+    fn migration_catalogue_contains_references_but_no_captured_bytes() {
+        let projection = CanonicalProjection {
+            schema_version: 3,
+            items: BTreeMap::from([(ITEM.to_owned(), item())]),
+        };
+        let migration = create_aggregate_migration(
+            &projection,
+            LIBRARY,
+            CHECKPOINT,
+            "2026-07-28T00:00:00Z",
+            31,
+        )
+        .expect("migration");
+        let repeated = create_aggregate_migration(
+            &projection,
+            LIBRARY,
+            CHECKPOINT,
+            "2026-07-28T00:00:00Z",
+            31,
+        )
+        .expect("repeated migration");
+        assert_eq!(migration.genesis_json, repeated.genesis_json);
+        assert_eq!(migration.catalogue_json, repeated.catalogue_json);
+        assert_eq!(migration.checkpoints, repeated.checkpoints);
+        assert_eq!(migration.checkpoints.len(), 1);
+        assert!(!migration.catalogue_json.contains("markdown"));
+        let (path, json) = &migration.checkpoints[0];
+        let checkpoint: ItemAggregateCheckpoint = serde_json::from_str(json).unwrap();
+        checkpoint.validate(path, 32).expect("checkpoint");
+    }
+
+    #[test]
+    fn recognized_v1_barrier_is_accepted_but_unknown_features_fail_closed() {
+        let library =
+            ItemAggregate::from_canonical(ITEM, &item(), CHECKPOINT, 41).expect("aggregate");
+        let before = library.library().version();
+        let barrier = library
+            .library()
+            .export_item_aggregates_migration_barrier(
+                &before,
+                LIBRARY,
+                DEVICE,
+                1,
+                "2026-07-28T00:00:00Z",
+            )
+            .expect("barrier");
+        let replica =
+            ItemAggregate::from_snapshot(ITEM, &library.export_snapshot().unwrap(), 42)
+                .expect("replica");
+        replica
+            .library()
+            .import_envelope(&barrier)
+            .expect("new client accepts barrier");
+        let mut future = barrier;
+        future.required_features.push("future-feature".into());
+        assert!(matches!(
+            replica.library().import_envelope(&future),
+            Err(DomainError::UnsupportedFeature(_))
+        ));
+    }
+}

--- a/crates/research-domain/src/captured.rs
+++ b/crates/research-domain/src/captured.rs
@@ -1,0 +1,247 @@
+use chrono::{DateTime, FixedOffset};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{DomainError, DomainResult, validate_item_url};
+
+pub const CAPTURED_CONTENT_PREFIX: &str = "sync/v2/content/sha256/";
+pub const CAPTURED_MARKDOWN_MEDIA_TYPE: &str = "text/markdown; charset=utf-8";
+pub const MAX_CAPTURED_DOCUMENT_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CapturedDocumentProvenance {
+    pub provider: String,
+    pub source_url: String,
+    pub captured_at: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CapturedDocumentRef {
+    pub sha256: String,
+    pub byte_length: u64,
+    pub media_type: String,
+    pub provenance: CapturedDocumentProvenance,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CapturedDocumentArtifact {
+    pub path: String,
+    pub markdown: String,
+    pub reference: CapturedDocumentRef,
+}
+
+pub fn create_captured_document(
+    markdown: &str,
+    provider: &str,
+    source_url: &str,
+    captured_at: &str,
+) -> DomainResult<CapturedDocumentArtifact> {
+    let markdown = normalize_markdown(markdown)?;
+    validate_provenance(provider, source_url, captured_at)?;
+    let bytes = markdown.as_bytes();
+    validate_size(bytes.len())?;
+    let sha256 = sha256_hex(bytes);
+    let byte_length = u64::try_from(bytes.len())
+        .map_err(|_| DomainError::InvalidState("captured document is too large".into()))?;
+    let reference = CapturedDocumentRef {
+        sha256: sha256.clone(),
+        byte_length,
+        media_type: CAPTURED_MARKDOWN_MEDIA_TYPE.to_owned(),
+        provenance: CapturedDocumentProvenance {
+            provider: provider.to_owned(),
+            source_url: source_url.to_owned(),
+            captured_at: captured_at.to_owned(),
+        },
+    };
+    Ok(CapturedDocumentArtifact {
+        path: captured_content_path(&sha256)?,
+        markdown,
+        reference,
+    })
+}
+
+pub fn validate_captured_document_ref(reference: &CapturedDocumentRef) -> DomainResult<()> {
+    validate_hash(&reference.sha256)?;
+    let byte_length = usize::try_from(reference.byte_length).map_err(|_| {
+        DomainError::InvalidState("captured document length is too large".into())
+    })?;
+    validate_size(byte_length)?;
+    if reference.media_type != CAPTURED_MARKDOWN_MEDIA_TYPE {
+        return Err(DomainError::InvalidState(
+            "captured document media type is unsupported".into(),
+        ));
+    }
+    validate_provenance(
+        &reference.provenance.provider,
+        &reference.provenance.source_url,
+        &reference.provenance.captured_at,
+    )
+}
+
+pub fn validate_captured_content(path: &str, bytes: &[u8]) -> DomainResult<String> {
+    validate_size(bytes.len())?;
+    std::str::from_utf8(bytes)
+        .map_err(|_| DomainError::InvalidState("captured document is not UTF-8".into()))?;
+    let sha256 = sha256_hex(bytes);
+    let expected_path = captured_content_path(&sha256)?;
+    if path != expected_path {
+        return Err(DomainError::Integrity {
+            path: path.to_owned(),
+            expected: expected_path,
+            actual: path.to_owned(),
+        });
+    }
+    Ok(sha256)
+}
+
+pub fn validate_captured_content_for_ref(
+    path: &str,
+    bytes: &[u8],
+    reference: &CapturedDocumentRef,
+) -> DomainResult<()> {
+    validate_captured_document_ref(reference)?;
+    let sha256 = validate_captured_content(path, bytes)?;
+    if sha256 != reference.sha256 {
+        return Err(DomainError::Integrity {
+            path: path.to_owned(),
+            expected: reference.sha256.clone(),
+            actual: sha256,
+        });
+    }
+    let byte_length = u64::try_from(bytes.len())
+        .map_err(|_| DomainError::InvalidState("captured document is too large".into()))?;
+    if byte_length != reference.byte_length {
+        return Err(DomainError::InvalidState(
+            "captured document byte length does not match its reference".into(),
+        ));
+    }
+    Ok(())
+}
+
+pub fn captured_content_path(sha256: &str) -> DomainResult<String> {
+    validate_hash(sha256)?;
+    Ok(format!(
+        "{CAPTURED_CONTENT_PREFIX}{}/{}.md",
+        &sha256[..2],
+        sha256
+    ))
+}
+
+fn normalize_markdown(value: &str) -> DomainResult<String> {
+    let normalized_newlines = value.replace("\r\n", "\n").replace('\r', "\n");
+    let sanitized = normalized_newlines
+        .chars()
+        .map(|character| {
+            if character.is_control() && !matches!(character, '\n' | '\t') {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+    let markdown = sanitized.trim();
+    if markdown.is_empty() {
+        return Err(DomainError::InvalidState(
+            "captured document cannot be blank".into(),
+        ));
+    }
+    validate_size(markdown.len())?;
+    Ok(markdown.to_owned())
+}
+
+fn validate_provenance(
+    provider: &str,
+    source_url: &str,
+    captured_at: &str,
+) -> DomainResult<()> {
+    if provider != "firecrawl" {
+        return Err(DomainError::InvalidState(
+            "captured document provider is unsupported".into(),
+        ));
+    }
+    validate_item_url(source_url)?;
+    DateTime::<FixedOffset>::parse_from_rfc3339(captured_at)
+        .map_err(|_| DomainError::InvalidState("captured time is not RFC 3339".into()))?;
+    Ok(())
+}
+
+fn validate_hash(value: &str) -> DomainResult<()> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(DomainError::InvalidState(
+            "captured document hash is not lowercase SHA-256".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_size(bytes: usize) -> DomainResult<()> {
+    if bytes == 0 || bytes > MAX_CAPTURED_DOCUMENT_BYTES {
+        return Err(DomainError::InvalidState(format!(
+            "captured document must contain 1 to {MAX_CAPTURED_DOCUMENT_BYTES} UTF-8 bytes"
+        )));
+    }
+    Ok(())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const URL: &str = "https://example.com/article";
+    const TIME: &str = "2026-07-28T12:00:00+05:30";
+
+    #[test]
+    fn content_is_normalized_and_addressed_by_exact_bytes() {
+        let artifact =
+            create_captured_document("  # Title\r\n\rBody\u{0000}  ", "firecrawl", URL, TIME)
+                .expect("artifact");
+        assert_eq!(artifact.markdown, "# Title\n\nBody");
+        assert_eq!(
+            artifact.reference.byte_length,
+            artifact.markdown.len() as u64
+        );
+        validate_captured_content_for_ref(
+            &artifact.path,
+            artifact.markdown.as_bytes(),
+            &artifact.reference,
+        )
+        .expect("valid content");
+    }
+
+    #[test]
+    fn path_hash_length_and_size_mismatches_fail_closed() {
+        let artifact =
+            create_captured_document("# Title", "firecrawl", URL, TIME).expect("artifact");
+        assert!(validate_captured_content(&artifact.path, b"# Changed").is_err());
+        let mut wrong_length = artifact.reference.clone();
+        wrong_length.byte_length += 1;
+        assert!(
+            validate_captured_content_for_ref(
+                &artifact.path,
+                artifact.markdown.as_bytes(),
+                &wrong_length,
+            )
+            .is_err()
+        );
+        assert!(
+            create_captured_document(
+                &"x".repeat(MAX_CAPTURED_DOCUMENT_BYTES + 1),
+                "firecrawl",
+                URL,
+                TIME,
+            )
+            .is_err()
+        );
+    }
+}

--- a/crates/research-domain/src/checkpoint.rs
+++ b/crates/research-domain/src/checkpoint.rs
@@ -1,0 +1,396 @@
+use std::collections::BTreeMap;
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use chrono::{DateTime, FixedOffset};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    DOMAIN_SCHEMA_VERSION, DomainError, DomainResult, LORO_CODEC, Library, PROTOCOL_VERSION,
+    identity::validate_uuid_v7,
+};
+
+pub const CHECKPOINTS_PREFIX: &str = "sync/v1/checkpoints/";
+pub const MAX_CHECKPOINT_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CoverageInterval {
+    pub start: String,
+    pub end: String,
+}
+
+impl CoverageInterval {
+    pub fn new(start: u64, end: u64) -> DomainResult<Self> {
+        if start == 0 || start > end {
+            return Err(DomainError::InvalidState(
+                "checkpoint coverage interval must be nonzero and ordered".into(),
+            ));
+        }
+        Ok(Self {
+            start: format!("{start:020}"),
+            end: format!("{end:020}"),
+        })
+    }
+
+    pub fn contains(&self, sequence: &str) -> bool {
+        self.start.as_str() <= sequence && sequence <= self.end.as_str()
+    }
+
+    fn bounds(&self) -> DomainResult<(u64, u64)> {
+        let start = parse_sequence(&self.start)?;
+        let end = parse_sequence(&self.end)?;
+        if start > end {
+            return Err(DomainError::InvalidState(
+                "checkpoint coverage interval is reversed".into(),
+            ));
+        }
+        Ok((start, end))
+    }
+}
+
+pub type CheckpointCoverage = BTreeMap<String, Vec<CoverageInterval>>;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Checkpoint {
+    pub protocol_version: u8,
+    pub domain_schema_version: u16,
+    pub loro_codec: String,
+    #[serde(default)]
+    pub required_features: Vec<String>,
+    #[serde(default)]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+    pub library_id: String,
+    pub checkpoint_id: String,
+    pub created_at: String,
+    pub frontier: BTreeMap<String, i32>,
+    pub coverage: CheckpointCoverage,
+    pub batch_count: u64,
+    pub payload: String,
+    pub payload_sha256: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CheckpointArtifact {
+    pub path: String,
+    pub json: String,
+    pub checkpoint_id: String,
+    pub created_at: String,
+    pub batch_count: u64,
+    pub coverage: CheckpointCoverage,
+    pub snapshot_base64: String,
+}
+
+pub fn create_checkpoint(
+    snapshot: &[u8],
+    library_id: &str,
+    created_at: &str,
+    coverage: CheckpointCoverage,
+) -> DomainResult<CheckpointArtifact> {
+    validate_uuid_v7(library_id, "checkpoint library ID")?;
+    validate_timestamp(created_at)?;
+    let library = Library::from_snapshot(snapshot, validation_peer_id())?;
+    let frontier = frontier(&library);
+    let batch_count = validate_coverage(&coverage)?;
+    let checkpoint_id = sha256_hex(snapshot);
+    let checkpoint = Checkpoint {
+        protocol_version: PROTOCOL_VERSION,
+        domain_schema_version: DOMAIN_SCHEMA_VERSION,
+        loro_codec: LORO_CODEC.to_owned(),
+        required_features: Vec::new(),
+        extensions: BTreeMap::new(),
+        library_id: library_id.to_owned(),
+        checkpoint_id: checkpoint_id.clone(),
+        created_at: created_at.to_owned(),
+        frontier,
+        coverage: coverage.clone(),
+        batch_count,
+        payload: STANDARD.encode(snapshot),
+        payload_sha256: checkpoint_id.clone(),
+    };
+    let json = serde_json::to_string(&checkpoint)?;
+    validate_size(json.len())?;
+    Ok(CheckpointArtifact {
+        path: checkpoint_path(&checkpoint_id),
+        json,
+        checkpoint_id,
+        created_at: created_at.to_owned(),
+        batch_count,
+        coverage,
+        snapshot_base64: checkpoint.payload,
+    })
+}
+
+pub fn validate_checkpoint(
+    path: &str,
+    json: &str,
+    expected_library_id: &str,
+) -> DomainResult<CheckpointArtifact> {
+    validate_size(json.len())?;
+    validate_uuid_v7(expected_library_id, "expected checkpoint library ID")?;
+    let checkpoint: Checkpoint = serde_json::from_str(json)?;
+    if checkpoint.protocol_version != PROTOCOL_VERSION {
+        return Err(DomainError::UnsupportedProtocol(
+            checkpoint.protocol_version,
+        ));
+    }
+    if checkpoint.domain_schema_version > DOMAIN_SCHEMA_VERSION {
+        return Err(DomainError::UnsupportedDomainSchema(
+            checkpoint.domain_schema_version,
+        ));
+    }
+    if checkpoint.loro_codec != LORO_CODEC {
+        return Err(DomainError::UnsupportedCodec(checkpoint.loro_codec.clone()));
+    }
+    if let Some(feature) = checkpoint.required_features.first() {
+        return Err(DomainError::UnsupportedFeature(feature.clone()));
+    }
+    if !checkpoint.extensions.is_empty() {
+        return Err(DomainError::InvalidState(
+            "checkpoint extensions must be empty".into(),
+        ));
+    }
+    validate_uuid_v7(&checkpoint.library_id, "checkpoint library ID")?;
+    if checkpoint.library_id != expected_library_id {
+        return Err(DomainError::Integrity {
+            path: path.to_owned(),
+            expected: expected_library_id.to_owned(),
+            actual: checkpoint.library_id,
+        });
+    }
+    validate_timestamp(&checkpoint.created_at)?;
+    let expected_path = checkpoint_path(&checkpoint.checkpoint_id);
+    if path != expected_path {
+        return Err(DomainError::Integrity {
+            path: path.to_owned(),
+            expected: expected_path,
+            actual: path.to_owned(),
+        });
+    }
+    if checkpoint.payload_sha256 != checkpoint.checkpoint_id {
+        return Err(DomainError::Integrity {
+            path: path.to_owned(),
+            expected: checkpoint.checkpoint_id,
+            actual: checkpoint.payload_sha256,
+        });
+    }
+    let snapshot = STANDARD.decode(&checkpoint.payload)?;
+    if STANDARD.encode(&snapshot) != checkpoint.payload {
+        return Err(DomainError::InvalidState(
+            "checkpoint payload is not canonical standard base64".into(),
+        ));
+    }
+    let actual_hash = sha256_hex(&snapshot);
+    if actual_hash != checkpoint.payload_sha256 {
+        return Err(DomainError::Integrity {
+            path: path.to_owned(),
+            expected: checkpoint.payload_sha256,
+            actual: actual_hash,
+        });
+    }
+    let library = Library::from_snapshot(&snapshot, validation_peer_id())?;
+    let actual_frontier = frontier(&library);
+    validate_frontier(&checkpoint.frontier)?;
+    if checkpoint.frontier != actual_frontier {
+        return Err(DomainError::InvalidState(
+            "checkpoint frontier does not match its snapshot".into(),
+        ));
+    }
+    let batch_count = validate_coverage(&checkpoint.coverage)?;
+    if checkpoint.batch_count != batch_count {
+        return Err(DomainError::InvalidState(
+            "checkpoint batch count does not match its coverage".into(),
+        ));
+    }
+    Ok(CheckpointArtifact {
+        path: path.to_owned(),
+        json: json.to_owned(),
+        checkpoint_id: checkpoint.checkpoint_id,
+        created_at: checkpoint.created_at,
+        batch_count,
+        coverage: checkpoint.coverage,
+        snapshot_base64: checkpoint.payload,
+    })
+}
+
+pub fn coverage_contains(
+    coverage: &CheckpointCoverage,
+    device_id: &str,
+    sequence: &str,
+) -> bool {
+    coverage
+        .get(device_id)
+        .is_some_and(|intervals| intervals.iter().any(|interval| interval.contains(sequence)))
+}
+
+fn validate_coverage(coverage: &CheckpointCoverage) -> DomainResult<u64> {
+    let mut batch_count = 0_u64;
+    for (device_id, intervals) in coverage {
+        validate_uuid_v7(device_id, "checkpoint coverage device ID")?;
+        let mut previous_end = 0_u64;
+        for interval in intervals {
+            let (start, end) = interval.bounds()?;
+            if start <= previous_end {
+                return Err(DomainError::InvalidState(
+                    "checkpoint coverage intervals overlap or are unsorted".into(),
+                ));
+            }
+            let count = end
+                .checked_sub(start)
+                .and_then(|distance| distance.checked_add(1))
+                .ok_or_else(|| {
+                    DomainError::InvalidState("checkpoint coverage size overflow".into())
+                })?;
+            batch_count = batch_count.checked_add(count).ok_or_else(|| {
+                DomainError::InvalidState("checkpoint batch count overflow".into())
+            })?;
+            previous_end = end;
+        }
+    }
+    Ok(batch_count)
+}
+
+fn validate_frontier(frontier: &BTreeMap<String, i32>) -> DomainResult<()> {
+    for (peer, counter) in frontier {
+        if peer.parse::<u64>().is_err() || *counter < 0 {
+            return Err(DomainError::InvalidState(
+                "checkpoint frontier contains an invalid entry".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn frontier(library: &Library) -> BTreeMap<String, i32> {
+    library
+        .version()
+        .iter()
+        .map(|(peer, counter)| (peer.to_string(), *counter))
+        .collect()
+}
+
+fn parse_sequence(value: &str) -> DomainResult<u64> {
+    if value.len() != 20
+        || value == "00000000000000000000"
+        || !value.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Err(DomainError::InvalidState(
+            "checkpoint sequence is not a nonzero fixed-width decimal".into(),
+        ));
+    }
+    value
+        .parse::<u64>()
+        .map_err(|_| DomainError::InvalidState("checkpoint sequence is out of range".into()))
+}
+
+fn validate_timestamp(value: &str) -> DomainResult<()> {
+    let parsed: DateTime<FixedOffset> = DateTime::parse_from_rfc3339(value)
+        .map_err(|_| DomainError::InvalidState("invalid checkpoint creation time".into()))?;
+    if parsed.offset().local_minus_utc() != 0 {
+        return Err(DomainError::InvalidState(
+            "checkpoint creation time is not in UTC".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn checkpoint_path(checkpoint_id: &str) -> String {
+    format!("{CHECKPOINTS_PREFIX}{checkpoint_id}.json")
+}
+
+fn validate_size(bytes: usize) -> DomainResult<()> {
+    if bytes > MAX_CHECKPOINT_BYTES {
+        return Err(DomainError::InvalidState(format!(
+            "checkpoint exceeds the {MAX_CHECKPOINT_BYTES}-byte limit"
+        )));
+    }
+    Ok(())
+}
+
+fn validation_peer_id() -> u64 {
+    u64::MAX - 1
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ItemSeed;
+
+    const LIBRARY_ID: &str = "00000000-0000-7000-8000-000000000001";
+    const DEVICE_ID: &str = "00000000-0000-7000-8000-000000000101";
+    const ITEM_ID: &str = "00000000-0000-7000-8000-000000000201";
+
+    fn artifact() -> CheckpointArtifact {
+        let library = Library::with_peer_id_for_fixture(101).expect("library");
+        library
+            .create_item(
+                &ItemSeed {
+                    item_id: ITEM_ID.into(),
+                    url: "https://example.com".into(),
+                    title: None,
+                    excerpt: None,
+                    favorite: false,
+                    language: None,
+                    saved_at: 1_700_000_000,
+                    note: String::new(),
+                    tags: Vec::new(),
+                },
+                "device/00000000000000000001",
+            )
+            .expect("item");
+        let coverage = BTreeMap::from([(
+            DEVICE_ID.to_owned(),
+            vec![CoverageInterval::new(1, 3).expect("coverage")],
+        )]);
+        create_checkpoint(
+            &library.export_snapshot().expect("snapshot"),
+            LIBRARY_ID,
+            "2026-07-28T00:00:00Z",
+            coverage,
+        )
+        .expect("checkpoint")
+    }
+
+    #[test]
+    fn checkpoint_round_trip_validates_snapshot_and_exact_coverage() {
+        let artifact = artifact();
+        let validated =
+            validate_checkpoint(&artifact.path, &artifact.json, LIBRARY_ID).expect("validate");
+        assert_eq!(validated.checkpoint_id, artifact.checkpoint_id);
+        assert_eq!(validated.batch_count, 3);
+        assert!(coverage_contains(
+            &validated.coverage,
+            DEVICE_ID,
+            "00000000000000000002"
+        ));
+        assert!(!coverage_contains(
+            &validated.coverage,
+            DEVICE_ID,
+            "00000000000000000004"
+        ));
+    }
+
+    #[test]
+    fn checkpoint_rejects_tampered_snapshot_and_coverage() {
+        let artifact = artifact();
+        let mut checkpoint: Checkpoint =
+            serde_json::from_str(&artifact.json).expect("checkpoint JSON");
+        checkpoint.payload.push('A');
+        let tampered = serde_json::to_string(&checkpoint).expect("tampered JSON");
+        assert!(validate_checkpoint(&artifact.path, &tampered, LIBRARY_ID).is_err());
+
+        let mut checkpoint: Checkpoint =
+            serde_json::from_str(&artifact.json).expect("checkpoint JSON");
+        checkpoint.batch_count += 1;
+        let tampered = serde_json::to_string(&checkpoint).expect("tampered JSON");
+        assert!(validate_checkpoint(&artifact.path, &tampered, LIBRARY_ID).is_err());
+    }
+}

--- a/crates/research-domain/src/document.rs
+++ b/crates/research-domain/src/document.rs
@@ -9,8 +9,9 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    CanonicalItem, CanonicalProjection, LifecycleRevision, LifecycleState, ScalarRevision,
-    ScalarView, UpdateEnvelope,
+    CanonicalItem, CanonicalProjection, CapturedDocumentRef, ITEM_AGGREGATES_FEATURE,
+    LifecycleRevision, LifecycleState, ScalarRevision, ScalarView, UpdateEnvelope,
+    captured::validate_captured_document_ref,
     identity::validate_uuid_v7,
     projection::{causal_heads, lifecycle_view, scalar_view},
 };
@@ -29,6 +30,7 @@ const EXCERPT: &str = "excerpt";
 const FAVORITE: &str = "favorite";
 const LANGUAGE: &str = "language";
 const SAVED_AT: &str = "saved_at";
+const CAPTURED_DOCUMENT: &str = "captured_document";
 
 pub type DomainResult<T> = Result<T, DomainError>;
 
@@ -126,6 +128,18 @@ impl Library {
 
     pub fn version(&self) -> VersionVector {
         self.doc.oplog_vv()
+    }
+
+    pub(crate) fn export_update(&self, from: &VersionVector) -> DomainResult<Vec<u8>> {
+        self.doc
+            .export(ExportMode::updates(from))
+            .map_err(loro_error)
+    }
+
+    pub(crate) fn import_update(&self, update: &[u8]) -> DomainResult<bool> {
+        LoroDoc::decode_import_blob_meta(update, true).map_err(loro_error)?;
+        let status = self.doc.import(update).map_err(loro_error)?;
+        Ok(status.pending.is_some())
     }
 
     pub fn create_item(&self, seed: &ItemSeed, operation_prefix: &str) -> DomainResult<()> {
@@ -307,6 +321,18 @@ impl Library {
         self.write_scalar(item_id, SAVED_AT, revision_id, value)
     }
 
+    pub fn write_captured_document(
+        &self,
+        item_id: &str,
+        revision_id: &str,
+        value: Option<&CapturedDocumentRef>,
+    ) -> DomainResult<()> {
+        if let Some(reference) = value {
+            validate_captured_document_ref(reference)?;
+        }
+        self.write_scalar(item_id, CAPTURED_DOCUMENT, revision_id, value.cloned())
+    }
+
     fn write_scalar<T>(
         &self,
         item_id: &str,
@@ -404,11 +430,22 @@ impl Library {
                 "envelope creation time cannot be blank".into(),
             ));
         }
-        let update = self
-            .doc
-            .export(ExportMode::updates(from))
-            .map_err(loro_error)?;
+        let update = self.export_update(from)?;
         UpdateEnvelope::new(library_id, device_id, sequence, from, created_at, &update)
+    }
+
+    pub fn export_item_aggregates_migration_barrier(
+        &self,
+        from: &VersionVector,
+        library_id: &str,
+        device_id: &str,
+        sequence: u64,
+        created_at: &str,
+    ) -> DomainResult<UpdateEnvelope> {
+        let mut envelope =
+            self.export_envelope(from, library_id, device_id, sequence, created_at)?;
+        envelope.required_features = vec![ITEM_AGGREGATES_FEATURE.to_owned()];
+        Ok(envelope)
     }
 
     pub fn import_envelope(&self, envelope: &UpdateEnvelope) -> DomainResult<()> {
@@ -416,10 +453,7 @@ impl Library {
     }
 
     pub fn import_envelope_has_pending(&self, envelope: &UpdateEnvelope) -> DomainResult<bool> {
-        let payload = envelope.verified_payload()?;
-        LoroDoc::decode_import_blob_meta(&payload, true).map_err(loro_error)?;
-        let status = self.doc.import(&payload).map_err(loro_error)?;
-        Ok(status.pending.is_some())
+        self.import_update(&envelope.verified_payload()?)
     }
 
     pub fn canonical_projection(&self) -> DomainResult<CanonicalProjection> {
@@ -435,6 +469,10 @@ impl Library {
             let favorite = project_scalar::<bool>(&scalars, FAVORITE)?;
             let language = project_scalar::<Option<String>>(&scalars, LANGUAGE)?;
             let saved_at = project_scalar::<i64>(&scalars, SAVED_AT)?;
+            let captured_document = project_optional_scalar::<Option<CapturedDocumentRef>>(
+                &scalars,
+                CAPTURED_DOCUMENT,
+            )?;
             let note = text_child(&item, NOTE)?.to_string();
             let tags = project_tags(map_child(&item, TAGS)?)?;
             let lifecycle = map_child(&item, LIFECYCLE)?;
@@ -449,6 +487,7 @@ impl Library {
                     favorite,
                     language,
                     saved_at,
+                    captured_document,
                     note,
                     tags,
                     lifecycle,
@@ -687,6 +726,19 @@ where
     let scalar = map_child(scalars, field)?;
     let revisions = map_child(&scalar, REVISIONS)?;
     scalar_view(read_records(&revisions)?)
+}
+
+fn project_optional_scalar<T>(
+    scalars: &LoroMap,
+    field: &str,
+) -> DomainResult<Option<ScalarView<T>>>
+where
+    T: Clone + DeserializeOwned,
+{
+    match scalars.get(field) {
+        Some(_) => project_scalar(scalars, field).map(Some),
+        None => Ok(None),
+    }
 }
 
 /// Reads the excerpt, falling back to the pre-schema-3 scalar register.

--- a/crates/research-domain/src/envelope.rs
+++ b/crates/research-domain/src/envelope.rs
@@ -6,7 +6,7 @@ use loro::VersionVector;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::{DomainError, DomainResult, identity::validate_uuid_v7};
+use crate::{DomainError, DomainResult, ITEM_AGGREGATES_FEATURE, identity::validate_uuid_v7};
 
 pub const PROTOCOL_VERSION: u8 = 1;
 pub const DOMAIN_SCHEMA_VERSION: u16 = 3;
@@ -127,7 +127,11 @@ impl UpdateEnvelope {
         if self.loro_codec != LORO_CODEC {
             return Err(DomainError::UnsupportedCodec(self.loro_codec.clone()));
         }
-        if let Some(feature) = self.required_features.first() {
+        if let Some(feature) = self
+            .required_features
+            .iter()
+            .find(|feature| feature.as_str() != ITEM_AGGREGATES_FEATURE)
+        {
             return Err(DomainError::UnsupportedFeature(feature.clone()));
         }
         let payload = STANDARD.decode(&self.payload)?;

--- a/crates/research-domain/src/lib.rs
+++ b/crates/research-domain/src/lib.rs
@@ -3,6 +3,9 @@
 //! This crate intentionally contains no storage or Git transport code. Loro
 //! resolves application conflicts; immutable envelopes only carry its updates.
 
+mod aggregate;
+mod captured;
+mod checkpoint;
 mod document;
 mod envelope;
 mod genesis;
@@ -283,3 +286,19 @@ pub fn run_wasm_convergence_scenario() -> Result<String, wasm_bindgen::JsValue> 
     run_convergence_scenario()
         .map_err(|error| wasm_bindgen::JsValue::from_str(&error.to_string()))
 }
+pub use aggregate::{
+    AGGREGATE_GENESIS_PATH, AGGREGATE_PROTOCOL_VERSION, AggregateCatalogue, AggregateEnvelope,
+    AggregateGenesis, AggregateKind, AggregateMigration, CatalogueEntry,
+    ITEM_AGGREGATES_FEATURE, ITEM_CHECKPOINTS_PREFIX, ITEM_OPS_PREFIX, ItemAggregate,
+    ItemAggregateCheckpoint, create_aggregate_migration,
+};
+pub use captured::{
+    CAPTURED_CONTENT_PREFIX, CAPTURED_MARKDOWN_MEDIA_TYPE, CapturedDocumentArtifact,
+    CapturedDocumentProvenance, CapturedDocumentRef, MAX_CAPTURED_DOCUMENT_BYTES,
+    captured_content_path, create_captured_document, validate_captured_content,
+    validate_captured_content_for_ref, validate_captured_document_ref,
+};
+pub use checkpoint::{
+    CHECKPOINTS_PREFIX, Checkpoint, CheckpointArtifact, CheckpointCoverage, CoverageInterval,
+    MAX_CHECKPOINT_BYTES, coverage_contains, create_checkpoint, validate_checkpoint,
+};

--- a/crates/research-domain/src/projection.rs
+++ b/crates/research-domain/src/projection.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{DomainError, DomainResult};
+use crate::{CapturedDocumentRef, DomainError, DomainResult};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ScalarRevision<T> {
@@ -49,6 +49,8 @@ pub struct CanonicalItem {
     pub favorite: ScalarView<bool>,
     pub language: ScalarView<Option<String>>,
     pub saved_at: ScalarView<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub captured_document: Option<ScalarView<Option<CapturedDocumentRef>>>,
     pub note: String,
     pub tags: Vec<String>,
     pub lifecycle: LifecycleView,

--- a/crates/research-domain/src/wasm.rs
+++ b/crates/research-domain/src/wasm.rs
@@ -5,10 +5,13 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    CanonicalProjection, DomainError, DomainResult, ItemSeed, Library, LibraryGenesis,
-    LifecycleState, UpdateEnvelope,
+    CanonicalItem, CanonicalProjection, CapturedDocumentRef, CheckpointCoverage, DomainError,
+    DomainResult, ItemSeed, Library, LibraryGenesis, LifecycleState, UpdateEnvelope,
+    checkpoint::{create_checkpoint, validate_checkpoint},
+    create_captured_document,
     identity::validate_uuid_v7,
     pack::{create_operation_pack, unpack_operation_pack},
+    validate_captured_content_for_ref,
 };
 
 #[derive(Serialize)]
@@ -17,7 +20,7 @@ struct BrowserProjection {
     items: Vec<BrowserItem>,
 }
 
-#[derive(Serialize)]
+#[derive(Eq, PartialEq, Serialize)]
 struct BrowserItem {
     id: String,
     url: String,
@@ -27,6 +30,8 @@ struct BrowserItem {
     favorite: bool,
     language: Option<String>,
     saved_at: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    captured_document: Option<CapturedDocumentRef>,
     tags: Vec<String>,
     state: &'static str,
 }
@@ -34,7 +39,7 @@ struct BrowserItem {
 #[derive(Serialize)]
 struct MutationResult {
     snapshot: String,
-    projection: BrowserProjection,
+    item: BrowserItem,
     /// Serialized immutable envelope, ready to persist in the browser outbox.
     envelope: String,
 }
@@ -201,6 +206,67 @@ pub fn validate_sync_genesis(genesis_json: &str) -> Result<String, JsValue> {
     Ok(genesis.library_id)
 }
 
+/// Build one immutable protocol-v1 checkpoint from a canonical snapshot.
+#[wasm_bindgen(js_name = createCheckpoint)]
+pub fn create_checkpoint_wasm(
+    snapshot_base64: &str,
+    library_id: &str,
+    created_at: &str,
+    coverage_json: &str,
+) -> Result<String, JsValue> {
+    let snapshot = STANDARD.decode(snapshot_base64).map_err(DomainError::from);
+    let coverage =
+        serde_json::from_str::<CheckpointCoverage>(coverage_json).map_err(DomainError::from);
+    let artifact = snapshot
+        .and_then(|snapshot| {
+            coverage.and_then(|coverage| {
+                create_checkpoint(&snapshot, library_id, created_at, coverage)
+            })
+        })
+        .map_err(js_error)?;
+    serde_json::to_string(&artifact).map_err(|error| js_error(error.into()))
+}
+
+/// Validate one immutable protocol-v1 checkpoint and return its restore state.
+#[wasm_bindgen(js_name = validateCheckpoint)]
+pub fn validate_checkpoint_wasm(
+    path: &str,
+    checkpoint_json: &str,
+    expected_library_id: &str,
+) -> Result<String, JsValue> {
+    let artifact =
+        validate_checkpoint(path, checkpoint_json, expected_library_id).map_err(js_error)?;
+    serde_json::to_string(&artifact).map_err(|error| js_error(error.into()))
+}
+
+/// Normalize and content-address fetched private Markdown.
+#[wasm_bindgen(js_name = createCapturedDocument)]
+pub fn create_captured_document_wasm(
+    markdown: &str,
+    provider: &str,
+    source_url: &str,
+    captured_at: &str,
+) -> Result<String, JsValue> {
+    let artifact = create_captured_document(markdown, provider, source_url, captured_at)
+        .map_err(js_error)?;
+    serde_json::to_string(&artifact).map_err(|error| js_error(error.into()))
+}
+
+/// Verify lazy-fetched Markdown against its immutable path and item reference.
+#[wasm_bindgen(js_name = validateCapturedContent)]
+pub fn validate_captured_content_wasm(
+    path: &str,
+    markdown: &str,
+    reference_json: &str,
+) -> Result<String, JsValue> {
+    let reference: CapturedDocumentRef = serde_json::from_str(reference_json)
+        .map_err(DomainError::from)
+        .map_err(js_error)?;
+    validate_captured_content_for_ref(path, markdown.as_bytes(), &reference)
+        .map_err(js_error)?;
+    Ok(markdown.to_owned())
+}
+
 /// Build one deterministic immutable operation pack from envelope JSON strings.
 #[wasm_bindgen(js_name = createOperationPack)]
 pub fn create_operation_pack_wasm(envelope_json_array: &str) -> Result<String, JsValue> {
@@ -246,6 +312,7 @@ fn apply_local_mutation(
         ));
     }
     let mutation: BrowserMutation = serde_json::from_str(mutation_json)?;
+    let mutation_item_id = browser_mutation_item_id(&mutation).to_owned();
     let library = restore(snapshot_base64, peer_id)?;
     let before = library.version();
     let before_projection = library.canonical_projection()?;
@@ -259,9 +326,15 @@ fn apply_local_mutation(
     )?;
     let envelope =
         library.export_envelope(&before, library_id, device_id, sequence_number, created_at)?;
+    let projection = library.canonical_projection()?;
+    let item = projection.items.get(&mutation_item_id).ok_or_else(|| {
+        DomainError::InvalidState(
+            "changed item is missing from the canonical projection".into(),
+        )
+    })?;
     let result = MutationResult {
         snapshot: encode_snapshot(&library)?,
-        projection: browser_projection(library.canonical_projection()?),
+        item: browser_item(mutation_item_id, item.clone()),
         envelope: serde_json::to_string(&envelope)?,
     };
     Ok(serde_json::to_string(&result)?)
@@ -307,6 +380,7 @@ fn apply_remote(
     }
 
     let library = restore(snapshot_base64, peer_id)?;
+    let before_projection = library.canonical_projection()?;
     let mut possibly_pending = Vec::new();
     for (index, (envelope, _, _)) in unique.iter().enumerate() {
         if library.import_envelope_has_pending(envelope)? {
@@ -326,9 +400,19 @@ fn apply_remote(
     }
     pending_indices.sort_unstable();
 
+    let after_projection = library.canonical_projection()?;
+    let changed = CanonicalProjection {
+        schema_version: after_projection.schema_version,
+        items: after_projection
+            .items
+            .iter()
+            .filter(|(item_id, item)| before_projection.items.get(*item_id) != Some(*item))
+            .map(|(item_id, item)| (item_id.clone(), item.clone()))
+            .collect(),
+    };
     let result = RemoteResult {
         snapshot: encode_snapshot(&library)?,
-        projection: browser_projection(library.canonical_projection()?),
+        projection: browser_projection(changed),
         pending_indices,
     };
     Ok(serde_json::to_string(&result)?)
@@ -419,6 +503,15 @@ fn apply_one_mutation(
             &item_id,
             LifecycleState::Active,
         ),
+    }
+}
+
+fn browser_mutation_item_id(mutation: &BrowserMutation) -> &str {
+    match mutation {
+        BrowserMutation::Create { item_id, .. }
+        | BrowserMutation::Edit { item_id, .. }
+        | BrowserMutation::Delete { item_id }
+        | BrowserMutation::Restore { item_id } => item_id,
     }
 }
 
@@ -553,25 +646,7 @@ fn browser_projection(projection: CanonicalProjection) -> BrowserProjection {
     let mut items = projection
         .items
         .into_iter()
-        .map(|(id, item)| {
-            let mut tags = item.tags;
-            tags.sort();
-            BrowserItem {
-                id,
-                url: item.url.value,
-                title: item.title.value,
-                excerpt: (!item.excerpt.is_empty()).then_some(item.excerpt),
-                note: (!item.note.is_empty()).then_some(item.note),
-                favorite: item.favorite.value,
-                language: item.language.value,
-                saved_at: item.saved_at.value,
-                tags,
-                state: match item.lifecycle.state {
-                    LifecycleState::Active => "active",
-                    LifecycleState::Deleted => "deleted",
-                },
-            }
-        })
+        .map(|(id, item)| browser_item(id, item))
         .collect::<Vec<_>>();
     items.sort_by(|left, right| {
         right
@@ -582,6 +657,28 @@ fn browser_projection(projection: CanonicalProjection) -> BrowserProjection {
     BrowserProjection {
         schema_version: projection.schema_version,
         items,
+    }
+}
+
+fn browser_item(id: String, item: CanonicalItem) -> BrowserItem {
+    let mut tags = item.tags;
+    tags.sort();
+    let captured_document = item.captured_document.and_then(|reference| reference.value);
+    BrowserItem {
+        id,
+        url: item.url.value,
+        title: item.title.value,
+        excerpt: (!item.excerpt.is_empty()).then_some(item.excerpt),
+        note: (!item.note.is_empty()).then_some(item.note),
+        favorite: item.favorite.value,
+        language: item.language.value,
+        saved_at: item.saved_at.value,
+        captured_document,
+        tags,
+        state: match item.lifecycle.state {
+            LifecycleState::Active => "active",
+            LifecycleState::Deleted => "deleted",
+        },
     }
 }
 

--- a/crates/research-domain/tests/scaled_checkpoint.rs
+++ b/crates/research-domain/tests/scaled_checkpoint.rs
@@ -1,0 +1,81 @@
+use std::collections::BTreeMap;
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use research_domain::{
+    CheckpointCoverage, CoverageInterval, ItemSeed, Library, create_captured_document,
+    create_checkpoint, validate_checkpoint,
+};
+
+const LIBRARY_ID: &str = "00000000-0000-7000-8000-000000000001";
+const DEVICE_ID: &str = "00000000-0000-7000-8000-000000000002";
+
+#[test]
+fn thousand_item_checkpoint_excludes_four_mib_captured_content_and_restores() {
+    let captured = create_captured_document(
+        &"x".repeat(4 * 1024 * 1024),
+        "firecrawl",
+        "https://example.com/scaled-fixture",
+        "2026-07-28T00:00:00Z",
+    )
+    .expect("captured fixture");
+    let library = Library::with_peer_id_for_fixture(91).expect("library");
+    for index in 1..=1_000_u64 {
+        let item_id = format!("01900000-0000-7000-8000-{index:012x}");
+        let prefix = format!("{DEVICE_ID}/{index:020}/fixture/{item_id}");
+        library
+            .create_item(
+                &ItemSeed {
+                    item_id: item_id.clone(),
+                    url: format!("https://example.com/items/{index}"),
+                    title: Some(format!("Fixture {index}")),
+                    excerpt: None,
+                    favorite: false,
+                    language: Some("en".into()),
+                    saved_at: 1_700_000_000 + index as i64,
+                    note: String::new(),
+                    tags: vec!["fixture".into()],
+                },
+                &prefix,
+            )
+            .expect("seed item");
+        library
+            .write_captured_document(
+                &item_id,
+                &format!("{prefix}/captured-document"),
+                Some(&captured.reference),
+            )
+            .expect("reference content");
+    }
+
+    let snapshot = library.export_snapshot().expect("snapshot");
+    let coverage = CheckpointCoverage::from([(
+        DEVICE_ID.to_owned(),
+        vec![CoverageInterval::new(1, 100).expect("coverage")],
+    )]);
+    let checkpoint = create_checkpoint(&snapshot, LIBRARY_ID, "2026-07-28T00:00:01Z", coverage)
+        .expect("checkpoint");
+    assert!(!checkpoint.json.contains(&captured.markdown));
+
+    let validated =
+        validate_checkpoint(&checkpoint.path, &checkpoint.json, LIBRARY_ID).expect("validate");
+    let restored = Library::from_snapshot(
+        &STANDARD.decode(validated.snapshot_base64).expect("decode"),
+        92,
+    )
+    .expect("restore");
+    let projection = restored.canonical_projection().expect("projection");
+    assert_eq!(projection.items.len(), 1_000);
+    assert!(projection.items.values().all(|item| {
+        item.captured_document
+            .as_ref()
+            .and_then(|view| view.value.as_ref())
+            .is_some_and(|reference| reference.sha256 == captured.reference.sha256)
+    }));
+    assert_eq!(
+        BTreeMap::from([(
+            DEVICE_ID.to_owned(),
+            vec![CoverageInterval::new(1, 100).unwrap()]
+        )]),
+        checkpoint.coverage
+    );
+}

--- a/crates/research-domain/tests/wasm_convergence.rs
+++ b/crates/research-domain/tests/wasm_convergence.rs
@@ -111,7 +111,7 @@ fn browser_snapshot_boundary_preserves_the_mutation_and_replay_contract() {
             "state": "active"
         }]
     });
-    assert_eq!(restored["projection"], expected_projection);
+    assert_eq!(restored["item"], expected_projection["items"][0]);
 
     let replica = initialize_library("42").expect("replica snapshot");
     let child_only: Value = serde_json::from_str(
@@ -141,7 +141,10 @@ fn browser_snapshot_boundary_preserves_the_mutation_and_replay_contract() {
     )
     .expect("resolved result JSON");
     assert_eq!(resolved["pending_indices"], json!([]));
-    assert_eq!(resolved["projection"], edited["projection"]);
+    assert_eq!(
+        resolved["projection"],
+        json!({"schema_version": 3, "items": [edited["item"].clone()]})
+    );
 
     let created_envelope = created["envelope"].as_str().expect("created envelope");
     let exact_duplicate: Value = serde_json::from_str(
@@ -155,7 +158,10 @@ fn browser_snapshot_boundary_preserves_the_mutation_and_replay_contract() {
     )
     .expect("exact duplicate result JSON");
     assert_eq!(exact_duplicate["pending_indices"], json!([]));
-    assert_eq!(exact_duplicate["projection"], created["projection"]);
+    assert_eq!(
+        exact_duplicate["projection"],
+        json!({"schema_version": 3, "items": [created["item"].clone()]})
+    );
 
     let mut invalid_timestamp: Value =
         serde_json::from_str(created_envelope).expect("created envelope JSON");

--- a/crates/research-store/Cargo.toml
+++ b/crates/research-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research-store"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2024"
 rust-version = "1.94"
 authors = ["KorigamiK <korigamik.is-a.dev>"]
@@ -9,8 +9,9 @@ repository = "https://github.com/ResearchPocket/researchpocket.github.io"
 description = "Local SQLite projection, import, enrichment, and outbox for ResearchPocket."
 
 [dependencies]
+base64 = "0.22.1"
 chrono = { version = "0.4.45", default-features = false, features = ["clock", "serde"] }
-research-domain = { version = "=2.0.1", path = "../research-domain" }
+research-domain = { version = "=2.1.0", path = "../research-domain" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 sha2 = "0.11.0"

--- a/crates/research-store/migrations/0006_checkpoints.sql
+++ b/crates/research-store/migrations/0006_checkpoints.sql
@@ -1,0 +1,24 @@
+CREATE TABLE checkpoints (
+    path TEXT PRIMARY KEY,
+    checkpoint_id TEXT NOT NULL UNIQUE CHECK (length(checkpoint_id) = 64),
+    checkpoint_json TEXT NOT NULL,
+    batch_count INTEGER NOT NULL CHECK (batch_count >= 0),
+    coverage_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    origin TEXT NOT NULL CHECK (origin IN ('local', 'remote')),
+    applied_at TEXT NOT NULL
+);
+
+CREATE TABLE checkpoint_coverage (
+    checkpoint_path TEXT NOT NULL REFERENCES checkpoints(path) ON DELETE CASCADE,
+    device_id TEXT NOT NULL,
+    start_sequence TEXT NOT NULL CHECK (length(start_sequence) = 20),
+    end_sequence TEXT NOT NULL CHECK (length(end_sequence) = 20),
+    PRIMARY KEY (checkpoint_path, device_id, start_sequence)
+);
+
+CREATE TABLE selected_checkpoint (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    checkpoint_path TEXT NOT NULL REFERENCES checkpoints(path),
+    selected_at TEXT NOT NULL
+);

--- a/crates/research-store/migrations/0007_captured_documents.sql
+++ b/crates/research-store/migrations/0007_captured_documents.sql
@@ -1,0 +1,14 @@
+ALTER TABLE items ADD COLUMN captured_document_json TEXT;
+
+CREATE TABLE captured_documents (
+    sha256 TEXT PRIMARY KEY CHECK (length(sha256) = 64),
+    path TEXT NOT NULL UNIQUE,
+    markdown TEXT NOT NULL,
+    byte_length INTEGER NOT NULL CHECK (byte_length > 0 AND byte_length <= 4194304),
+    media_type TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    source_url TEXT NOT NULL,
+    captured_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    remote_blob_sha TEXT
+);

--- a/crates/research-store/src/captured.rs
+++ b/crates/research-store/src/captured.rs
@@ -1,0 +1,183 @@
+use research_domain::{
+    CapturedDocumentArtifact, CapturedDocumentRef, validate_captured_content_for_ref,
+};
+use sqlx::{Row, SqliteConnection};
+
+use crate::{PendingCapturedDocument, StoreError, StoreResult, V2Store, store::now_rfc3339};
+
+impl V2Store {
+    pub async fn pending_captured_documents(
+        &self,
+    ) -> StoreResult<Vec<PendingCapturedDocument>> {
+        let rows = sqlx::query(
+            "SELECT path, sha256, markdown, byte_length, media_type, provider, source_url, \
+             captured_at FROM captured_documents \
+             WHERE remote_blob_sha IS NULL ORDER BY sha256 ASC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|row| {
+                let byte_length: i64 = row.try_get("byte_length")?;
+                Ok(PendingCapturedDocument {
+                    path: row.try_get("path")?,
+                    sha256: row.try_get("sha256")?,
+                    markdown: row.try_get("markdown")?,
+                    reference: CapturedDocumentRef {
+                        sha256: row.try_get("sha256")?,
+                        byte_length: u64::try_from(byte_length).map_err(|_| {
+                            StoreError::NumericRange("captured document byte length")
+                        })?,
+                        media_type: row.try_get("media_type")?,
+                        provenance: research_domain::CapturedDocumentProvenance {
+                            provider: row.try_get("provider")?,
+                            source_url: row.try_get("source_url")?,
+                            captured_at: row.try_get("captured_at")?,
+                        },
+                    },
+                })
+            })
+            .collect()
+    }
+
+    pub async fn confirm_captured_document(
+        &self,
+        reference: &CapturedDocumentRef,
+        path: &str,
+        blob_sha: &str,
+        bytes: &[u8],
+    ) -> StoreResult<()> {
+        validate_blob_sha(blob_sha)?;
+        validate_captured_content_for_ref(path, bytes, reference)?;
+        let markdown = std::str::from_utf8(bytes)
+            .map_err(|_| StoreError::SyncIntegrity("captured document is not UTF-8".into()))?;
+        let mut connection = self.pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *connection)
+            .await?;
+        let result = async {
+            let existing = sqlx::query(
+                "SELECT markdown, remote_blob_sha FROM captured_documents WHERE sha256 = ?",
+            )
+            .bind(&reference.sha256)
+            .fetch_optional(&mut *connection)
+            .await?;
+            if let Some(existing) = existing {
+                let stored: String = existing.try_get("markdown")?;
+                if stored.as_bytes() != bytes {
+                    return Err(StoreError::SyncIntegrity(
+                        "captured document identity collision".into(),
+                    ));
+                }
+                let observed: Option<String> = existing.try_get("remote_blob_sha")?;
+                if observed
+                    .as_deref()
+                    .is_some_and(|observed| observed != blob_sha)
+                {
+                    return Err(StoreError::SyncIntegrity(
+                        "immutable captured content changed Git identity".into(),
+                    ));
+                }
+            } else {
+                persist_reference_and_markdown(&mut connection, reference, path, markdown)
+                    .await?;
+            }
+            sqlx::query("UPDATE captured_documents SET remote_blob_sha = ? WHERE sha256 = ?")
+                .bind(blob_sha)
+                .bind(&reference.sha256)
+                .execute(&mut *connection)
+                .await?;
+            Ok(())
+        }
+        .await;
+        match result {
+            Ok(()) => {
+                sqlx::query("COMMIT").execute(&mut *connection).await?;
+                Ok(())
+            }
+            Err(error) => {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *connection).await;
+                Err(error)
+            }
+        }
+    }
+
+    pub async fn captured_document_markdown(
+        &self,
+        sha256: &str,
+    ) -> StoreResult<Option<String>> {
+        Ok(
+            sqlx::query_scalar("SELECT markdown FROM captured_documents WHERE sha256 = ?")
+                .bind(sha256)
+                .fetch_optional(&self.pool)
+                .await?,
+        )
+    }
+}
+
+pub(crate) async fn persist_captured_document(
+    connection: &mut SqliteConnection,
+    artifact: &CapturedDocumentArtifact,
+) -> StoreResult<()> {
+    if let Some(existing) = sqlx::query_scalar::<_, String>(
+        "SELECT markdown FROM captured_documents WHERE sha256 = ?",
+    )
+    .bind(&artifact.reference.sha256)
+    .fetch_optional(&mut *connection)
+    .await?
+    {
+        if existing.as_bytes() != artifact.markdown.as_bytes() {
+            return Err(StoreError::SyncIntegrity(
+                "captured document identity collision".into(),
+            ));
+        }
+        return Ok(());
+    }
+    persist_reference_and_markdown(
+        connection,
+        &artifact.reference,
+        &artifact.path,
+        &artifact.markdown,
+    )
+    .await
+}
+
+async fn persist_reference_and_markdown(
+    connection: &mut SqliteConnection,
+    reference: &CapturedDocumentRef,
+    path: &str,
+    markdown: &str,
+) -> StoreResult<()> {
+    let byte_length = i64::try_from(reference.byte_length)
+        .map_err(|_| StoreError::NumericRange("captured document byte length"))?;
+    sqlx::query(
+        "INSERT INTO captured_documents \
+         (sha256, path, markdown, byte_length, media_type, provider, source_url, captured_at, \
+          created_at, remote_blob_sha) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)",
+    )
+    .bind(&reference.sha256)
+    .bind(path)
+    .bind(markdown)
+    .bind(byte_length)
+    .bind(&reference.media_type)
+    .bind(&reference.provenance.provider)
+    .bind(&reference.provenance.source_url)
+    .bind(&reference.provenance.captured_at)
+    .bind(now_rfc3339())
+    .execute(&mut *connection)
+    .await?;
+    Ok(())
+}
+
+fn validate_blob_sha(value: &str) -> StoreResult<()> {
+    if !matches!(value.len(), 40 | 64)
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(StoreError::SyncIntegrity(
+            "remote Git object identity is invalid".into(),
+        ));
+    }
+    Ok(())
+}

--- a/crates/research-store/src/enrichment.rs
+++ b/crates/research-store/src/enrichment.rs
@@ -1,10 +1,11 @@
 use chrono::{DateTime, Duration, SecondsFormat, Utc};
-use research_domain::{CanonicalItem, Library, LifecycleState};
+use research_domain::{CanonicalItem, Library, LifecycleState, create_captured_document};
 use sqlx::{FromRow, Row, SqliteConnection};
 use uuid::Uuid;
 
+use crate::captured::persist_captured_document;
 use crate::mutation::apply_item_mutation;
-use crate::store::{fresh_peer_id, now_rfc3339, sha256_hex};
+use crate::store::{now_rfc3339, peer_id_for_device, sha256_hex};
 use crate::{
     EnrichmentApplyResult, EnrichmentCandidates, EnrichmentClaim, EnrichmentJob,
     EnrichmentProvider, EnrichmentQueueCounts, EnrichmentStatus, StoreError, StoreResult,
@@ -248,7 +249,8 @@ async fn queue_enrichment_on_connection_with_options(
     let targets = EnrichmentTargets {
         title_revision: (item.title.value.is_none() && item.title.revisions.len() == 1)
             .then(|| item.title.winner.clone()),
-        excerpt_text: (replace_excerpt
+        excerpt_text: (provider == EnrichmentProvider::Firecrawl
+            || replace_excerpt
             || item.excerpt.is_empty()
             || applied_excerpt.as_deref() == Some(item.excerpt.as_str()))
         .then(|| item.excerpt.clone()),
@@ -325,16 +327,32 @@ async fn apply_enrichment_on_connection(
             && current_job.expected_title_revision.as_deref()
                 == Some(current_item.title.winner.as_str())
     });
-    let excerpt = candidate(candidates.excerpt).filter(|_| {
+    let fetched_context = candidate(candidates.excerpt).filter(|_| {
         current_job.expected_excerpt_text.as_deref() == Some(current_item.excerpt.as_str())
     });
+    let (excerpt, captured_document) = if current_job.job.provider
+        == EnrichmentProvider::Firecrawl
+    {
+        let artifact = fetched_context
+            .as_deref()
+            .map(|markdown| {
+                create_captured_document(markdown, "firecrawl", expected_url, &now_rfc3339())
+            })
+            .transpose()?;
+        (None, artifact)
+    } else {
+        (fetched_context, None)
+    };
+    if let Some(artifact) = &captured_document {
+        persist_captured_document(connection, artifact).await?;
+    }
     let language = candidate(candidates.language).filter(|_| {
         current_item.language.value.is_none()
             && current_job.expected_language_revision.as_deref()
                 == Some(current_item.language.winner.as_str())
     });
     let applied_title = title.is_some();
-    let applied_excerpt = excerpt.is_some();
+    let applied_excerpt = excerpt.is_some() || captured_document.is_some();
     // Remembered so a later re-queue can tell this excerpt came from a provider.
     let applied_excerpt_text = excerpt.clone();
     let applied_language = language.is_some();
@@ -345,6 +363,9 @@ async fn apply_enrichment_on_connection(
         let expected_title_revision = current_job.expected_title_revision.clone();
         let expected_excerpt_text = current_job.expected_excerpt_text.clone();
         let expected_language_revision = current_job.expected_language_revision.clone();
+        let captured_reference = captured_document
+            .as_ref()
+            .map(|artifact| artifact.reference.clone());
         apply_item_mutation(connection, item_id, move |library, projection, prefix| {
             let item = projection
                 .items
@@ -367,6 +388,13 @@ async fn apply_enrichment_on_connection(
                     return Err(StoreError::StaleEdit);
                 }
                 library.set_excerpt(&mutation_item_id, &item.excerpt, excerpt)?;
+            }
+            if let Some(reference) = &captured_reference {
+                library.write_captured_document(
+                    &mutation_item_id,
+                    &enrichment_revision_id(prefix, "captured-document"),
+                    Some(reference),
+                )?;
             }
             if let Some(language) = &language {
                 if item.language.value.is_some()
@@ -482,7 +510,8 @@ async fn stored_item_from_connection(
     item_id: &str,
 ) -> StoreResult<StoredItem> {
     let row = sqlx::query(
-        "SELECT url, title, excerpt, favorite, language, saved_at, note, lifecycle_state \
+        "SELECT url, title, excerpt, favorite, language, saved_at, note, lifecycle_state, \
+         captured_document_json \
          FROM items WHERE item_id = ?",
     )
     .bind(item_id)
@@ -509,6 +538,10 @@ async fn stored_item_from_connection(
         favorite: row.try_get("favorite")?,
         language: row.try_get("language")?,
         saved_at,
+        captured_document: row
+            .try_get::<Option<String>, _>("captured_document_json")?
+            .map(|json| serde_json::from_str(&json))
+            .transpose()?,
         tags,
         state: row.try_get("lifecycle_state")?,
     })
@@ -624,7 +657,11 @@ async fn canonical_item_from_connection(
             "canonical snapshot checksum mismatch".into(),
         ));
     }
-    Library::from_snapshot(&snapshot, fresh_peer_id())?
+    let device_id: String =
+        sqlx::query_scalar("SELECT value FROM store_meta WHERE key = 'device_id'")
+            .fetch_one(&mut *connection)
+            .await?;
+    Library::from_snapshot(&snapshot, peer_id_for_device(&device_id)?)?
         .canonical_projection()?
         .items
         .get(item_id)

--- a/crates/research-store/src/import.rs
+++ b/crates/research-store/src/import.rs
@@ -14,7 +14,7 @@ use sqlx::{Connection, Row, SqliteConnection};
 use tempfile::TempDir;
 use uuid::Uuid;
 
-use crate::store::{fresh_peer_id, now_rfc3339, sha256_hex};
+use crate::store::{now_rfc3339, peer_id_for_device, sha256_hex};
 use crate::{
     ImportRejection, ImportResult, SourceBundleReceipt, SourceFileReceipt, StoreError,
     StoreResult, V2Store,
@@ -555,7 +555,7 @@ async fn commit_import(
             "canonical snapshot checksum mismatch".into(),
         ));
     }
-    let library = Library::from_snapshot(&snapshot, fresh_peer_id())?;
+    let library = Library::from_snapshot(&snapshot, peer_id_for_device(&device_id)?)?;
     let before = library.version();
 
     let mut imported = 0_u64;
@@ -769,17 +769,24 @@ pub(crate) async fn persist_item_projection(
     };
     let lifecycle_generation = i64::try_from(item.lifecycle.generation)
         .map_err(|_| StoreError::NumericRange("lifecycle generation"))?;
+    let captured_document = item
+        .captured_document
+        .as_ref()
+        .and_then(|reference| reference.value.as_ref())
+        .map(serde_json::to_string)
+        .transpose()?;
     sqlx::query(
         "INSERT INTO items \
          (item_id, url, title, excerpt, favorite, language, saved_at, note, \
-          lifecycle_state, lifecycle_generation) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+          lifecycle_state, lifecycle_generation, captured_document_json) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
          ON CONFLICT(item_id) DO UPDATE SET \
          url = excluded.url, title = excluded.title, excerpt = excluded.excerpt, \
          favorite = excluded.favorite, language = excluded.language, \
          saved_at = excluded.saved_at, note = excluded.note, \
          lifecycle_state = excluded.lifecycle_state, \
-         lifecycle_generation = excluded.lifecycle_generation",
+         lifecycle_generation = excluded.lifecycle_generation, \
+         captured_document_json = excluded.captured_document_json",
     )
     .bind(item_id)
     .bind(&item.url.value)
@@ -791,6 +798,7 @@ pub(crate) async fn persist_item_projection(
     .bind(&item.note)
     .bind(lifecycle_state)
     .bind(lifecycle_generation)
+    .bind(captured_document)
     .execute(&mut *connection)
     .await?;
     sqlx::query("DELETE FROM item_tags WHERE item_id = ?")

--- a/crates/research-store/src/lib.rs
+++ b/crates/research-store/src/lib.rs
@@ -1,5 +1,6 @@
 //! Durable, local-only persistence for a V2 ResearchPocket library.
 
+mod captured;
 mod enrichment;
 mod error;
 mod import;
@@ -14,8 +15,9 @@ pub use model::{
     CreateItemRequest, EditItemRequest, EnrichmentApplyResult, EnrichmentCandidates,
     EnrichmentClaim, EnrichmentJob, EnrichmentProvider, EnrichmentQueueCounts,
     EnrichmentStatus, ImportRejection, ImportResult, ListPage, ListQuery, ListResult,
-    OptionalTextUpdate, PendingBatch, RemoteBatchDisposition, RemoteBatchResult,
-    RemotePackResult, SearchQuery, SearchResult, SourceBundleReceipt, SourceFileReceipt,
-    StoreStatus, StoredItem, SyncConfiguration, SyncIdentity,
+    OptionalTextUpdate, PendingBatch, PendingCapturedDocument, PendingCheckpoint,
+    RemoteBatchDisposition, RemoteBatchResult, RemoteCheckpointResult, RemotePackResult,
+    SearchQuery, SearchResult, SourceBundleReceipt, SourceFileReceipt, StoreStatus, StoredItem,
+    SyncConfiguration, SyncIdentity,
 };
 pub use store::V2Store;

--- a/crates/research-store/src/model.rs
+++ b/crates/research-store/src/model.rs
@@ -1,3 +1,4 @@
+use research_domain::CapturedDocumentRef;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default)]
@@ -70,6 +71,8 @@ pub struct StoredItem {
     pub favorite: bool,
     pub language: Option<String>,
     pub saved_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub captured_document: Option<CapturedDocumentRef>,
     pub tags: Vec<String>,
     pub state: String,
 }
@@ -212,6 +215,28 @@ pub struct PendingBatch {
     pub payload_sha256: String,
     pub envelope_json: String,
     pub attempts: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingCheckpoint {
+    pub path: String,
+    pub checkpoint_id: String,
+    pub checkpoint_json: String,
+    pub batch_count: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingCapturedDocument {
+    pub path: String,
+    pub sha256: String,
+    pub markdown: String,
+    pub reference: CapturedDocumentRef,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RemoteCheckpointResult {
+    pub batch_count: u64,
+    pub restored: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/research-store/src/mutation.rs
+++ b/crates/research-store/src/mutation.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use crate::enrichment::queue_enrichment_on_connection;
 use crate::import::persist_item_projection;
-use crate::store::{fresh_peer_id, now_rfc3339, sha256_hex};
+use crate::store::{now_rfc3339, peer_id_for_device, sha256_hex};
 use crate::{
     CreateItemRequest, EditItemRequest, EnrichmentProvider, OptionalTextUpdate, StoreError,
     StoreResult, StoredItem, V2Store,
@@ -266,7 +266,7 @@ where
         ));
     }
 
-    let library = Library::from_snapshot(&snapshot, fresh_peer_id())?;
+    let library = Library::from_snapshot(&snapshot, peer_id_for_device(&device_id)?)?;
     let before = library.version();
     let before_projection = library.canonical_projection()?;
     let prefix = format!("{device_id}/{sequence_text}/mutation/{item_id}");
@@ -361,6 +361,10 @@ fn stored_item(
         favorite: item.favorite.value,
         language: item.language.value.clone(),
         saved_at,
+        captured_document: item
+            .captured_document
+            .as_ref()
+            .and_then(|reference| reference.value.clone()),
         tags: item.tags.clone(),
         state: state.to_owned(),
     })

--- a/crates/research-store/src/store.rs
+++ b/crates/research-store/src/store.rs
@@ -116,7 +116,7 @@ impl V2Store {
     pub async fn item(&self, item_id: &str) -> StoreResult<StoredItem> {
         let row = sqlx::query_as::<_, ItemRow>(
             "SELECT item_id, url, title, excerpt, favorite, language, saved_at, note, \
-             lifecycle_state FROM items WHERE item_id = ?",
+             lifecycle_state, captured_document_json FROM items WHERE item_id = ?",
         )
         .bind(item_id)
         .fetch_optional(&self.pool)
@@ -141,7 +141,8 @@ impl V2Store {
 
         let mut builder = QueryBuilder::<Sqlite>::new(
             "SELECT i.item_id, i.url, i.title, i.excerpt, i.favorite, i.language, \
-             i.saved_at, i.note, i.lifecycle_state FROM items i WHERE 1 = 1",
+             i.saved_at, i.note, i.lifecycle_state, i.captured_document_json \
+             FROM items i WHERE 1 = 1",
         );
         append_list_filters(&mut builder, &query);
         builder
@@ -203,7 +204,7 @@ impl V2Store {
 
         let mut builder = QueryBuilder::<Sqlite>::new(
             "SELECT i.item_id, i.url, i.title, i.excerpt, i.favorite, i.language, \
-             i.saved_at, i.note, i.lifecycle_state \
+             i.saved_at, i.note, i.lifecycle_state, i.captured_document_json \
              FROM item_search JOIN items i ON i.item_id = item_search.item_id \
              WHERE item_search MATCH ",
         );
@@ -322,7 +323,8 @@ impl V2Store {
                 "canonical snapshot checksum mismatch".into(),
             ));
         }
-        Library::from_snapshot(&snapshot, fresh_peer_id())?;
+        let device_id = self.meta("device_id").await?;
+        Library::from_snapshot(&snapshot, peer_id_for_device(&device_id)?)?;
         Ok(())
     }
 
@@ -357,6 +359,10 @@ impl V2Store {
                 favorite: row.favorite,
                 language: row.language,
                 saved_at,
+                captured_document: row
+                    .captured_document_json
+                    .map(|json| serde_json::from_str(&json))
+                    .transpose()?,
                 tags,
                 state: row.lifecycle_state,
             });
@@ -376,6 +382,7 @@ struct ItemRow {
     saved_at: i64,
     note: String,
     lifecycle_state: String,
+    captured_document_json: Option<String>,
 }
 
 fn append_list_filters(builder: &mut QueryBuilder<Sqlite>, query: &ListQuery) {
@@ -459,11 +466,22 @@ pub(crate) fn now_rfc3339() -> String {
     Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
 }
 
-pub(crate) fn fresh_peer_id() -> u64 {
-    let uuid = Uuid::now_v7();
+/// Derive the durable Loro replica identity from this installation's device UUID.
+///
+/// The device UUID is already persistent and unique. Reusing its random low
+/// bits keeps a native replica on one Loro peer across snapshot restores instead
+/// of widening every causal frontier by one peer per mutation.
+pub(crate) fn peer_id_for_device(device_id: &str) -> StoreResult<u64> {
+    let uuid = Uuid::parse_str(device_id)
+        .map_err(|_| StoreError::InvalidStore("device ID is not a UUID".into()))?;
     let mut bytes = [0_u8; 8];
     bytes.copy_from_slice(&uuid.as_bytes()[8..]);
-    u64::from_be_bytes(bytes).max(1)
+    let peer_id = u64::from_be_bytes(bytes);
+    Ok(match peer_id {
+        0 => 1,
+        u64::MAX => u64::MAX - 1,
+        value => value,
+    })
 }
 
 pub(crate) fn sha256_hex(bytes: &[u8]) -> String {

--- a/crates/research-store/src/sync.rs
+++ b/crates/research-store/src/sync.rs
@@ -1,13 +1,24 @@
+use std::collections::BTreeMap;
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use chrono::{DateTime, FixedOffset};
-use research_domain::{Library, LibraryGenesis, UpdateEnvelope, unpack_operation_pack};
+use research_domain::{
+    CheckpointArtifact, CheckpointCoverage, CoverageInterval, Library, LibraryGenesis,
+    UpdateEnvelope, coverage_contains, create_checkpoint, unpack_operation_pack,
+    validate_checkpoint,
+};
 use sqlx::{Row, SqliteConnection};
 
-use crate::import::persist_projection;
-use crate::store::{fresh_peer_id, now_rfc3339, sha256_hex};
+use crate::import::{persist_item_projection, persist_projection};
+use crate::store::{now_rfc3339, peer_id_for_device, sha256_hex};
 use crate::{
-    PendingBatch, RemoteBatchDisposition, RemoteBatchResult, RemotePackResult, StoreError,
-    StoreResult, SyncConfiguration, SyncIdentity, V2Store,
+    PendingBatch, PendingCheckpoint, RemoteBatchDisposition, RemoteBatchResult,
+    RemoteCheckpointResult, RemotePackResult, StoreError, StoreResult, SyncConfiguration,
+    SyncIdentity, V2Store,
 };
+
+pub const CHECKPOINT_BATCH_THRESHOLD: u64 = 100;
+pub const CHECKPOINT_PAYLOAD_THRESHOLD: u64 = 2 * 1024 * 1024;
 
 impl V2Store {
     pub async fn sync_identity(&self) -> StoreResult<SyncIdentity> {
@@ -136,6 +147,113 @@ impl V2Store {
             .collect()
     }
 
+    pub async fn checkpoint_candidate(
+        &self,
+        force: bool,
+    ) -> StoreResult<Option<PendingCheckpoint>> {
+        let mut connection = self.pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *connection)
+            .await?;
+        let result = build_checkpoint_candidate(&mut connection, force).await;
+        match result {
+            Ok(candidate) => {
+                sqlx::query("COMMIT").execute(&mut *connection).await?;
+                Ok(candidate)
+            }
+            Err(error) => {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *connection).await;
+                Err(error)
+            }
+        }
+    }
+
+    pub async fn receive_remote_checkpoint(
+        &self,
+        path: &str,
+        blob_sha: &str,
+        bytes: &[u8],
+    ) -> StoreResult<RemoteCheckpointResult> {
+        validate_blob_sha(blob_sha)?;
+        let checkpoint_json = std::str::from_utf8(bytes)
+            .map_err(|_| StoreError::SyncIntegrity(format!("{path} is not UTF-8 JSON")))?;
+        let library_id = self.meta("library_id").await?;
+        let artifact = validate_checkpoint(path, checkpoint_json, &library_id)?;
+        let local_device_id = self.meta("device_id").await?;
+        let peer_id = peer_id_for_device(&local_device_id)?;
+        let snapshot = STANDARD.decode(&artifact.snapshot_base64).map_err(|_| {
+            StoreError::SyncIntegrity("checkpoint payload is not Base64".into())
+        })?;
+
+        let mut connection = self.pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *connection)
+            .await?;
+        let result = async {
+            let state = sqlx::query(
+                "SELECT snapshot_sha256 FROM canonical_state WHERE singleton = 1",
+            )
+            .fetch_one(&mut *connection)
+            .await?;
+            let current_snapshot_sha256: String = state.try_get("snapshot_sha256")?;
+            let pristine = store_is_pristine(&mut connection).await?;
+            let restored = if pristine {
+                let library = Library::from_snapshot(&snapshot, peer_id)?;
+                let projection = library.canonical_projection()?;
+                sqlx::query("DELETE FROM item_tags")
+                    .execute(&mut *connection)
+                    .await?;
+                sqlx::query("DELETE FROM item_search")
+                    .execute(&mut *connection)
+                    .await?;
+                sqlx::query("DELETE FROM items")
+                    .execute(&mut *connection)
+                    .await?;
+                persist_projection(&mut connection, &projection).await?;
+                sqlx::query(
+                    "UPDATE canonical_state SET snapshot = ?, snapshot_sha256 = ?, updated_at = ? \
+                     WHERE singleton = 1",
+                )
+                .bind(&snapshot)
+                .bind(&artifact.checkpoint_id)
+                .bind(now_rfc3339())
+                .execute(&mut *connection)
+                .await?;
+                true
+            } else {
+                current_snapshot_sha256 == artifact.checkpoint_id
+            };
+            persist_checkpoint(&mut connection, &artifact, "remote").await?;
+            if restored {
+                select_checkpoint(&mut connection, &artifact).await?;
+            }
+            observe_remote(&mut connection, path, blob_sha).await?;
+            Ok(RemoteCheckpointResult {
+                batch_count: artifact.batch_count,
+                restored,
+            })
+        }
+        .await;
+        match result {
+            Ok(result) => {
+                sqlx::query("COMMIT").execute(&mut *connection).await?;
+                Ok(result)
+            }
+            Err(error) => {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *connection).await;
+                Err(error)
+            }
+        }
+    }
+
+    pub async fn batch_is_checkpoint_covered(
+        &self,
+        device_id: &str,
+        sequence: &str,
+    ) -> StoreResult<bool> {
+        checkpoint_covers(&self.pool, device_id, sequence).await
+    }
+
     pub async fn remote_blob_is_current(
         &self,
         path: &str,
@@ -191,6 +309,8 @@ impl V2Store {
             .map_err(|_| StoreError::SyncIntegrity(format!("{path} is not UTF-8 JSON")))?;
         let envelope: UpdateEnvelope = serde_json::from_slice(bytes)?;
         let library_id = self.meta("library_id").await?;
+        let local_device_id = self.meta("device_id").await?;
+        let peer_id = peer_id_for_device(&local_device_id)?;
         envelope.validate_identity(&library_id, path)?;
         validate_timestamp(&envelope.created_at, "operation creation time")?;
 
@@ -200,7 +320,8 @@ impl V2Store {
             .await?;
         let result = async {
             let result =
-                apply_remote_batch(&mut connection, path, envelope_json, &envelope).await?;
+                apply_remote_batch(&mut connection, path, envelope_json, &envelope, peer_id)
+                    .await?;
             observe_remote(&mut connection, path, blob_sha).await?;
             Ok(result)
         }
@@ -228,6 +349,8 @@ impl V2Store {
             .map_err(|_| StoreError::SyncIntegrity(format!("{path} is not UTF-8 JSON")))?;
         let artifact = unpack_operation_pack(path, pack_json)?;
         let expected_library_id = self.meta("library_id").await?;
+        let local_device_id = self.meta("device_id").await?;
+        let peer_id = peer_id_for_device(&local_device_id)?;
         let mut members = Vec::with_capacity(artifact.member_envelopes.len());
         for envelope_json in artifact.member_envelopes {
             let envelope: UpdateEnvelope = serde_json::from_str(&envelope_json)?;
@@ -246,9 +369,14 @@ impl V2Store {
             let mut already_applied = 0_u64;
             let mut acknowledged_outbox = 0_u64;
             for (member_path, envelope_json, envelope) in &members {
-                let member =
-                    apply_remote_batch(&mut connection, member_path, envelope_json, envelope)
-                        .await?;
+                let member = apply_remote_batch(
+                    &mut connection,
+                    member_path,
+                    envelope_json,
+                    envelope,
+                    peer_id,
+                )
+                .await?;
                 match member.disposition {
                     RemoteBatchDisposition::Applied => applied += 1,
                     RemoteBatchDisposition::AlreadyApplied => already_applied += 1,
@@ -417,6 +545,7 @@ async fn apply_remote_batch(
     path: &str,
     envelope_json: &str,
     envelope: &UpdateEnvelope,
+    peer_id: u64,
 ) -> StoreResult<RemoteBatchResult> {
     let existing = sqlx::query(
         "SELECT envelope_json, payload_sha256 FROM batches \
@@ -442,6 +571,12 @@ async fn apply_remote_batch(
             acknowledged_outbox,
         });
     }
+    if checkpoint_covers(&mut *connection, &envelope.device_id, &envelope.sequence).await? {
+        return Ok(RemoteBatchResult {
+            disposition: RemoteBatchDisposition::AlreadyApplied,
+            acknowledged_outbox: false,
+        });
+    }
 
     let state = sqlx::query(
         "SELECT snapshot, snapshot_sha256 FROM canonical_state WHERE singleton = 1",
@@ -455,7 +590,8 @@ async fn apply_remote_batch(
             "canonical snapshot checksum mismatch".into(),
         ));
     }
-    let library = Library::from_snapshot(&snapshot, fresh_peer_id())?;
+    let library = Library::from_snapshot(&snapshot, peer_id)?;
+    let before_projection = library.canonical_projection()?;
     let incoming_pending = library.import_envelope_has_pending(envelope)?;
     // A Loro snapshot does not retain an update whose causal predecessor was
     // absent when that snapshot was exported. Receipted immutable envelopes do
@@ -484,7 +620,11 @@ async fn apply_remote_batch(
     let new_snapshot = library.export_snapshot()?;
     let projection = library.canonical_projection()?;
     let now = now_rfc3339();
-    persist_projection(connection, &projection).await?;
+    for (item_id, item) in &projection.items {
+        if before_projection.items.get(item_id) != Some(item) {
+            persist_item_projection(connection, item_id, item).await?;
+        }
+    }
     sqlx::query(
         "UPDATE canonical_state SET snapshot = ?, snapshot_sha256 = ?, updated_at = ? \
          WHERE singleton = 1",
@@ -521,6 +661,286 @@ async fn apply_remote_batch(
         disposition: RemoteBatchDisposition::Applied,
         acknowledged_outbox: false,
     })
+}
+
+async fn build_checkpoint_candidate(
+    connection: &mut SqliteConnection,
+    force: bool,
+) -> StoreResult<Option<PendingCheckpoint>> {
+    if sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM deferred_batches")
+        .fetch_one(&mut *connection)
+        .await?
+        != 0
+    {
+        return Ok(None);
+    }
+    let selected_coverage = selected_coverage(&mut *connection).await?;
+    let rows = sqlx::query(
+        "SELECT device_id, sequence, envelope_json, applied_at FROM batches \
+         ORDER BY device_id ASC, sequence ASC",
+    )
+    .fetch_all(&mut *connection)
+    .await?;
+    let mut intervals = selected_coverage
+        .iter()
+        .flat_map(|(device_id, ranges)| {
+            ranges.iter().map(|range| {
+                (
+                    device_id.clone(),
+                    parse_sequence(&range.start).expect("validated checkpoint sequence"),
+                    parse_sequence(&range.end).expect("validated checkpoint sequence"),
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    let mut tail_batches = 0_u64;
+    let mut tail_payload_bytes = 0_u64;
+    let mut created_at = selected_checkpoint_created_at(&mut *connection).await?;
+    for row in rows {
+        let device_id: String = row.try_get("device_id")?;
+        let sequence: String = row.try_get("sequence")?;
+        let sequence_number = parse_sequence(&sequence)?;
+        intervals.push((device_id.clone(), sequence_number, sequence_number));
+        let envelope_json: String = row.try_get("envelope_json")?;
+        let envelope: UpdateEnvelope = serde_json::from_str(&envelope_json)?;
+        created_at = Some(match created_at {
+            Some(current) if current >= envelope.created_at => current,
+            _ => envelope.created_at.clone(),
+        });
+        if !coverage_contains(&selected_coverage, &device_id, &sequence) {
+            tail_batches = tail_batches
+                .checked_add(1)
+                .ok_or(StoreError::NumericRange("checkpoint tail batch count"))?;
+            tail_payload_bytes = tail_payload_bytes
+                .checked_add(decoded_base64_len(&envelope.payload)?)
+                .ok_or(StoreError::NumericRange("checkpoint tail payload bytes"))?;
+        }
+    }
+    if !force
+        && tail_batches < CHECKPOINT_BATCH_THRESHOLD
+        && tail_payload_bytes < CHECKPOINT_PAYLOAD_THRESHOLD
+    {
+        return Ok(None);
+    }
+    if intervals.is_empty() {
+        return Ok(None);
+    }
+
+    let coverage = merge_coverage(intervals)?;
+    let state = sqlx::query(
+        "SELECT snapshot, snapshot_sha256 FROM canonical_state WHERE singleton = 1",
+    )
+    .fetch_one(&mut *connection)
+    .await?;
+    let snapshot: Vec<u8> = state.try_get("snapshot")?;
+    let expected_snapshot_sha256: String = state.try_get("snapshot_sha256")?;
+    if sha256_hex(&snapshot) != expected_snapshot_sha256 {
+        return Err(StoreError::InvalidStore(
+            "canonical snapshot checksum mismatch".into(),
+        ));
+    }
+    let library_id: String =
+        sqlx::query_scalar("SELECT value FROM store_meta WHERE key = 'library_id'")
+            .fetch_one(&mut *connection)
+            .await?;
+    let artifact = create_checkpoint(
+        &snapshot,
+        &library_id,
+        created_at.as_deref().unwrap_or("1970-01-01T00:00:00Z"),
+        coverage,
+    )?;
+    persist_checkpoint(&mut *connection, &artifact, "local").await?;
+    Ok(Some(PendingCheckpoint {
+        path: artifact.path,
+        checkpoint_id: artifact.checkpoint_id,
+        checkpoint_json: artifact.json,
+        batch_count: artifact.batch_count,
+    }))
+}
+
+async fn persist_checkpoint(
+    connection: &mut SqliteConnection,
+    artifact: &CheckpointArtifact,
+    origin: &str,
+) -> StoreResult<()> {
+    let coverage_json = serde_json::to_string(&artifact.coverage)?;
+    sqlx::query(
+        "INSERT INTO checkpoints \
+         (path, checkpoint_id, checkpoint_json, batch_count, coverage_json, created_at, \
+          origin, applied_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?) \
+         ON CONFLICT(path) DO NOTHING",
+    )
+    .bind(&artifact.path)
+    .bind(&artifact.checkpoint_id)
+    .bind(&artifact.json)
+    .bind(
+        i64::try_from(artifact.batch_count)
+            .map_err(|_| StoreError::NumericRange("checkpoint batch count"))?,
+    )
+    .bind(&coverage_json)
+    .bind(&artifact.created_at)
+    .bind(origin)
+    .bind(now_rfc3339())
+    .execute(&mut *connection)
+    .await?;
+    let stored: String =
+        sqlx::query_scalar("SELECT checkpoint_json FROM checkpoints WHERE path = ?")
+            .bind(&artifact.path)
+            .fetch_one(&mut *connection)
+            .await?;
+    if stored.as_bytes() != artifact.json.as_bytes() {
+        return Err(StoreError::SyncIntegrity(
+            "checkpoint identity collision".into(),
+        ));
+    }
+    for (device_id, intervals) in &artifact.coverage {
+        for interval in intervals {
+            sqlx::query(
+                "INSERT OR IGNORE INTO checkpoint_coverage \
+                 (checkpoint_path, device_id, start_sequence, end_sequence) \
+                 VALUES (?, ?, ?, ?)",
+            )
+            .bind(&artifact.path)
+            .bind(device_id)
+            .bind(&interval.start)
+            .bind(&interval.end)
+            .execute(&mut *connection)
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+async fn select_checkpoint(
+    connection: &mut SqliteConnection,
+    artifact: &CheckpointArtifact,
+) -> StoreResult<()> {
+    let selected_count: Option<i64> = sqlx::query_scalar(
+        "SELECT c.batch_count FROM selected_checkpoint s \
+         JOIN checkpoints c ON c.path = s.checkpoint_path WHERE s.singleton = 1",
+    )
+    .fetch_optional(&mut *connection)
+    .await?;
+    if selected_count.is_some_and(|count| count > artifact.batch_count as i64) {
+        return Ok(());
+    }
+    sqlx::query(
+        "INSERT INTO selected_checkpoint (singleton, checkpoint_path, selected_at) \
+         VALUES (1, ?, ?) ON CONFLICT(singleton) DO UPDATE SET \
+         checkpoint_path = excluded.checkpoint_path, selected_at = excluded.selected_at",
+    )
+    .bind(&artifact.path)
+    .bind(now_rfc3339())
+    .execute(&mut *connection)
+    .await?;
+    Ok(())
+}
+
+async fn selected_coverage(
+    connection: &mut SqliteConnection,
+) -> StoreResult<CheckpointCoverage> {
+    let rows = sqlx::query(
+        "SELECT cc.device_id, cc.start_sequence, cc.end_sequence \
+         FROM checkpoint_coverage cc JOIN selected_checkpoint s \
+         ON s.checkpoint_path = cc.checkpoint_path WHERE s.singleton = 1 \
+         ORDER BY cc.device_id ASC, cc.start_sequence ASC",
+    )
+    .fetch_all(&mut *connection)
+    .await?;
+    let mut coverage = BTreeMap::<String, Vec<CoverageInterval>>::new();
+    for row in rows {
+        coverage
+            .entry(row.try_get("device_id")?)
+            .or_default()
+            .push(CoverageInterval {
+                start: row.try_get("start_sequence")?,
+                end: row.try_get("end_sequence")?,
+            });
+    }
+    Ok(coverage)
+}
+
+async fn selected_checkpoint_created_at(
+    connection: &mut SqliteConnection,
+) -> StoreResult<Option<String>> {
+    Ok(sqlx::query_scalar(
+        "SELECT c.created_at FROM checkpoints c JOIN selected_checkpoint s \
+         ON s.checkpoint_path = c.path WHERE s.singleton = 1",
+    )
+    .fetch_optional(&mut *connection)
+    .await?)
+}
+
+async fn checkpoint_covers<'e, E>(
+    executor: E,
+    device_id: &str,
+    sequence: &str,
+) -> StoreResult<bool>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM checkpoint_coverage cc JOIN selected_checkpoint s \
+         ON s.checkpoint_path = cc.checkpoint_path WHERE s.singleton = 1 \
+         AND cc.device_id = ? AND cc.start_sequence <= ? AND cc.end_sequence >= ?",
+    )
+    .bind(device_id)
+    .bind(sequence)
+    .bind(sequence)
+    .fetch_one(executor)
+    .await?;
+    Ok(count > 0)
+}
+
+async fn store_is_pristine(connection: &mut SqliteConnection) -> StoreResult<bool> {
+    let count: i64 = sqlx::query_scalar(
+        "SELECT (SELECT COUNT(*) FROM batches) + (SELECT COUNT(*) FROM items) + \
+         (SELECT COUNT(*) FROM import_rows) + (SELECT COUNT(*) FROM outbox)",
+    )
+    .fetch_one(&mut *connection)
+    .await?;
+    Ok(count == 0)
+}
+
+fn merge_coverage(mut intervals: Vec<(String, u64, u64)>) -> StoreResult<CheckpointCoverage> {
+    intervals.sort();
+    let mut merged = BTreeMap::<String, Vec<(u64, u64)>>::new();
+    for (device_id, start, end) in intervals {
+        let device = merged.entry(device_id).or_default();
+        if let Some((_, previous_end)) = device.last_mut()
+            && start <= previous_end.saturating_add(1)
+        {
+            *previous_end = (*previous_end).max(end);
+            continue;
+        }
+        device.push((start, end));
+    }
+    merged
+        .into_iter()
+        .map(|(device_id, intervals)| {
+            let intervals = intervals
+                .into_iter()
+                .map(|(start, end)| CoverageInterval::new(start, end).map_err(StoreError::from))
+                .collect::<StoreResult<Vec<_>>>()?;
+            Ok((device_id, intervals))
+        })
+        .collect()
+}
+
+fn parse_sequence(value: &str) -> StoreResult<u64> {
+    value
+        .parse::<u64>()
+        .ok()
+        .filter(|sequence| *sequence > 0 && value.len() == 20)
+        .ok_or_else(|| StoreError::InvalidStore("invalid batch sequence".into()))
+}
+
+fn decoded_base64_len(value: &str) -> StoreResult<u64> {
+    let bytes = STANDARD
+        .decode(value)
+        .map_err(|_| StoreError::InvalidStore("stored update payload is not Base64".into()))?;
+    u64::try_from(bytes.len())
+        .map_err(|_| StoreError::NumericRange("decoded update payload bytes"))
 }
 
 async fn observe_remote(

--- a/crates/research-store/tests/local_mutation_contract.rs
+++ b/crates/research-store/tests/local_mutation_contract.rs
@@ -5,7 +5,8 @@ use research_store::{
 };
 
 #[tokio::test]
-async fn explicit_reenrichment_replaces_only_an_enrichment_owned_excerpt() {
+async fn firecrawl_reenrichment_replaces_captured_content_without_overwriting_authored_excerpt()
+{
     let directory = tempfile::tempdir().expect("library temp directory");
     let store = V2Store::init(directory.path().join("library"))
         .await
@@ -44,6 +45,20 @@ async fn explicit_reenrichment_replaces_only_an_enrichment_owned_excerpt() {
         .await
         .expect("apply initial enrichment");
     assert!(first.applied_excerpt);
+    assert!(first.item.excerpt.is_none());
+    let first_reference = first
+        .item
+        .captured_document
+        .as_ref()
+        .expect("captured reference");
+    assert_eq!(
+        store
+            .captured_document_markdown(&first_reference.sha256)
+            .await
+            .expect("read content")
+            .as_deref(),
+        Some("Short metadata description")
+    );
 
     let requeued = store
         .queue_item_enrichment(&item.id, EnrichmentProvider::Firecrawl)
@@ -67,8 +82,18 @@ async fn explicit_reenrichment_replaces_only_an_enrichment_owned_excerpt() {
         )
         .await
         .expect("replace enrichment-owned excerpt");
+    assert!(replaced.item.excerpt.is_none());
+    let replaced_reference = replaced
+        .item
+        .captured_document
+        .as_ref()
+        .expect("replacement reference");
     assert_eq!(
-        replaced.item.excerpt.as_deref(),
+        store
+            .captured_document_markdown(&replaced_reference.sha256)
+            .await
+            .expect("read replacement")
+            .as_deref(),
         Some("# Complete page\n\nPreserved Markdown")
     );
 
@@ -84,8 +109,8 @@ async fn explicit_reenrichment_replaces_only_an_enrichment_owned_excerpt() {
         .queue_item_enrichment(&item.id, EnrichmentProvider::Firecrawl)
         .await
         .expect("requeue after authored edit");
-    assert!(!protected.target_excerpt);
-    assert_eq!(protected.status, EnrichmentStatus::Skipped);
+    assert!(protected.target_excerpt);
+    assert_eq!(protected.status, EnrichmentStatus::Pending);
 
     let forced = store
         .queue_item_enrichment_replacing_excerpt(&item.id, EnrichmentProvider::Firecrawl)
@@ -145,7 +170,23 @@ async fn explicit_reenrichment_replaces_only_an_enrichment_owned_excerpt() {
         .await
         .expect("replace unchanged authored excerpt explicitly");
     assert!(replacement.applied_excerpt);
-    assert_eq!(replacement.item.excerpt.as_deref(), Some("# Fresh parse"));
+    assert_eq!(
+        replacement.item.excerpt.as_deref(),
+        Some("Newer authored context")
+    );
+    let fresh_reference = replacement
+        .item
+        .captured_document
+        .as_ref()
+        .expect("fresh captured reference");
+    assert_eq!(
+        store
+            .captured_document_markdown(&fresh_reference.sha256)
+            .await
+            .expect("read fresh parse")
+            .as_deref(),
+        Some("# Fresh parse")
+    );
 }
 
 #[tokio::test]

--- a/crates/research-store/tests/sync_contract.rs
+++ b/crates/research-store/tests/sync_contract.rs
@@ -1,8 +1,173 @@
-use research_domain::create_operation_pack;
+use research_domain::{UpdateEnvelope, create_operation_pack};
 use research_store::{
     CreateItemRequest, EditItemRequest, ListQuery, OptionalTextUpdate, RemoteBatchDisposition,
     SearchQuery, StoreError, V2Store,
 };
+
+#[tokio::test]
+async fn checkpoint_bootstrap_restores_coverage_and_applies_only_the_tail() {
+    let root = tempfile::tempdir().expect("temporary test root");
+    let sender = V2Store::init(root.path().join("sender"))
+        .await
+        .expect("sender store");
+    let receiver = V2Store::init(root.path().join("receiver"))
+        .await
+        .expect("receiver store");
+    let identity = sender.sync_identity().await.expect("sender identity");
+    receiver
+        .adopt_library_id_if_pristine(&identity.library_id)
+        .await
+        .expect("adopt sender library");
+
+    let item = sender
+        .create_item(CreateItemRequest {
+            url: "https://example.com/checkpoint".into(),
+            title: Some("Checkpoint".into()),
+            excerpt: Some("bounded state".into()),
+            favorite: false,
+            language: Some("en".into()),
+            saved_at: Some(1_700_000_000),
+            note: String::new(),
+            tags: vec!["restore".into()],
+        })
+        .await
+        .expect("create checkpoint item");
+    sender
+        .edit_item(EditItemRequest {
+            item_id: item.id.clone(),
+            favorite: Some(true),
+            ..EditItemRequest::default()
+        })
+        .await
+        .expect("edit before checkpoint");
+    let covered = sender.pending_batches().await.expect("covered batches");
+    let checkpoint = sender
+        .checkpoint_candidate(true)
+        .await
+        .expect("build checkpoint")
+        .expect("checkpoint candidate");
+
+    let restored = receiver
+        .receive_remote_checkpoint(
+            &checkpoint.path,
+            &"a".repeat(40),
+            checkpoint.checkpoint_json.as_bytes(),
+        )
+        .await
+        .expect("restore checkpoint");
+    assert!(restored.restored);
+    assert_eq!(restored.batch_count, 2);
+    assert_eq!(
+        receiver
+            .list(ListQuery::default())
+            .await
+            .expect("restored projection"),
+        sender
+            .list(ListQuery::default())
+            .await
+            .expect("sender projection")
+    );
+
+    for batch in &covered {
+        assert!(
+            receiver
+                .batch_is_checkpoint_covered(&batch.device_id, &batch.sequence)
+                .await
+                .expect("coverage lookup")
+        );
+        let result = receiver
+            .receive_remote_batch(&batch.path, &"b".repeat(40), batch.envelope_json.as_bytes())
+            .await
+            .expect("covered operation is idempotent");
+        assert_eq!(result.disposition, RemoteBatchDisposition::AlreadyApplied);
+    }
+
+    sender
+        .edit_item(EditItemRequest {
+            item_id: item.id,
+            title: Some(OptionalTextUpdate::Set("After checkpoint".into())),
+            ..EditItemRequest::default()
+        })
+        .await
+        .expect("create uncovered tail");
+    let tail = sender
+        .pending_batches()
+        .await
+        .expect("tail outbox")
+        .into_iter()
+        .find(|batch| !covered.iter().any(|covered| covered.path == batch.path))
+        .expect("uncovered tail batch");
+    let applied = receiver
+        .receive_remote_batch(&tail.path, &"c".repeat(40), tail.envelope_json.as_bytes())
+        .await
+        .expect("apply uncovered tail");
+    assert_eq!(applied.disposition, RemoteBatchDisposition::Applied);
+    assert_eq!(
+        receiver
+            .item(
+                &sender
+                    .list(ListQuery::default())
+                    .await
+                    .expect("sender list")
+                    .items[0]
+                    .id
+            )
+            .await
+            .expect("receiver item")
+            .title
+            .as_deref(),
+        Some("After checkpoint")
+    );
+}
+
+#[tokio::test]
+async fn native_mutations_reuse_one_durable_loro_peer() {
+    let root = tempfile::tempdir().expect("temporary test root");
+    let store = V2Store::init(root.path().join("library"))
+        .await
+        .expect("initialize store");
+    let item = store
+        .create_item(CreateItemRequest {
+            url: "https://example.com/stable-peer".into(),
+            title: None,
+            excerpt: None,
+            favorite: false,
+            language: None,
+            saved_at: Some(1_700_000_000),
+            note: String::new(),
+            tags: Vec::new(),
+        })
+        .await
+        .expect("create item");
+    for favorite in [true, false] {
+        store
+            .edit_item(EditItemRequest {
+                item_id: item.id.clone(),
+                favorite: Some(favorite),
+                ..EditItemRequest::default()
+            })
+            .await
+            .expect("edit item");
+    }
+    let envelopes = store
+        .pending_batches()
+        .await
+        .expect("pending batches")
+        .into_iter()
+        .map(|batch| {
+            serde_json::from_str::<UpdateEnvelope>(&batch.envelope_json)
+                .expect("stored update envelope")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(envelopes.len(), 3);
+    assert!(envelopes[0].causal_frontier.is_empty());
+    assert_eq!(envelopes[1].causal_frontier.len(), 1);
+    assert_eq!(envelopes[2].causal_frontier.len(), 1);
+    assert_eq!(
+        envelopes[1].causal_frontier.keys().collect::<Vec<_>>(),
+        envelopes[2].causal_frontier.keys().collect::<Vec<_>>()
+    );
+}
 
 #[tokio::test]
 async fn one_operation_pack_applies_and_acknowledges_several_exact_updates() {

--- a/docs/releases/v2.1.0.md
+++ b/docs/releases/v2.1.0.md
@@ -1,0 +1,76 @@
+# ResearchPocket 2.1.0
+
+ResearchPocket 2.1.0 keeps large private libraries responsive by bounding
+browser restore work, moving shared-domain processing off the main thread, and
+making routine projection writes proportional to the items that changed.
+
+## Install
+
+With Rust installed:
+
+```sh
+cargo install --locked --force research
+```
+
+Or download the verified archive for Linux, macOS, or Windows from the GitHub
+release and check it against `SHA256SUMS`.
+
+## What changed
+
+- Native and browser synchronization now create and validate immutable
+  protocol-v1 checkpoints after 100 newly covered batches or 2 MiB of decoded
+  update payload. A pristine client restores the best checkpoint and applies
+  only its uncovered tail.
+- Browser checkpoint validation and remote application run in a dedicated
+  worker and process direct operations in bounded chunks, keeping the page
+  responsive while a large library is restored.
+- Native installations keep one stable Loro peer identity. Causal frontiers now
+  grow with active replicas instead of growing once per native edit.
+- Local mutations and remote application return and persist only affected item
+  projections after bootstrap instead of rewriting the complete item table.
+- Enriched full-page Markdown is stored as an immutable SHA-256-addressed
+  private object. List projections exclude its bytes, and the Reader downloads
+  and validates it only when opened.
+- The shared domain includes the validated item-aggregate, catalogue, migration
+  barrier, and deterministic migration artifact primitives for the next sync
+  generation. This release does not activate a protocol-v2 cutover or rewrite
+  existing protocol-v1 history.
+
+## Upgrade and prime an existing private library
+
+Upgrade the native client, verify the version, and run one normal sync:
+
+```sh
+cargo install --locked --force research
+research --version
+research sync
+```
+
+The expected version is `research 2.1.0`. The first sync of an existing
+repository may still replay its current protocol-v1 history once. It then
+publishes the first checkpoint when the threshold is met. A fresh or reset
+browser can use that checkpoint on its next connection instead of replaying the
+covered history.
+
+Protocol-v1 operation files remain immutable and are not pruned. ResearchPocket
+2.0 clients ignore the optional checkpoint files, but upgrading every writer is
+recommended before relying on the improved restore path.
+
+## GitHub release archives
+
+| Platform | Release asset |
+| --- | --- |
+| Linux GNU/glibc x86-64 (glibc 2.35 or newer) | `research-v2.1.0-linux-amd64.tar.gz` |
+| Windows x86-64 | `research-v2.1.0-windows-amd64.zip` |
+| macOS Intel | `research-v2.1.0-macos-amd64.tar.gz` |
+| macOS Apple Silicon | `research-v2.1.0-macos-arm64.tar.gz` |
+
+The archives remain unsigned. Verify the selected file with `SHA256SUMS`, or
+build the exact tag with the pinned toolchain:
+
+```sh
+git clone --branch v2.1.0 --depth 1 \
+  https://github.com/ResearchPocket/researchpocket.github.io.git
+cd researchpocket.github.io
+cargo build --locked --release
+```

--- a/docs/v2/ADR_0004_BOUNDED_FIRECRAWL_MARKDOWN.md
+++ b/docs/v2/ADR_0004_BOUNDED_FIRECRAWL_MARKDOWN.md
@@ -1,6 +1,6 @@
 # ADR 0004: Retain bounded Firecrawl Markdown in the excerpt register
 
-- Status: accepted
+- Status: superseded in part by [ADR 0010](./ADR_0010_BOUNDED_ITEM_SCOPED_SYNC.md)
 - Date: 2026-07-20
 - Issue: [#79](https://github.com/ResearchPocket/researchpocket.github.io/issues/79)
 - Amends: [ADR 0002](./ADR_0002_LINK_ENRICHMENT.md)
@@ -59,6 +59,12 @@ any other private excerpt; no excerpt becomes public without explicit collection
 and field policy.
 
 ## Consequences
+
+ADR 0010 supersedes the storage-location part of this decision. New Firecrawl
+Markdown is now an immutable content-addressed `CapturedDocument`; the authored
+excerpt remains editable and is no longer replaced by Firecrawl. The bounds,
+normalization, private-by-default policy, and Reader safety decisions here
+remain in force.
 
 - A private library, checkpoint, restore, export, and sync history may be much
   larger than a URL-and-metadata-only library.

--- a/docs/v2/ADR_0010_BOUNDED_ITEM_SCOPED_SYNC.md
+++ b/docs/v2/ADR_0010_BOUNDED_ITEM_SCOPED_SYNC.md
@@ -1,0 +1,158 @@
+# ADR 0010: Bound restore work and scope durable content to items
+
+- Status: accepted
+- Date: 2026-07-28
+- Issue: [#132](https://github.com/ResearchPocket/researchpocket.github.io/issues/132)
+- Amends: [ADR 0003](./ADR_0003_OPERATION_PACKS.md),
+  [ADR 0004](./ADR_0004_BOUNDED_FIRECRAWL_MARKDOWN.md), and
+  [ADR 0008](./ADR_0008_EXCERPT_AS_MERGED_TEXT.md)
+
+## Context
+
+The first production-sized private repository exposed two independent scaling
+failures.
+
+First, protocol v1 describes checkpoints but neither shipped transport creates
+or consumes them. A pristine browser therefore downloads and replays the entire
+immutable operation history. A 1,016-item library with 115 unique updates
+expanded to 13.8 MB of envelope JSON, took about 34 seconds in the shared WASM
+domain, and grew process RSS to roughly 1 GiB before IndexedDB persistence.
+
+Second, the complete library is one Loro document. Every local or remote
+mutation restores that document, returns a complete snapshot and private
+projection, and rewrites the browser item store. A scalar update with a 448-byte
+Loro payload returned about 13.7 MB of snapshot-plus-projection JSON. Retained
+page Markdown represented about 91 percent of the projection.
+
+Native callers also assigned a fresh Loro peer identity whenever they restored
+the snapshot. One installation consequently added one causal-frontier peer per
+edit instead of one peer per replica. The operation set remained convergent, but
+frontier metadata and merge work grew with history length.
+
+ADR 0004 deliberately put bounded Firecrawl Markdown in the existing excerpt
+field to avoid an object boundary before real usage justified one. Real usage
+now justifies that boundary. The product still does not need arbitrary
+attachments or a general webpage archive.
+
+## Decision
+
+Delivery is staged so the existing private repository becomes usable before the
+aggregate migration is required.
+
+### Protocol-v1 bounded restore
+
+Native and browser clients implement the checkpoint format already specified by
+the synchronization protocol. A checkpoint contains one validated full Loro
+snapshot and exact logical device-sequence coverage. It is immutable, optional,
+and never replaces or prunes an operation.
+
+Clients create a checkpoint after 100 newly covered logical batches or 2 MiB of
+decoded update payload since the selected checkpoint. These lower operational
+thresholds amend the original 1,000-batch/10-MiB requirement; clients may still
+create equivalent checkpoints earlier. A manual or migration-triggered
+checkpoint is always allowed.
+
+A pristine replica selects the compatible checkpoint with the greatest exact
+batch coverage, validates its path, payload hash, snapshot mode, frontier,
+coverage, schema, codec, and library identity, then applies only logical updates
+outside its coverage. Checkpoint selection cannot acknowledge a local outbox.
+Every covered operation remains remotely immutable and recoverable.
+
+Browser checkpoint validation and tail application run in a dedicated worker.
+Verified state and observations are committed atomically. Reload or worker
+failure leaves the previous snapshot usable and causes a safe retry.
+
+### Stable replica identity and affected projections
+
+One durable Loro peer identity belongs to one installation. Native clients
+derive it deterministically from their persistent device UUID; browsers retain
+their existing persisted peer ID. Restoring a local snapshot no longer creates
+a new peer.
+
+Domain mutation results contain the changed item projection rather than the
+complete private projection. Remote application returns only projections whose
+canonical values changed. SQLite and IndexedDB update those rows in the same
+transaction as snapshot, receipt, and outbox state. Bootstrap is the only path
+that replaces a complete materialized projection.
+
+### Item aggregates and captured documents
+
+The next synchronization generation treats an item as the consistency and CRDT
+aggregate boundary:
+
+- item-authored fields, note text, tags, lifecycle, and visibility converge in
+  an item-scoped Loro document;
+- collection definitions are separate aggregates when collections ship;
+- a compact catalogue lists aggregate identities and ordering metadata without
+  embedding item bodies; and
+- an operation declares its aggregate kind and UUID, so apply and projection
+  work are bounded by the changed aggregate.
+
+Fetched full-page Markdown becomes an immutable private `CapturedDocument`
+addressed by the lowercase SHA-256 of its exact normalized UTF-8 bytes. Item
+state contains a causal reference with byte length, media type, provenance, and
+content hash. Re-enrichment writes a new object and a small reference update.
+The owner Reader fetches document bytes lazily. List/bootstrap projections never
+embed them.
+
+The authored excerpt remains an item field. Existing v1 excerpts remain
+lossless. Migration may externalize an excerpt only when durable enrichment
+provenance proves it is fetched content; ambiguous authored values remain
+excerpt text. New Firecrawl enrichment writes `CapturedDocument`, not excerpt.
+
+Captured documents use a private immutable path:
+
+```text
+sync/v2/content/sha256/<first-two-hex>/<sha256>.md
+```
+
+The decoded content hash must equal the path identity, content stays within the
+existing 4 MiB UTF-8 bound, and publication excludes it unless a future
+allowlisted policy explicitly says otherwise.
+
+### Fail-closed migration
+
+The aggregate protocol uses a new `sync/v2/` genesis and operation namespace.
+Adding files only under that namespace is insufficient because protocol-v1
+clients ignore it. Cutover therefore starts with a recognized protocol-v1
+migration-barrier operation carrying the required
+`item-aggregates-v2` feature. Older clients discover that operation during their
+mandatory pull and stop before uploading.
+
+A compatible client drains its local v1 outbox, applies the complete v1 set,
+creates the canonical migration checkpoint, emits v2 catalogue/item state and
+captured documents, and records the v1 checkpoint identity in v2 genesis.
+Protocol-v1 history is retained without rewriting. Migration is idempotent by
+library ID, checkpoint ID, aggregate ID, and content hash.
+
+## Consequences
+
+- Existing repositories gain a bounded restore path without changing merge
+  semantics or immutable operation bytes.
+- Future causal frontiers grow with replicas rather than native edit count.
+- Ordinary saves and sync tail application persist only affected items.
+- New full-page content no longer inflates catalogue/list materialization or
+  scalar-edit results.
+- Item-scoped documents add a versioned migration and more protocol objects, but
+  make save, edit, checkpoint, and lazy-reader costs proportional to the item.
+- Previously synchronized fetched Markdown cannot always be distinguished from
+  authored excerpts. Ambiguous content stays inline until the owner explicitly
+  moves it; the migration never guesses.
+- Protocol-v1 clients fail closed after the migration barrier and must upgrade.
+
+## Verification
+
+- Restore a sanitized 1,000-item, 100-update fixture with 4 MiB of captured
+  content from a checkpoint and apply an uncovered reordered tail.
+- Reject mismatched checkpoint hashes, paths, frontiers, coverage, versions,
+  codecs, libraries, and future required features.
+- Prove that two native edits reuse one peer and do not widen the frontier.
+- Prove local and remote scalar edits return and persist only affected item
+  projections while native and WASM canonical state remains identical.
+- Interrupt browser worker application before commit and verify the prior
+  snapshot and outbox remain intact.
+- Reject captured-document path/hash/size mismatches and prove list/bootstrap
+  projections contain no document bytes.
+- Verify that a protocol-v1 client stops on the migration barrier before
+  applying or uploading and that repeated migration produces identical v2
+  identities.

--- a/docs/v2/CLI.md
+++ b/docs/v2/CLI.md
@@ -102,7 +102,8 @@ observed at queue time instead. A later human clear/edit and a concurrent
 unsynchronized human revision both win. `--title ""` and `--language ""` are
 authored values and are not replaced; `--excerpt ""` leaves the excerpt blank,
 which merged text cannot distinguish from unset, so enrichment may still fill
-it.
+it. Firecrawl is the exception: its full Markdown is stored separately as
+private captured content and never replaces the authored excerpt.
 
 ### Direct public-HTML provider
 
@@ -130,30 +131,30 @@ parses only public HTML metadata.
 
 Firecrawl is never an automatic fallback. Selecting it means the saved target
 URL is sent to the configured Firecrawl service. ResearchPocket uses the narrow
-`/v2/scrape` REST endpoint through its existing HTTP client. It retains cleaned
-Markdown in a missing excerpt, plus normalized title and language metadata, and
-adds no Firecrawl Cargo dependency. Markdown is preserved up to 4 MiB inside the
-existing excerpt text; the complete JSON response is limited to
-8 MiB. Larger results fail explicitly and remain retryable without affecting the
-already-saved URL. The request includes the complete page instead of restricting
-extraction to main content, disables Firecrawl cache storage, requires target TLS
-validation, and uses the basic proxy tier.
+`/v2/scrape` REST endpoint through its existing HTTP client. It stores cleaned
+Markdown once under its SHA-256 identity in `sync/v2/content/sha256/`, while the
+item carries only the hash, byte length, media type, and provenance. List and
+bootstrap projections contain no Markdown bytes; the Reader fetches and
+validates them lazily. Markdown is preserved up to 4 MiB and the complete JSON
+response is limited to 8 MiB. Larger results fail explicitly and remain
+retryable without affecting the already-saved URL. The request includes the
+complete page instead of restricting extraction to main content, disables
+Firecrawl cache storage, requires target TLS validation, and uses the basic
+proxy tier.
 
-Passing an item ID and `--provider firecrawl` can upgrade an excerpt created by
-an earlier enrichment run. The replacement is allowed only while the excerpt still
-reads exactly as the previous enrichment run left it; an excerpt a human has
-since edited remains ineligible.
+Passing an item ID and `--provider firecrawl` refreshes its captured document.
+The authored excerpt remains untouched.
 
-To deliberately re-parse a saved URL and replace any current excerpt, including
-authored content, use the explicit replacement flag:
+The historical `--replace-excerpt` flag now means “force a fresh parse” for
+compatibility with existing scripts:
 
 ```sh
 research enrich run <item-id> --provider firecrawl --replace-excerpt
 ```
 
-The job records the exact current excerpt revision before network access. If the
-excerpt changes while Firecrawl is running, the fetched Markdown is skipped and
-the newer local or synchronized value wins.
+The job records the current authored excerpt before network access. If that
+context changes while Firecrawl is running, the fetched result is skipped; a
+subsequent run can capture the page without replacing that context.
 
 Store the key in a separate per-library file without placing it in process
 arguments or shell history:

--- a/docs/v2/SYNC_PROTOCOL.md
+++ b/docs/v2/SYNC_PROTOCOL.md
@@ -1,9 +1,9 @@
 # ResearchPocket synchronization protocol v1
 
-Status: protocol decisions for issues #33 and #68
+Status: protocol decisions for issues #33, #68, and #132
 
 Protocol version: 1  
-Domain schema version: 2  
+Domain schema version: 3
 Loro codec: 1.13.6  
 GitHub REST API version verified: 2026-03-10
 
@@ -78,6 +78,11 @@ sync/
           <pack-sha256>.json
     checkpoints/
       <snapshot-sha256>.json
+  v2/
+    content/
+      sha256/
+        <first-two-hex>/
+          <content-sha256>.md
 ```
 
 `sync/v1/library.json` is immutable genesis metadata created during setup:
@@ -99,7 +104,8 @@ checkpoint pointer, device list, or current state. If genesis already exists,
 setup accepts only the same library and compatible versions; otherwise it stops
 without replacing the file.
 
-Files outside `sync/v1/` are ignored. Within the protocol tree, a recognized
+Files outside `sync/v1/` and the recognized `sync/v2/content/sha256/` object
+namespace are ignored. Within the protocol tree, a recognized
 path with an invalid identity, non-blob Git entry, duplicate semantic identity,
 or incompatible document is an integrity error. Symlinks and submodules are not
 protocol objects.
@@ -389,27 +395,71 @@ sequences are contiguous. The checkpoint ID and path equal the decoded snapshot
 SHA-256. A client validates versions, library, path, coverage syntax, snapshot
 hash, Loro snapshot mode, and snapshot frontier before use.
 
-Create a checkpoint after either 1,000 newly applied batches or 10 MiB of
+Create a checkpoint after either 100 newly applied batches or 2 MiB of
 decoded update tail since the selected checkpoint. Checkpoint creation is an
 optimization and may be repeated by several devices. Clients select a compatible
 valid checkpoint with the greatest `batch_count`, breaking ties by lowercase
 checkpoint ID, then apply every discovered operation outside its exact coverage.
 Selection order cannot change final state.
 
-Every operation remains in the repository. A client can ignore checkpoints and
-rebuild from the full operation set, and diagnostics provide that fallback when
-checkpoint validation fails. Protocol v1 never deletes or rewrites operations or
-checkpoints.
+Every operation remains in the repository. A client can rebuild from the full
+operation set when no checkpoint exists. A discovered malformed or incompatible
+checkpoint fails closed; clients do not silently downgrade after observing a
+recognized corrupt protocol object. Protocol v1 never deletes or rewrites
+operations or checkpoints.
+
+## Captured Markdown objects
+
+New Firecrawl full-page Markdown is not embedded in an item excerpt or list
+projection. The domain normalizes line endings, removes disallowed control
+characters, trims the result, and limits it to 4 MiB of UTF-8. Exact normalized
+bytes are written once at:
+
+```text
+sync/v2/content/sha256/<first-two-hex>/<sha256>.md
+```
+
+The item CRDT carries only a causal `CapturedDocument` reference containing the
+lowercase SHA-256, byte length, fixed media type
+`text/markdown; charset=utf-8`, provider, source URL, and capture time. Before
+uploading the referencing operation, the producing client creates or verifies
+the content object. The Reader downloads it only on explicit open and validates
+path, hash, byte length, UTF-8, media type, and reference before persistence.
+Captured content is private and never enters publication output by default.
+
+## Item-aggregate protocol generation
+
+The negotiated `item-aggregates-v2` generation scopes an envelope to
+`(library_id, aggregate_kind, aggregate_id, device_id, sequence)` and stores item
+operations at:
+
+```text
+sync/v2/ops/items/<item-uuid>/<device-uuid>/<20-digit-sequence>.json
+```
+
+An immutable compact catalogue lists item aggregate IDs, saved ordering,
+lifecycle state, and content-addressed item-checkpoint paths; it contains no
+captured-document bytes. Each item checkpoint validates that its full Loro
+snapshot contains exactly its declared item. Migration deterministically seeds
+these checkpoints from one selected v1 canonical checkpoint, retains all v1
+history, and records that checkpoint identity in v2 genesis.
+
+Cutover begins with a normal recognized v1 envelope whose sole required feature
+is `item-aggregates-v2`. Older clients reject that feature during their
+pull-before-push cycle and therefore cannot upload after the barrier. Compatible
+clients accept the barrier, validate v2 genesis/catalogue/checkpoints, and apply
+only aggregate-scoped updates. Repeating migration with the same v1 checkpoint
+and identities produces the same aggregate identities and visible state.
 
 ## Version negotiation
 
 A client advertises an internal supported tuple:
 
 ```text
-protocol versions: {1}
-domain schema versions: {2}
+protocol versions: {1, 2}
+domain schema versions: {2, 3}
 Loro codecs: {1.13.6}
-required features: {}
+required features: {operation-packs-v1, item-aggregates-v2}
 ```
 
 Pack-aware clients additionally support the transport feature

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -170,7 +170,7 @@ pub struct EnrichRunArgs {
     #[arg(long, value_enum, value_name = "PROVIDER")]
     pub provider: Option<EnrichmentProviderArg>,
 
-    /// Explicitly replace the current excerpt after re-parsing the saved URL
+    /// Force a fresh parse; retained name for compatibility (authored excerpt is preserved)
     #[arg(long, requires = "item_id")]
     pub replace_excerpt: bool,
 
@@ -361,7 +361,7 @@ pub enum OutputFormat {
 pub enum EnrichmentProviderArg {
     /// Fetch public HTML directly from this device
     Direct,
-    /// Send the URL to Firecrawl and retain bounded Markdown in the excerpt
+    /// Send the URL to Firecrawl and retain bounded private captured Markdown
     Firecrawl,
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -8,10 +8,11 @@ use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT}
 use reqwest::{Client, Response, StatusCode, Url};
 use research_domain::{
     DomainError, LibraryGenesis, MAX_OPERATION_PACK_BYTES, MAX_OPERATION_PACK_MEMBERS,
-    OperationPackArtifact, create_operation_pack,
+    OperationPackArtifact, create_operation_pack, validate_checkpoint,
 };
 use research_store::{
-    PendingBatch, RemoteBatchDisposition, StoreError, SyncConfiguration, V2Store,
+    PendingBatch, PendingCapturedDocument, RemoteBatchDisposition, StoreError,
+    SyncConfiguration, V2Store,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -22,6 +23,8 @@ const API_VERSION: &str = "2026-03-10";
 const GENESIS_PATH: &str = "sync/v1/library.json";
 const OPS_PREFIX: &str = "sync/v1/ops/";
 const PACKS_PREFIX: &str = "sync/v1/ops/packs/";
+const CHECKPOINTS_PREFIX: &str = "sync/v1/checkpoints/";
+const CONTENT_PREFIX: &str = "sync/v2/content/sha256/";
 const MAX_UPLOAD_ATTEMPTS: usize = 4;
 const PACK_JSON_OVERHEAD_ALLOWANCE: usize = 1_024;
 
@@ -447,6 +450,7 @@ async fn run_configured(
         .inspect_repository(&remote.owner, &remote.repository)
         .await?;
     let mut pull = pull_remote(store, client, remote).await?;
+    ensure_captured_documents_uploaded(store, client, remote).await?;
     let pending = prepare_uploads(store.pending_batches().await?)?;
     let mut uploaded = 0_u64;
     for upload in pending {
@@ -457,6 +461,7 @@ async fn run_configured(
         pull.add(race_pull);
     }
     pull.add(pull_remote(store, client, remote).await?);
+    ensure_checkpoint_uploaded(store, client, remote).await?;
     let pending = u64::try_from(store.pending_batches().await?.len())
         .map_err(|_| StoreError::NumericRange("pending sync batch count"))?;
     Ok(SyncCycleResult {
@@ -478,6 +483,7 @@ async fn pull_remote(
 ) -> Result<PullStats, SyncError> {
     let tree = client.discover(remote).await?;
     validate_remote_genesis(store, client, remote, &tree).await?;
+    maybe_restore_checkpoint(store, client, remote, &tree).await?;
     let operations = tree
         .blobs
         .iter()
@@ -514,6 +520,139 @@ async fn pull_remote(
         ));
     }
     Ok(stats)
+}
+
+async fn maybe_restore_checkpoint(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+    tree: &ProtocolTree,
+) -> Result<(), SyncError> {
+    let identity = store.sync_identity().await?;
+    if !identity.pristine {
+        return Ok(());
+    }
+    let mut candidates = Vec::new();
+    for (path, sha) in tree
+        .blobs
+        .iter()
+        .filter(|(path, _)| path.starts_with(CHECKPOINTS_PREFIX))
+    {
+        let bytes = client.download_blob(remote, sha).await?;
+        let json = std::str::from_utf8(&bytes)
+            .map_err(|_| SyncError::RemoteData("checkpoint is not UTF-8 JSON".into()))?;
+        let artifact = validate_checkpoint(path, json, &identity.library_id)?;
+        candidates.push((
+            artifact.batch_count,
+            artifact.checkpoint_id,
+            path,
+            sha,
+            bytes,
+        ));
+    }
+    candidates.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| left.1.cmp(&right.1)));
+    if let Some((_, _, path, sha, bytes)) = candidates.into_iter().next() {
+        store.receive_remote_checkpoint(path, sha, &bytes).await?;
+    }
+    Ok(())
+}
+
+async fn ensure_checkpoint_uploaded(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+) -> Result<(), SyncError> {
+    let Some(checkpoint) = store.checkpoint_candidate(false).await? else {
+        return Ok(());
+    };
+    for attempt in 0..MAX_UPLOAD_ATTEMPTS {
+        let tree = client.discover(remote).await?;
+        if let Some(sha) = tree.blobs.get(&checkpoint.path) {
+            let bytes = client.download_blob(remote, sha).await?;
+            store
+                .receive_remote_checkpoint(&checkpoint.path, sha, &bytes)
+                .await?;
+            return Ok(());
+        }
+        match client
+            .put_new(
+                remote,
+                &checkpoint.path,
+                checkpoint.checkpoint_json.as_bytes(),
+                Some(&remote.branch),
+            )
+            .await?
+        {
+            PutResult::Created(sha) => {
+                store
+                    .receive_remote_checkpoint(
+                        &checkpoint.path,
+                        &sha,
+                        checkpoint.checkpoint_json.as_bytes(),
+                    )
+                    .await?;
+                return Ok(());
+            }
+            PutResult::Race | PutResult::Ambiguous(_) => {
+                retry_delay(&checkpoint.path, attempt).await;
+            }
+        }
+    }
+    Err(SyncError::Contention)
+}
+
+async fn ensure_captured_documents_uploaded(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+) -> Result<(), SyncError> {
+    for document in store.pending_captured_documents().await? {
+        ensure_captured_document_uploaded(store, client, remote, &document).await?;
+    }
+    Ok(())
+}
+
+async fn ensure_captured_document_uploaded(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+    document: &PendingCapturedDocument,
+) -> Result<(), SyncError> {
+    for attempt in 0..MAX_UPLOAD_ATTEMPTS {
+        let tree = client.discover(remote).await?;
+        if let Some(sha) = tree.blobs.get(&document.path) {
+            let bytes = client.download_blob(remote, sha).await?;
+            store
+                .confirm_captured_document(&document.reference, &document.path, sha, &bytes)
+                .await?;
+            return Ok(());
+        }
+        match client
+            .put_new(
+                remote,
+                &document.path,
+                document.markdown.as_bytes(),
+                Some(&remote.branch),
+            )
+            .await?
+        {
+            PutResult::Created(sha) => {
+                store
+                    .confirm_captured_document(
+                        &document.reference,
+                        &document.path,
+                        &sha,
+                        document.markdown.as_bytes(),
+                    )
+                    .await?;
+                return Ok(());
+            }
+            PutResult::Race | PutResult::Ambiguous(_) => {
+                retry_delay(&document.path, attempt).await;
+            }
+        }
+    }
+    Err(SyncError::Contention)
 }
 
 async fn validate_remote_genesis(
@@ -718,7 +857,7 @@ impl GitHubClient {
                 validate_reserved_directory(&path, &entry)?;
                 if entry.kind == "tree" && protocol_tree_relevant(&path) {
                     stack.push((entry.sha, path));
-                } else if path.starts_with("sync/v1/") {
+                } else if path.starts_with("sync/v1/") || path.starts_with(CONTENT_PREFIX) {
                     insert_protocol_blob(&mut protocol, &path, &entry)?;
                 }
             }
@@ -887,7 +1026,9 @@ fn collect_protocol_entries(
     for entry in entries {
         let path = join_path(prefix, &entry.path);
         validate_reserved_directory(&path, &entry)?;
-        if path.starts_with("sync/v1/") && entry.kind != "tree" {
+        if (path.starts_with("sync/v1/") || path.starts_with(CONTENT_PREFIX))
+            && entry.kind != "tree"
+        {
             insert_protocol_blob(&mut protocol, &path, &entry)?;
         }
     }
@@ -918,7 +1059,11 @@ fn insert_protocol_blob(
 }
 
 fn validate_reserved_directory(path: &str, entry: &TreeEntry) -> Result<(), SyncError> {
-    if matches!(path, "sync" | "sync/v1") && entry.kind != "tree" {
+    if matches!(
+        path,
+        "sync" | "sync/v1" | "sync/v2" | "sync/v2/content" | "sync/v2/content/sha256"
+    ) && entry.kind != "tree"
+    {
         return Err(SyncError::Integrity(
             "the reserved synchronization path is not a directory".into(),
         ));
@@ -927,7 +1072,11 @@ fn validate_reserved_directory(path: &str, entry: &TreeEntry) -> Result<(), Sync
 }
 
 fn protocol_tree_relevant(path: &str) -> bool {
-    matches!(path, "sync" | "sync/v1") || path.starts_with("sync/v1/")
+    matches!(
+        path,
+        "sync" | "sync/v1" | "sync/v2" | "sync/v2/content" | "sync/v2/content/sha256"
+    ) || path.starts_with("sync/v1/")
+        || path.starts_with(CONTENT_PREFIX)
 }
 
 fn join_path(prefix: &str, path: &str) -> String {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "research-pocket-web",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "research-pocket-web",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "dependencies": {
         "highlight.js": "11.11.1",
         "idb": "8.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "research-pocket-web",
   "private": true,
-  "version": "2.0.1",
+  "version": "2.1.0",
   "type": "module",
   "scripts": {
     "dev": "npm run wasm && vite",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ import {
 } from "./components/MarkdownDocument.tsx";
 import {
   type LibraryState,
+  type CapturedDocumentReference,
   type PendingSyncChange,
   type UndoableChange,
   libraryRepository,
@@ -48,6 +49,7 @@ interface LibraryItemView {
   favorite: boolean;
   deleted: boolean;
   savedAt: string;
+  capturedDocument?: CapturedDocumentReference | null;
 }
 
 type LifecycleFilter = "active" | "deleted" | "all";
@@ -2160,15 +2162,53 @@ function ReaderView({
     image: MarkdownImage;
     opener: HTMLButtonElement;
   } | null>(null);
+  const [capturedContext, setCapturedContext] = useState<string | null>(null);
+  const [capturedContextError, setCapturedContextError] = useState<string | null>(
+    null,
+  );
+  const [capturedContextLoading, setCapturedContextLoading] = useState(false);
   const imageCloseRef = useRef<HTMLButtonElement | null>(null);
   const label = item.title?.trim() || item.url;
-  const context = item.excerpt;
+  const context = capturedContext ?? item.excerpt;
   const hasContext = Boolean(context?.trim());
   const imagesAllowed = itemsWithImages.has(item.id);
 
   useEffect(() => {
     setExpandedImage(null);
   }, [item.id]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setCapturedContext(null);
+    setCapturedContextError(null);
+    const reference = item.capturedDocument;
+    if (!reference) {
+      setCapturedContextLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+    setCapturedContextLoading(true);
+    void browserSync.loadCapturedDocument(reference).then(
+      (markdown) => {
+        if (cancelled) return;
+        setCapturedContext(markdown);
+        setCapturedContextLoading(false);
+      },
+      (error: unknown) => {
+        if (cancelled) return;
+        setCapturedContextError(
+          error instanceof Error
+            ? error.message
+            : "Captured page content could not be loaded.",
+        );
+        setCapturedContextLoading(false);
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [item.id, item.capturedDocument?.sha256]);
 
   useEffect(() => {
     if (expandedImage) imageCloseRef.current?.focus();
@@ -2235,6 +2275,12 @@ function ReaderView({
           {item.tags.length > 0 ? <p className="reader-tags">{item.tags.map((tag) => <span key={tag}>#{tag}</span>)}</p> : null}
           {item.note?.trim() ? <aside className="reader-note"><strong>Your note</strong><p>{item.note}</p></aside> : null}
           <div className="reader-body">
+            {capturedContextLoading ? (
+              <p role="status">Loading captured page content…</p>
+            ) : null}
+            {capturedContextError ? (
+              <p className="sync-error" role="alert">{capturedContextError}</p>
+            ) : null}
             {hasContext && context ? (
               <MarkdownDocument
                 imageBaseUrl={item.url}
@@ -2245,7 +2291,7 @@ function ReaderView({
                 }
                 source={context}
               />
-            ) : (
+            ) : capturedContextLoading ? null : (
               <p>This save has no extracted preview yet. Open the original to read the full page, or add a private note to keep the context that matters.</p>
             )}
             <p className="reader-source">ResearchPocket keeps the URL and your authored context locally. The original page remains at <a href={item.url} rel="noreferrer" target="_blank">{readHostname(item.url)}</a>.</p>

--- a/web/src/data/db.ts
+++ b/web/src/data/db.ts
@@ -25,8 +25,28 @@ export interface PersistedItem {
   language: string | null;
   savedAt: string;
   savedAtUnix: number;
+  capturedDocument: CapturedDocumentReference | null;
   tags: string[];
   deleted: boolean;
+}
+
+export interface CapturedDocumentReference {
+  sha256: string;
+  byte_length: number;
+  media_type: string;
+  provenance: {
+    provider: string;
+    source_url: string;
+    captured_at: string;
+  };
+}
+
+export interface PersistedCapturedDocument {
+  sha256: string;
+  path: string;
+  markdown: string;
+  byteLength: number;
+  storedAt: string;
 }
 
 export interface PersistedBatch {
@@ -78,6 +98,33 @@ export interface RemoteObservation {
   observedAt: string;
 }
 
+export interface PersistedCoverageInterval {
+  start: string;
+  end: string;
+}
+
+export type PersistedCheckpointCoverage = Record<
+  string,
+  PersistedCoverageInterval[]
+>;
+
+export interface PersistedCheckpoint {
+  path: string;
+  checkpointId: string;
+  checkpointJson: string;
+  batchCount: number;
+  coverage: PersistedCheckpointCoverage;
+  createdAt: string;
+  origin: "local" | "remote";
+  appliedAt: string;
+}
+
+export interface PersistedSelectedCheckpoint {
+  key: "selected";
+  checkpointPath: string;
+  selectedAt: string;
+}
+
 export interface PersistedSyncConfiguration {
   key: "github";
   owner: string;
@@ -124,6 +171,18 @@ interface ResearchPocketBrowserDb extends DBSchema {
     key: string;
     value: RemoteObservation;
   };
+  checkpoints: {
+    key: string;
+    value: PersistedCheckpoint;
+  };
+  selectedCheckpoint: {
+    key: "selected";
+    value: PersistedSelectedCheckpoint;
+  };
+  capturedDocuments: {
+    key: string;
+    value: PersistedCapturedDocument;
+  };
   syncConfig: {
     key: "github";
     value: PersistedSyncConfiguration;
@@ -133,7 +192,7 @@ interface ResearchPocketBrowserDb extends DBSchema {
 export function openBrowserDatabase(
   name: string,
 ): Promise<IDBPDatabase<ResearchPocketBrowserDb>> {
-  return openDB<ResearchPocketBrowserDb>(name, 2, {
+  return openDB<ResearchPocketBrowserDb>(name, 4, {
     upgrade(database, oldVersion) {
       if (oldVersion < 1) {
         database.createObjectStore("meta", { keyPath: "key" });
@@ -152,6 +211,13 @@ export function openBrowserDatabase(
       }
       if (oldVersion < 2) {
         database.createObjectStore("syncConfig", { keyPath: "key" });
+      }
+      if (oldVersion < 3) {
+        database.createObjectStore("checkpoints", { keyPath: "path" });
+        database.createObjectStore("selectedCheckpoint", { keyPath: "key" });
+      }
+      if (oldVersion < 4) {
+        database.createObjectStore("capturedDocuments", { keyPath: "sha256" });
       }
     },
     blocked() {

--- a/web/src/data/domain.ts
+++ b/web/src/data/domain.ts
@@ -1,0 +1,72 @@
+type DomainMethod =
+  | "applyMutation"
+  | "applyRemoteEnvelopes"
+  | "createCheckpoint"
+  | "createCapturedDocument"
+  | "createOperationPack"
+  | "createSyncGenesis"
+  | "initializeLibrary"
+  | "materializeLibrary"
+  | "unpackOperationPack"
+  | "validateCheckpoint"
+  | "validateCapturedContent"
+  | "validateSyncGenesis";
+
+interface DomainResponse {
+  id: number;
+  result?: string;
+  error?: string;
+}
+
+class BrowserDomainCore {
+  private worker: Worker | null = null;
+  private nextId = 1;
+  private readonly pending = new Map<
+    number,
+    { resolve(value: string): void; reject(reason: Error): void }
+  >();
+
+  call(method: DomainMethod, ...args: string[]): Promise<string> {
+    const worker = this.ensureWorker();
+    const id = this.nextId;
+    this.nextId += 1;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      worker.postMessage({ id, method, args });
+    });
+  }
+
+  private ensureWorker(): Worker {
+    if (this.worker) return this.worker;
+    const worker = new Worker(new URL("./domain.worker.ts", import.meta.url), {
+      type: "module",
+      name: "researchpocket-domain",
+    });
+    worker.addEventListener("message", (event: MessageEvent<DomainResponse>) => {
+      const response = event.data;
+      const pending = this.pending.get(response.id);
+      if (!pending) return;
+      this.pending.delete(response.id);
+      if (typeof response.error === "string") {
+        pending.reject(new Error(response.error));
+      } else if (typeof response.result === "string") {
+        pending.resolve(response.result);
+      } else {
+        pending.reject(new Error("The domain worker returned an invalid response."));
+      }
+    });
+    worker.addEventListener("error", () => {
+      const error = new Error(
+        "The private library worker stopped before its operation completed.",
+      );
+      for (const pending of this.pending.values()) pending.reject(error);
+      this.pending.clear();
+      worker.terminate();
+      if (this.worker === worker) this.worker = null;
+    });
+    this.worker = worker;
+    return worker;
+  }
+}
+
+export const domainCore = new BrowserDomainCore();

--- a/web/src/data/domain.worker.ts
+++ b/web/src/data/domain.worker.ts
@@ -1,0 +1,73 @@
+import initWasm, {
+  applyMutation,
+  applyRemoteEnvelopes,
+  createCheckpoint,
+  createCapturedDocument,
+  createOperationPack,
+  createSyncGenesis,
+  initializeLibrary,
+  materializeLibrary,
+  unpackOperationPack,
+  validateCheckpoint,
+  validateCapturedContent,
+  validateSyncGenesis,
+} from "../generated/research_domain";
+
+type DomainMethod =
+  | "applyMutation"
+  | "applyRemoteEnvelopes"
+  | "createCheckpoint"
+  | "createCapturedDocument"
+  | "createOperationPack"
+  | "createSyncGenesis"
+  | "initializeLibrary"
+  | "materializeLibrary"
+  | "unpackOperationPack"
+  | "validateCheckpoint"
+  | "validateCapturedContent"
+  | "validateSyncGenesis";
+
+interface DomainRequest {
+  id: number;
+  method: DomainMethod;
+  args: string[];
+}
+
+interface DomainResponse {
+  id: number;
+  result?: string;
+  error?: string;
+}
+
+const methods: Record<DomainMethod, (...args: string[]) => string> = {
+  applyMutation,
+  applyRemoteEnvelopes,
+  createCheckpoint,
+  createCapturedDocument,
+  createOperationPack,
+  createSyncGenesis,
+  initializeLibrary,
+  materializeLibrary,
+  unpackOperationPack,
+  validateCheckpoint,
+  validateCapturedContent,
+  validateSyncGenesis,
+};
+
+const ready = initWasm();
+
+self.addEventListener("message", (event: MessageEvent<DomainRequest>) => {
+  void handle(event.data);
+});
+
+async function handle(request: DomainRequest): Promise<void> {
+  const response: DomainResponse = { id: request.id };
+  try {
+    await ready;
+    const method = methods[request.method];
+    response.result = method(...request.args);
+  } catch (error) {
+    response.error = error instanceof Error ? error.message : String(error);
+  }
+  self.postMessage(response);
+}

--- a/web/src/data/github.ts
+++ b/web/src/data/github.ts
@@ -8,6 +8,7 @@ const GET_RETRY_DELAY_MS = 250;
 export const GENESIS_PATH = "sync/v1/library.json";
 export const OPS_PREFIX = "sync/v1/ops/";
 export const PACKS_PREFIX = `${OPS_PREFIX}packs/`;
+export const CONTENT_PREFIX = "sync/v2/content/sha256/";
 
 export interface GitHubRemote {
   owner: string;
@@ -160,7 +161,10 @@ export class GitHubClient {
         validateReservedDirectory(path, entry);
         if (entry.type === "tree" && protocolTreeRelevant(path)) {
           stack.push([entry.sha, path]);
-        } else if (path.startsWith("sync/v1/")) {
+        } else if (
+          path.startsWith("sync/v1/") ||
+          path.startsWith(CONTENT_PREFIX)
+        ) {
           insertProtocolBlob(protocol, path, entry);
         }
       }
@@ -334,7 +338,10 @@ function collectProtocolEntries(entries: TreeEntry[], prefix: string): ProtocolT
   for (const entry of entries) {
     const path = joinPath(prefix, entry.path);
     validateReservedDirectory(path, entry);
-    if (path.startsWith("sync/v1/") && entry.type !== "tree") {
+    if (
+      (path.startsWith("sync/v1/") || path.startsWith(CONTENT_PREFIX)) &&
+      entry.type !== "tree"
+    ) {
       insertProtocolBlob(protocol, path, entry);
     }
   }
@@ -363,7 +370,16 @@ function insertProtocolBlob(
 }
 
 function validateReservedDirectory(path: string, entry: TreeEntry): void {
-  if ((path === "sync" || path === "sync/v1") && entry.type !== "tree") {
+  if (
+    [
+      "sync",
+      "sync/v1",
+      "sync/v2",
+      "sync/v2/content",
+      "sync/v2/content/sha256",
+    ].includes(path) &&
+    entry.type !== "tree"
+  ) {
     throw new GitHubSyncError(
       "The reserved synchronization path is not a directory.",
       "integrity",
@@ -372,7 +388,17 @@ function validateReservedDirectory(path: string, entry: TreeEntry): void {
 }
 
 function protocolTreeRelevant(path: string): boolean {
-  return path === "sync" || path === "sync/v1" || path.startsWith("sync/v1/");
+  return (
+    [
+      "sync",
+      "sync/v1",
+      "sync/v2",
+      "sync/v2/content",
+      "sync/v2/content/sha256",
+    ].includes(path) ||
+    path.startsWith("sync/v1/") ||
+    path.startsWith(CONTENT_PREFIX)
+  );
 }
 
 function joinPath(prefix: string, path: string): string {

--- a/web/src/data/library.ts
+++ b/web/src/data/library.ts
@@ -1,14 +1,10 @@
-import initWasm, {
-  applyMutation,
-  applyRemoteEnvelopes,
-  initializeLibrary,
-  materializeLibrary,
-} from "../generated/research_domain";
-
 import {
   openBrowserDatabase,
   type BrowserDatabase,
+  type CapturedDocumentReference,
   type PersistedBatch,
+  type PersistedCheckpoint,
+  type PersistedCheckpointCoverage,
   type PersistedChangeField,
   type PersistedChangeKind,
   type PersistedChangeSummary,
@@ -20,6 +16,7 @@ import {
   type PersistedSyncConfiguration,
   type RemoteObservation,
 } from "./db";
+import { domainCore } from "./domain.ts";
 import {
   createUndoableChange,
   matchesUndoExpectation,
@@ -35,6 +32,7 @@ import {
 
 export type { UndoableChange } from "./undo.ts";
 export type { LibraryProfile } from "./profiles.ts";
+export type { CapturedDocumentReference } from "./db.ts";
 
 export type LibraryItem = PersistedItem;
 
@@ -107,6 +105,19 @@ export interface BrowserSyncIdentity {
   libraryId: string;
   deviceId: string;
   createdAt: string;
+  pristine: boolean;
+}
+
+export interface BrowserCheckpointCandidate {
+  path: string;
+  json: string;
+  checkpointId: string;
+  batchCount: number;
+}
+
+export interface BrowserCheckpointResult {
+  batchCount: number;
+  restored: boolean;
 }
 
 interface RawProjection {
@@ -120,6 +131,7 @@ interface RawProjection {
     favorite: boolean;
     language: string | null;
     saved_at: number;
+    captured_document?: CapturedDocumentReference;
     tags: string[];
     state: "active" | "deleted";
   }>;
@@ -127,7 +139,7 @@ interface RawProjection {
 
 interface MutationResult {
   snapshot: string;
-  projection: RawProjection;
+  item: RawProjection["items"][number];
   envelope: string;
 }
 
@@ -142,6 +154,21 @@ interface EnvelopeIdentity {
   device_id: string;
   sequence: string;
   payload_sha256: string;
+}
+
+interface EnvelopeDetails extends EnvelopeIdentity {
+  created_at: string;
+  payload: string;
+}
+
+interface CheckpointArtifact {
+  path: string;
+  json: string;
+  checkpoint_id: string;
+  created_at: string;
+  batch_count: number;
+  coverage: PersistedCheckpointCoverage;
+  snapshot_base64: string;
 }
 
 interface ValidatedRemoteMember {
@@ -164,13 +191,8 @@ const U64_MAX = 18_446_744_073_709_551_615n;
 
 /** Must track `DOMAIN_SCHEMA_VERSION` in the Rust core. */
 const DOMAIN_SCHEMA_VERSION = 3;
-
-let wasmPromise: Promise<unknown> | undefined;
-
-function ensureWasm(): Promise<unknown> {
-  wasmPromise ??= initWasm();
-  return wasmPromise;
-}
+const CHECKPOINT_BATCH_THRESHOLD = 100;
+const CHECKPOINT_PAYLOAD_THRESHOLD = 2 * 1024 * 1024;
 
 class LibraryRepository {
   private state: LibraryState = {
@@ -256,7 +278,6 @@ class LibraryRepository {
         return;
       }
       this.patchState({ loading: true, status: "Creating your offline library…", error: null });
-      await ensureWasm();
       const now = new Date().toISOString();
       const meta: PersistedLibraryMeta = {
         key: "library",
@@ -266,8 +287,10 @@ class LibraryRepository {
         nextSequence: "00000000000000000001",
         createdAt: now,
       };
-      const snapshot = initializeLibrary(meta.peerId);
-      const projection = parseProjection(materializeLibrary(snapshot, meta.peerId));
+      const snapshot = await domainCore.call("initializeLibrary", meta.peerId);
+      const projection = parseProjection(
+        await domainCore.call("materializeLibrary", snapshot, meta.peerId),
+      );
       const items = materializeProjection(projection);
       const transaction = database.transaction(["meta", "state", "items"], "readwrite");
       try {
@@ -340,10 +363,19 @@ class LibraryRepository {
     const database = await this.database();
     const meta = await database.get("meta", "library");
     if (!meta) throw new Error("Create the browser library before connecting sync.");
+    const counts = await Promise.all([
+      database.count("items"),
+      database.count("batches"),
+      database.count("outbox"),
+      database.count("deferred"),
+    ]);
     return {
       libraryId: meta.libraryId,
       deviceId: meta.deviceId,
       createdAt: meta.createdAt,
+      pristine:
+        meta.nextSequence === "00000000000000000001" &&
+        counts.every((count) => count === 0),
     };
   }
 
@@ -391,7 +423,17 @@ class LibraryRepository {
     let adopted = false;
     await this.write(async (database) => {
       const transaction = database.transaction(
-        ["meta", "items", "batches", "outbox", "deferred", "remoteObservations"],
+        [
+          "meta",
+          "items",
+          "batches",
+          "outbox",
+          "deferred",
+          "remoteObservations",
+          "checkpoints",
+          "selectedCheckpoint",
+          "capturedDocuments",
+        ],
         "readwrite",
       );
       try {
@@ -408,6 +450,9 @@ class LibraryRepository {
           transaction.objectStore("outbox").count(),
           transaction.objectStore("deferred").count(),
           transaction.objectStore("remoteObservations").count(),
+          transaction.objectStore("checkpoints").count(),
+          transaction.objectStore("selectedCheckpoint").count(),
+          transaction.objectStore("capturedDocuments").count(),
         ]);
         if (
           meta.nextSequence !== "00000000000000000001" ||
@@ -450,6 +495,52 @@ class LibraryRepository {
 
   async remoteObservation(path: string): Promise<RemoteObservation | null> {
     return (await (await this.database()).get("remoteObservations", path)) ?? null;
+  }
+
+  async capturedDocument(
+    reference: CapturedDocumentReference,
+  ): Promise<string | null> {
+    validateCapturedDocumentReference(reference);
+    const stored = await (await this.database()).get(
+      "capturedDocuments",
+      reference.sha256,
+    );
+    if (!stored) return null;
+    if (
+      stored.byteLength !== reference.byte_length ||
+      new TextEncoder().encode(stored.markdown).byteLength !== reference.byte_length
+    ) {
+      throw new Error("Stored captured Markdown does not match its item reference.");
+    }
+    return stored.markdown;
+  }
+
+  async storeCapturedDocument(
+    reference: CapturedDocumentReference,
+    path: string,
+    markdown: string,
+  ): Promise<void> {
+    validateCapturedDocumentReference(reference);
+    const byteLength = new TextEncoder().encode(markdown).byteLength;
+    if (
+      path !== capturedDocumentPath(reference.sha256) ||
+      byteLength !== reference.byte_length
+    ) {
+      throw new Error("Captured Markdown does not match its immutable reference.");
+    }
+    await this.write(async (database) => {
+      const existing = await database.get("capturedDocuments", reference.sha256);
+      if (existing && existing.markdown !== markdown) {
+        throw new Error("A captured-document identity has conflicting bytes.");
+      }
+      await database.put("capturedDocuments", {
+        sha256: reference.sha256,
+        path,
+        markdown,
+        byteLength,
+        storedAt: new Date().toISOString(),
+      });
+    });
   }
 
   async recordRemoteObservation(path: string, blobSha: string): Promise<void> {
@@ -499,6 +590,172 @@ class LibraryRepository {
     return (await this.database()).count("deferred");
   }
 
+  async checkpointCandidate(
+    force = false,
+  ): Promise<BrowserCheckpointCandidate | null> {
+    let candidate: BrowserCheckpointCandidate | null = null;
+    await this.write(async (database) => {
+      if ((await database.count("deferred")) !== 0) return;
+      const persisted = await readPersisted(database);
+      const selected = await selectedCheckpoint(database);
+      const selectedCoverage = selected?.coverage ?? {};
+      const intervals: Array<[string, bigint, bigint]> = [];
+      for (const [deviceId, ranges] of Object.entries(selectedCoverage)) {
+        for (const range of ranges) {
+          intervals.push([
+            deviceId,
+            parseSequence(range.start),
+            parseSequence(range.end),
+          ]);
+        }
+      }
+
+      let tailBatches = 0;
+      let tailPayloadBytes = 0;
+      let createdAt = selected?.createdAt ?? "1970-01-01T00:00:00Z";
+      for (const batch of await database.getAll("batches")) {
+        const details = parseEnvelopeDetails(batch.envelopeJson);
+        intervals.push([
+          details.device_id,
+          parseSequence(details.sequence),
+          parseSequence(details.sequence),
+        ]);
+        if (details.created_at > createdAt) createdAt = details.created_at;
+        if (!coverageContains(selectedCoverage, details.device_id, details.sequence)) {
+          tailBatches += 1;
+          tailPayloadBytes += decodedBase64Length(details.payload);
+        }
+      }
+
+      if (
+        !force &&
+        tailBatches < CHECKPOINT_BATCH_THRESHOLD &&
+        tailPayloadBytes < CHECKPOINT_PAYLOAD_THRESHOLD
+      ) {
+        return;
+      }
+      if (intervals.length === 0) return;
+
+      const artifact = parseCheckpointArtifact(
+        await domainCore.call(
+          "createCheckpoint",
+          persisted.snapshot.snapshot,
+          persisted.meta.libraryId,
+          createdAt,
+          JSON.stringify(mergeCoverage(intervals)),
+        ),
+      );
+      if (artifact.snapshot_base64 !== persisted.snapshot.snapshot) {
+        throw new Error("The domain core changed the checkpoint snapshot bytes.");
+      }
+      await persistCheckpoint(database, artifact, "local");
+      candidate = {
+        path: artifact.path,
+        json: artifact.json,
+        checkpointId: artifact.checkpoint_id,
+        batchCount: artifact.batch_count,
+      };
+    });
+    return candidate;
+  }
+
+  async receiveRemoteCheckpoint(
+    path: string,
+    blobSha: string,
+    checkpointJson: string,
+  ): Promise<BrowserCheckpointResult> {
+    validateBlobSha(blobSha);
+    const result = await this.write(async (database) => {
+      const persisted = await readPersisted(database);
+      const artifact = parseCheckpointArtifact(
+        await domainCore.call(
+          "validateCheckpoint",
+          path,
+          checkpointJson,
+          persisted.meta.libraryId,
+        ),
+      );
+      if (artifact.path !== path || artifact.json !== checkpointJson) {
+        throw new Error("The domain core changed immutable checkpoint bytes.");
+      }
+      const observation = await database.get("remoteObservations", path);
+      if (observation && observation.blobSha !== blobSha) {
+        throw new Error("An immutable remote checkpoint changed its Git object identity.");
+      }
+      const counts = await Promise.all([
+        database.count("items"),
+        database.count("batches"),
+        database.count("outbox"),
+        database.count("deferred"),
+      ]);
+      const pristine =
+        persisted.meta.nextSequence === "00000000000000000001" &&
+        counts.every((count) => count === 0);
+      const restored =
+        pristine || persisted.snapshot.snapshot === artifact.snapshot_base64;
+      const items = pristine
+        ? materializeProjection(
+            parseProjection(
+              await domainCore.call(
+                "materializeLibrary",
+                artifact.snapshot_base64,
+                persisted.meta.peerId,
+              ),
+            ),
+          )
+        : [];
+      const now = new Date().toISOString();
+      const transaction = database.transaction(
+        [
+          "state",
+          "items",
+          "checkpoints",
+          "selectedCheckpoint",
+          "remoteObservations",
+        ],
+        "readwrite",
+      );
+      try {
+        const checkpoints = transaction.objectStore("checkpoints");
+        await persistCheckpointStore(checkpoints, artifact, "remote", now);
+        if (pristine) {
+          await transaction.objectStore("state").put({
+            key: "canonical",
+            snapshot: artifact.snapshot_base64,
+            updatedAt: now,
+          });
+          await replaceItems(transaction.objectStore("items"), items);
+        }
+        if (restored) {
+          const selected = await selectedCheckpointFromStores(
+            transaction.objectStore("selectedCheckpoint"),
+            checkpoints,
+          );
+          if (!selected || selected.batchCount <= artifact.batch_count) {
+            await transaction.objectStore("selectedCheckpoint").put({
+              key: "selected",
+              checkpointPath: artifact.path,
+              selectedAt: now,
+            });
+          }
+        }
+        await transaction.objectStore("remoteObservations").put({
+          path,
+          blobSha,
+          observedAt: now,
+        });
+        await transaction.done;
+      } catch (error) {
+        abortTransaction(transaction);
+        throw error;
+      }
+      return { batchCount: artifact.batch_count, restored };
+    });
+    if (result.restored) await this.afterCommit("Library checkpoint restored");
+    else this.channel.postMessage({ type: "changed" });
+    return result;
+  }
+
   async recordSyncSuccess(): Promise<void> {
     await this.recordSyncResult(null);
   }
@@ -516,6 +773,8 @@ class LibraryRepository {
     await this.write(async (database) => {
       const persisted = await readPersisted(database);
       const artifacts = validateRemoteArtifacts(inputs, packs, persisted.meta.libraryId);
+      const checkpoint = await selectedCheckpoint(database);
+      const coverage = checkpoint?.coverage ?? {};
       const newMembers: ValidatedRemoteMember[] = [];
       const newMemberPaths = new Set<string>();
       for (const artifact of artifacts) {
@@ -528,7 +787,12 @@ class LibraryRepository {
           if (existing && existing.envelopeJson !== member.envelopeJson) {
             throw new Error("An immutable remote update changed after it was observed.");
           }
-          if (!existing && !newMemberPaths.has(member.path)) {
+          const covered = coverageContains(
+            coverage,
+            member.identity.device_id,
+            member.identity.sequence,
+          );
+          if (!existing && !covered && !newMemberPaths.has(member.path)) {
             newMembers.push(member);
             newMemberPaths.add(member.path);
           }
@@ -548,18 +812,23 @@ class LibraryRepository {
           envelopeJson: entry.envelopeJson,
         })),
       ];
-      await ensureWasm();
-      const result = JSON.parse(
-        applyRemoteEnvelopes(
-          persisted.snapshot.snapshot,
-          persisted.meta.peerId,
-          persisted.meta.libraryId,
-          JSON.stringify(combined.map((entry) => entry.envelopeJson)),
-        ),
-      ) as RemoteApplyResult;
+      const result =
+        combined.length === 0
+          ? null
+          : (JSON.parse(
+              await domainCore.call(
+                "applyRemoteEnvelopes",
+                persisted.snapshot.snapshot,
+                persisted.meta.peerId,
+                persisted.meta.libraryId,
+                JSON.stringify(combined.map((entry) => entry.envelopeJson)),
+              ),
+            ) as RemoteApplyResult);
       const now = new Date().toISOString();
-      const items = materializeProjection(result.projection);
-      const pendingRecords = materializeDeferred(result.pending_indices, combined);
+      const items = result ? materializeProjection(result.projection) : [];
+      const pendingRecords = result
+        ? materializeDeferred(result.pending_indices, combined)
+        : [];
       const newBatchRecords = newMembers.map((member) =>
         batchRecord(
           member.path,
@@ -574,12 +843,16 @@ class LibraryRepository {
         "readwrite",
       );
       try {
-        await transaction.objectStore("state").put({
-          key: "canonical",
-          snapshot: result.snapshot,
-          updatedAt: now,
-        });
-        await replaceItems(transaction.objectStore("items"), items);
+        if (result) {
+          await transaction.objectStore("state").put({
+            key: "canonical",
+            snapshot: result.snapshot,
+            updatedAt: now,
+          });
+        }
+        for (const item of items) {
+          await transaction.objectStore("items").put(item);
+        }
         await transaction.objectStore("deferred").clear();
         for (const record of pendingRecords) {
           await transaction.objectStore("deferred").put(record);
@@ -625,10 +898,10 @@ class LibraryRepository {
       }
       const normalizedMutation = normalizeMutation(mutation, beforeItem, targetTags);
       if (!normalizedMutation) return;
-      await ensureWasm();
       const now = new Date().toISOString();
       const result = JSON.parse(
-        applyMutation(
+        await domainCore.call(
+          "applyMutation",
           persisted.snapshot.snapshot,
           persisted.meta.peerId,
           persisted.meta.libraryId,
@@ -651,9 +924,8 @@ class LibraryRepository {
         ...persisted.meta,
         nextSequence: incrementSequence(persisted.meta.nextSequence),
       };
-      const items = materializeProjection(result.projection);
-      const afterItem = items.find((item) => item.id === itemId);
-      if (!afterItem) {
+      const afterItem = materializeItem(result.item);
+      if (afterItem.id !== itemId) {
         throw new Error("The domain core omitted the changed item from its projection.");
       }
       const summary = summarizeMutation(normalizedMutation, beforeItem, afterItem);
@@ -677,7 +949,7 @@ class LibraryRepository {
           snapshot: result.snapshot,
           updatedAt: now,
         });
-        await replaceItems(transaction.objectStore("items"), items);
+        await transaction.objectStore("items").put(afterItem);
         await transaction.objectStore("batches").add(batch);
         await transaction.objectStore("outbox").add(outbox);
         await transaction.done;
@@ -750,7 +1022,9 @@ class LibraryRepository {
     }
   }
 
-  private async write(operation: (database: BrowserDatabase) => Promise<void>): Promise<void> {
+  private async write<T>(
+    operation: (database: BrowserDatabase) => Promise<T>,
+  ): Promise<T> {
     const execute = async () => operation(await this.database());
     try {
       if (this.closed) {
@@ -761,7 +1035,7 @@ class LibraryRepository {
           "Safe library writes require a browser with cross-tab Web Locks support.",
         );
       }
-      await this.track(navigator.locks.request(this.names.writeLock, execute));
+      return await this.track(navigator.locks.request(this.names.writeLock, execute));
     } catch (error) {
       this.patchState({ error: safeError(error), status: "Change was not saved" });
       throw error;
@@ -794,6 +1068,77 @@ async function readPersisted(database: BrowserDatabase): Promise<{
   ]);
   if (!meta || !snapshot) throw new Error("The browser library is incomplete.");
   return { meta, snapshot };
+}
+
+async function selectedCheckpoint(
+  database: BrowserDatabase,
+): Promise<PersistedCheckpoint | null> {
+  const selected = await database.get("selectedCheckpoint", "selected");
+  if (!selected) return null;
+  return (await database.get("checkpoints", selected.checkpointPath)) ?? null;
+}
+
+type CheckpointStore = {
+  get(key: string): Promise<PersistedCheckpoint | undefined>;
+  put(value: PersistedCheckpoint): Promise<unknown>;
+};
+
+type SelectedCheckpointStore = {
+  get(key: "selected"): Promise<
+    { key: "selected"; checkpointPath: string; selectedAt: string } | undefined
+  >;
+};
+
+async function selectedCheckpointFromStores(
+  selectedStore: SelectedCheckpointStore,
+  checkpointStore: CheckpointStore,
+): Promise<PersistedCheckpoint | null> {
+  const selected = await selectedStore.get("selected");
+  if (!selected) return null;
+  return (await checkpointStore.get(selected.checkpointPath)) ?? null;
+}
+
+async function persistCheckpoint(
+  database: BrowserDatabase,
+  artifact: CheckpointArtifact,
+  origin: "local" | "remote",
+): Promise<void> {
+  const transaction = database.transaction("checkpoints", "readwrite");
+  try {
+    await persistCheckpointStore(
+      transaction.objectStore("checkpoints"),
+      artifact,
+      origin,
+      new Date().toISOString(),
+    );
+    await transaction.done;
+  } catch (error) {
+    abortTransaction(transaction);
+    throw error;
+  }
+}
+
+async function persistCheckpointStore(
+  store: CheckpointStore,
+  artifact: CheckpointArtifact,
+  origin: "local" | "remote",
+  now: string,
+): Promise<void> {
+  const existing = await store.get(artifact.path);
+  if (existing && existing.checkpointJson !== artifact.json) {
+    throw new Error("An immutable checkpoint identity has conflicting bytes.");
+  }
+  if (existing) return;
+  await store.put({
+    path: artifact.path,
+    checkpointId: artifact.checkpoint_id,
+    checkpointJson: artifact.json,
+    batchCount: artifact.batch_count,
+    coverage: artifact.coverage,
+    createdAt: artifact.created_at,
+    origin,
+    appliedAt: now,
+  });
 }
 
 async function replaceItems(
@@ -860,6 +1205,39 @@ function validateBlobSha(value: string): void {
   }
 }
 
+function materializeCapturedDocumentReference(
+  value: CapturedDocumentReference | undefined,
+): CapturedDocumentReference | null {
+  if (value === undefined) return null;
+  validateCapturedDocumentReference(value);
+  return structuredClone(value);
+}
+
+function validateCapturedDocumentReference(
+  value: CapturedDocumentReference,
+): void {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !/^[0-9a-f]{64}$/.test(value.sha256) ||
+    !Number.isSafeInteger(value.byte_length) ||
+    value.byte_length <= 0 ||
+    value.byte_length > 4 * 1024 * 1024 ||
+    value.media_type !== "text/markdown; charset=utf-8" ||
+    typeof value.provenance !== "object" ||
+    value.provenance === null ||
+    value.provenance.provider !== "firecrawl" ||
+    typeof value.provenance.source_url !== "string" ||
+    typeof value.provenance.captured_at !== "string"
+  ) {
+    throw new Error("The domain core returned an invalid captured-document reference.");
+  }
+}
+
+function capturedDocumentPath(sha256: string): string {
+  return `sync/v2/content/sha256/${sha256.slice(0, 2)}/${sha256}.md`;
+}
+
 function materializeItem(item: RawProjection["items"][number]): PersistedItem {
   if (!Number.isSafeInteger(item.saved_at)) {
     throw new Error("The domain core returned an invalid saved time.");
@@ -878,6 +1256,9 @@ function materializeItem(item: RawProjection["items"][number]): PersistedItem {
     language: item.language,
     savedAt: savedAt.toISOString(),
     savedAtUnix: item.saved_at,
+    capturedDocument: materializeCapturedDocumentReference(
+      item.captured_document,
+    ),
     tags: [...item.tags],
     deleted: item.state === "deleted",
   };
@@ -1099,6 +1480,161 @@ function parseEnvelope(envelopeJson: string): EnvelopeIdentity {
     throw new Error("The domain core returned a malformed immutable envelope.");
   }
   return value as EnvelopeIdentity;
+}
+
+function parseEnvelopeDetails(envelopeJson: string): EnvelopeDetails {
+  const value = JSON.parse(envelopeJson) as Partial<EnvelopeDetails>;
+  parseEnvelope(envelopeJson);
+  if (
+    typeof value.created_at !== "string" ||
+    typeof value.payload !== "string"
+  ) {
+    throw new Error("An immutable envelope is missing checkpoint metadata.");
+  }
+  return value as EnvelopeDetails;
+}
+
+function parseCheckpointArtifact(json: string): CheckpointArtifact {
+  const value = JSON.parse(json) as Partial<CheckpointArtifact>;
+  if (
+    typeof value.path !== "string" ||
+    !/^sync\/v1\/checkpoints\/[0-9a-f]{64}\.json$/.test(value.path) ||
+    typeof value.json !== "string" ||
+    typeof value.checkpoint_id !== "string" ||
+    !/^[0-9a-f]{64}$/.test(value.checkpoint_id) ||
+    !value.path.endsWith(`/${value.checkpoint_id}.json`) ||
+    typeof value.created_at !== "string" ||
+    typeof value.batch_count !== "number" ||
+    !Number.isSafeInteger(value.batch_count) ||
+    value.batch_count < 0 ||
+    typeof value.snapshot_base64 !== "string" ||
+    !isCheckpointCoverage(value.coverage)
+  ) {
+    throw new Error("The domain core returned an invalid checkpoint artifact.");
+  }
+  const covered = coverageSize(value.coverage);
+  if (covered !== BigInt(value.batch_count)) {
+    throw new Error("The checkpoint batch count does not match its coverage.");
+  }
+  return value as CheckpointArtifact;
+}
+
+function isCheckpointCoverage(
+  value: unknown,
+): value is PersistedCheckpointCoverage {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  for (const [deviceId, intervals] of Object.entries(value)) {
+    if (deviceId.length === 0 || !Array.isArray(intervals) || intervals.length === 0) {
+      return false;
+    }
+    let previousEnd = 0n;
+    for (const [index, interval] of intervals.entries()) {
+      if (typeof interval !== "object" || interval === null) return false;
+      const candidate = interval as Partial<{ start: string; end: string }>;
+      if (
+        typeof candidate.start !== "string" ||
+        typeof candidate.end !== "string"
+      ) {
+        return false;
+      }
+      let start: bigint;
+      let end: bigint;
+      try {
+        start = parseSequence(candidate.start);
+        end = parseSequence(candidate.end);
+      } catch {
+        return false;
+      }
+      if (start > end || (index > 0 && start <= previousEnd)) return false;
+      previousEnd = end;
+    }
+  }
+  return true;
+}
+
+function coverageContains(
+  coverage: PersistedCheckpointCoverage,
+  deviceId: string,
+  sequence: string,
+): boolean {
+  const target = parseSequence(sequence);
+  return (coverage[deviceId] ?? []).some(
+    (interval) =>
+      parseSequence(interval.start) <= target &&
+      target <= parseSequence(interval.end),
+  );
+}
+
+function coverageSize(coverage: PersistedCheckpointCoverage): bigint {
+  let count = 0n;
+  for (const intervals of Object.values(coverage)) {
+    for (const interval of intervals) {
+      count += parseSequence(interval.end) - parseSequence(interval.start) + 1n;
+    }
+  }
+  return count;
+}
+
+function mergeCoverage(
+  intervals: Array<[string, bigint, bigint]>,
+): PersistedCheckpointCoverage {
+  const ordered = [...intervals].sort(
+    ([leftDevice, leftStart], [rightDevice, rightStart]) =>
+      leftDevice.localeCompare(rightDevice) ||
+      (leftStart < rightStart ? -1 : leftStart > rightStart ? 1 : 0),
+  );
+  const merged = new Map<string, Array<[bigint, bigint]>>();
+  for (const [deviceId, start, end] of ordered) {
+    const ranges = merged.get(deviceId) ?? [];
+    const previous = ranges.at(-1);
+    if (previous && start <= previous[1] + 1n) {
+      previous[1] = previous[1] > end ? previous[1] : end;
+    } else {
+      ranges.push([start, end]);
+    }
+    merged.set(deviceId, ranges);
+  }
+  return Object.fromEntries(
+    [...merged.entries()].map(([deviceId, ranges]) => [
+      deviceId,
+      ranges.map(([start, end]) => ({
+        start: formatSequence(start),
+        end: formatSequence(end),
+      })),
+    ]),
+  );
+}
+
+function parseSequence(value: string): bigint {
+  if (!/^\d{20}$/.test(value)) {
+    throw new Error("A synchronization sequence is not a canonical u64.");
+  }
+  const sequence = BigInt(value);
+  if (sequence === 0n || sequence > U64_MAX) {
+    throw new Error("A synchronization sequence is outside the supported range.");
+  }
+  return sequence;
+}
+
+function formatSequence(value: bigint): string {
+  if (value === 0n || value > U64_MAX) {
+    throw new Error("A synchronization sequence is outside the supported range.");
+  }
+  return value.toString().padStart(20, "0");
+}
+
+function decodedBase64Length(value: string): number {
+  if (
+    value.length === 0 ||
+    value.length % 4 !== 0 ||
+    !/^[A-Za-z0-9+/]*={0,2}$/.test(value)
+  ) {
+    throw new Error("An immutable envelope has a malformed Base64 payload.");
+  }
+  const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0;
+  return (value.length / 4) * 3 - padding;
 }
 
 function batchRecord(
@@ -1423,6 +1959,24 @@ class LibraryWorkspace {
     return (await this.instance()).remoteObservation(path);
   }
 
+  async capturedDocument(
+    reference: CapturedDocumentReference,
+  ): Promise<string | null> {
+    return (await this.instance()).capturedDocument(reference);
+  }
+
+  async storeCapturedDocument(
+    reference: CapturedDocumentReference,
+    path: string,
+    markdown: string,
+  ): Promise<void> {
+    return (await this.instance()).storeCapturedDocument(
+      reference,
+      path,
+      markdown,
+    );
+  }
+
   async recordRemoteObservation(path: string, blobSha: string): Promise<void> {
     return (await this.instance()).recordRemoteObservation(path, blobSha);
   }
@@ -1437,6 +1991,24 @@ class LibraryWorkspace {
 
   async deferredSyncCount(): Promise<number> {
     return (await this.instance()).deferredSyncCount();
+  }
+
+  async checkpointCandidate(
+    force = false,
+  ): Promise<BrowserCheckpointCandidate | null> {
+    return (await this.instance()).checkpointCandidate(force);
+  }
+
+  async receiveRemoteCheckpoint(
+    path: string,
+    blobSha: string,
+    checkpointJson: string,
+  ): Promise<BrowserCheckpointResult> {
+    return (await this.instance()).receiveRemoteCheckpoint(
+      path,
+      blobSha,
+      checkpointJson,
+    );
   }
 
   async recordSyncSuccess(): Promise<void> {

--- a/web/src/data/sync.ts
+++ b/web/src/data/sync.ts
@@ -1,11 +1,5 @@
-import initWasm, {
-  createOperationPack,
-  createSyncGenesis,
-  unpackOperationPack,
-  validateSyncGenesis,
-} from "../generated/research_domain";
-
 import {
+  CONTENT_PREFIX,
   GENESIS_PATH,
   GitHubClient,
   GitHubSyncError,
@@ -16,8 +10,11 @@ import {
   type ProtocolTree,
   type RepositoryInfo,
 } from "./github.ts";
+import { domainCore } from "./domain.ts";
 import {
   libraryRepository,
+  type BrowserCheckpointCandidate,
+  type CapturedDocumentReference,
   type PendingSyncBatch,
   type RemoteEnvelopeInput,
   type RemoteOperationPackInput,
@@ -79,19 +76,23 @@ interface PendingUpload {
   packed: boolean;
 }
 
+interface CheckpointDescriptor {
+  path: string;
+  blobSha: string;
+  json: string;
+  batchCount: number;
+  checkpointId: string;
+}
+
 const MAX_UPLOAD_ATTEMPTS = 4;
 const PERIODIC_SYNC_MS = 60_000;
 const LOCAL_CHANGE_SYNC_DELAY_MS = 5_000;
 const MAX_PACK_MEMBERS = 1_000;
 const MAX_PACK_BYTES = 20 * 1024 * 1024;
 const PACK_JSON_OVERHEAD_BYTES = 1_024;
-
-let wasmPromise: Promise<unknown> | undefined;
-
-function ensureWasm(): Promise<unknown> {
-  wasmPromise ??= initWasm();
-  return wasmPromise;
-}
+const CHECKPOINTS_PREFIX = "sync/v1/checkpoints/";
+const MAX_REMOTE_APPLY_MEMBERS = 32;
+const MAX_REMOTE_APPLY_BYTES = 2 * 1024 * 1024;
 
 class BrowserSyncService {
   private state: BrowserSyncState = {
@@ -132,6 +133,40 @@ class BrowserSyncService {
         void this.requestSync("periodic refresh");
       }
     }, PERIODIC_SYNC_MS);
+  }
+
+  async loadCapturedDocument(
+    reference: CapturedDocumentReference,
+  ): Promise<string> {
+    const cached = await libraryRepository.capturedDocument(reference);
+    if (cached !== null) return cached;
+    const configuration = await libraryRepository.syncConfiguration();
+    if (!configuration) {
+      throw new GitHubSyncError(
+        "Connect private sync before loading captured page content.",
+        "configuration",
+      );
+    }
+    const path = capturedDocumentPath(reference.sha256);
+    const client = new GitHubClient(this.requireToken());
+    const remote = remoteFrom(configuration);
+    const tree = await client.discover(remote);
+    const blobSha = tree.blobs.get(path);
+    if (!blobSha) {
+      throw new GitHubSyncError(
+        "The captured page content referenced by this save is missing.",
+        "integrity",
+      );
+    }
+    const markdown = await client.downloadText(remote, blobSha);
+    const validated = await domainCore.call(
+      "validateCapturedContent",
+      path,
+      markdown,
+      JSON.stringify(reference),
+    );
+    await libraryRepository.storeCapturedDocument(reference, path, validated);
+    return validated;
   }
 
   /**
@@ -381,8 +416,7 @@ class BrowserSyncService {
       const remoteGenesisSha = tree.blobs.get(GENESIS_PATH);
       if (remoteGenesisSha) {
         const genesisJson = await client.downloadText(remote, remoteGenesisSha);
-        await ensureWasm();
-        const remoteLibraryId = validatedGenesisLibraryId(genesisJson);
+        const remoteLibraryId = await validatedGenesisLibraryId(genesisJson);
         await libraryRepository.adoptRemoteLibraryIfPristine(remoteLibraryId);
         await libraryRepository.recordRemoteObservation(GENESIS_PATH, remoteGenesisSha);
         return;
@@ -399,8 +433,11 @@ class BrowserSyncService {
       }
 
       const identity = await libraryRepository.syncIdentity();
-      await ensureWasm();
-      const genesisJson = createSyncGenesis(identity.libraryId, identity.createdAt);
+      const genesisJson = await domainCore.call(
+        "createSyncGenesis",
+        identity.libraryId,
+        identity.createdAt,
+      );
       const put = await client.putNew(
         remote,
         GENESIS_PATH,
@@ -439,6 +476,11 @@ class BrowserSyncService {
     }
     this.patch({ status: "Confirming the synchronized library…" });
     pull = addPullStats(pull, await this.pullRemote(client, remote));
+    const checkpoint = await libraryRepository.checkpointCandidate(false);
+    if (checkpoint) {
+      this.patch({ status: "Publishing a fast-restore checkpoint…" });
+      await this.ensureCheckpointUploaded(client, remote, checkpoint);
+    }
     const pending = (await libraryRepository.pendingSyncBatches()).length;
     const result: SyncCycleResult = {
       ...pull,
@@ -461,6 +503,7 @@ class BrowserSyncService {
   private async pullRemote(client: GitHubClient, remote: GitHubRemote): Promise<PullStats> {
     const tree = await client.discover(remote);
     await this.validateRemoteGenesis(client, remote, tree);
+    await this.restoreBestCheckpoint(client, remote, tree);
     const operations = [...tree.blobs.entries()]
       .filter(([path]) => path.startsWith(OPS_PREFIX))
       .sort(([left], [right]) => left.localeCompare(right));
@@ -476,9 +519,21 @@ class BrowserSyncService {
         );
       }
     }
-    const inputs: RemoteEnvelopeInput[] = [];
-    const packs: RemoteOperationPackInput[] = [];
     let downloaded = 0;
+    let applied = 0;
+    let directInputs: RemoteEnvelopeInput[] = [];
+    let directBytes = 0;
+    const pendingBefore = (await libraryRepository.pendingSyncBatches()).length;
+    const flushDirectInputs = async (): Promise<void> => {
+      if (directInputs.length === 0) return;
+      const chunk = directInputs;
+      directInputs = [];
+      directBytes = 0;
+      this.patch({
+        status: `Applying ${chunk.length} downloaded remote change${chunk.length === 1 ? "" : "s"}…`,
+      });
+      applied += await this.applyRemoteUpdates(chunk);
+    };
     const progressStep = Math.max(1, Math.ceil(unseen.length / 20));
     for (const [index, [path, blobSha]] of unseen.entries()) {
       if (index === 0 || index + 1 === unseen.length || index % progressStep === 0) {
@@ -488,19 +543,34 @@ class BrowserSyncService {
       }
       const json = await client.downloadText(remote, blobSha);
       if (path.startsWith(PACKS_PREFIX)) {
+        await flushDirectInputs();
         const pack = await unpackRemotePack(path, blobSha, json);
-        packs.push(pack);
+        this.patch({
+          status: `Applying downloaded remote pack ${index + 1} of ${unseen.length}…`,
+        });
+        applied += await this.applyRemoteUpdates([], [pack]);
         downloaded += 1;
       } else {
-        inputs.push({ path, blobSha, envelopeJson: json });
+        const bytes = new TextEncoder().encode(json).byteLength;
+        if (
+          directInputs.length > 0 &&
+          (directInputs.length >= MAX_REMOTE_APPLY_MEMBERS ||
+            directBytes + bytes > MAX_REMOTE_APPLY_BYTES)
+        ) {
+          await flushDirectInputs();
+        }
+        directInputs.push({ path, blobSha, envelopeJson: json });
+        directBytes += bytes;
         downloaded += 1;
+        if (
+          directInputs.length >= MAX_REMOTE_APPLY_MEMBERS ||
+          directBytes >= MAX_REMOTE_APPLY_BYTES
+        ) {
+          await flushDirectInputs();
+        }
       }
     }
-    if (unseen.length > 0) {
-      this.patch({ status: "Applying downloaded remote changes…" });
-    }
-    const pendingBefore = (await libraryRepository.pendingSyncBatches()).length;
-    const applied = await this.applyRemoteUpdates(inputs, packs);
+    await flushDirectInputs();
     if ((await libraryRepository.deferredSyncCount()) > 0) {
       throw new GitHubSyncError(
         "Remote updates are missing a causal predecessor. No local changes were uploaded.",
@@ -537,8 +607,7 @@ class BrowserSyncService {
     }
     if (!observation) {
       const genesisJson = await client.downloadText(remote, sha);
-      await ensureWasm();
-      const remoteLibraryId = validatedGenesisLibraryId(genesisJson);
+      const remoteLibraryId = await validatedGenesisLibraryId(genesisJson);
       const local = await libraryRepository.syncIdentity();
       if (remoteLibraryId !== local.libraryId) {
         throw new GitHubSyncError(
@@ -548,6 +617,126 @@ class BrowserSyncService {
       }
       await libraryRepository.recordRemoteObservation(GENESIS_PATH, sha);
     }
+  }
+
+  private async restoreBestCheckpoint(
+    client: GitHubClient,
+    remote: GitHubRemote,
+    tree: ProtocolTree,
+  ): Promise<void> {
+    if (!(await libraryRepository.syncIdentity()).pristine) return;
+    const checkpoints = [...tree.blobs.entries()]
+      .filter(([path]) => path.startsWith(CHECKPOINTS_PREFIX))
+      .sort(([left], [right]) => left.localeCompare(right));
+    const candidates: CheckpointDescriptor[] = [];
+    for (const [index, [path, blobSha]] of checkpoints.entries()) {
+      const observation = await libraryRepository.remoteObservation(path);
+      if (observation) {
+        if (observation.blobSha !== blobSha) {
+          throw new GitHubSyncError(
+            "An immutable remote checkpoint changed after it was observed.",
+            "integrity",
+          );
+        }
+        continue;
+      }
+      this.patch({
+        status: `Checking restore checkpoint ${index + 1} of ${checkpoints.length}…`,
+      });
+      const json = await client.downloadText(remote, blobSha);
+      try {
+        const identity = await libraryRepository.syncIdentity();
+        candidates.push(
+          parseCheckpointDescriptor(
+            path,
+            blobSha,
+            json,
+            await domainCore.call(
+              "validateCheckpoint",
+              path,
+              json,
+              identity.libraryId,
+            ),
+          ),
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const upgradeRequired =
+          /unsupported (?:protocol|domain schema|Loro codec|feature)/i.test(message);
+        throw new GitHubSyncError(
+          upgradeRequired
+            ? "This private library uses a newer checkpoint format. Upgrade ResearchPocket before syncing."
+            : "A remote library checkpoint is malformed or failed its content-address check.",
+          upgradeRequired ? "upgrade_required" : "integrity",
+        );
+      }
+    }
+    if (candidates.length === 0) return;
+    candidates.sort(
+      (left, right) =>
+        right.batchCount - left.batchCount ||
+        right.checkpointId.localeCompare(left.checkpointId),
+    );
+    const selected = candidates[0]!;
+    for (const candidate of candidates.slice(1)) {
+      await libraryRepository.recordRemoteObservation(
+        candidate.path,
+        candidate.blobSha,
+      );
+    }
+    this.patch({
+      status: `Restoring ${selected.batchCount} synchronized changes from checkpoint…`,
+    });
+    const restored = await libraryRepository.receiveRemoteCheckpoint(
+      selected.path,
+      selected.blobSha,
+      selected.json,
+    );
+    if (!restored.restored) {
+      throw new GitHubSyncError(
+        "The browser library changed while its restore checkpoint was being selected.",
+        "local_state",
+      );
+    }
+  }
+
+  private async ensureCheckpointUploaded(
+    client: GitHubClient,
+    remote: GitHubRemote,
+    checkpoint: BrowserCheckpointCandidate,
+  ): Promise<void> {
+    for (let attempt = 0; attempt < MAX_UPLOAD_ATTEMPTS; attempt += 1) {
+      const tree = await client.discover(remote);
+      const existingSha = tree.blobs.get(checkpoint.path);
+      if (existingSha) {
+        const existingJson = await client.downloadText(remote, existingSha);
+        await libraryRepository.receiveRemoteCheckpoint(
+          checkpoint.path,
+          existingSha,
+          existingJson,
+        );
+        return;
+      }
+      const put = await client.putNew(
+        remote,
+        checkpoint.path,
+        checkpoint.json,
+        remote.branch,
+      );
+      if (put.type === "created") {
+        await libraryRepository.receiveRemoteCheckpoint(
+          checkpoint.path,
+          put.blobSha,
+          checkpoint.json,
+        );
+        return;
+      }
+      await retryDelay(checkpoint.path, attempt);
+    }
+    throw new GitHubSyncError(
+      "Checkpoint publication remained contended after safe retries.",
+      "contention",
+    );
   }
 
   private async ensureUploaded(
@@ -690,9 +879,8 @@ async function buildPendingUploads(
   pending: PendingSyncBatch[],
 ): Promise<PendingUpload[]> {
   const chunks = chunkPendingBatches(pending);
-  if (chunks.some((chunk) => chunk.length > 1)) await ensureWasm();
-
-  return chunks.map((members) => {
+  const uploads: PendingUpload[] = [];
+  for (const members of chunks) {
     const first = members[0];
     if (!first) {
       throw new GitHubSyncError(
@@ -701,18 +889,22 @@ async function buildPendingUploads(
       );
     }
     if (members.length === 1) {
-      return {
+      uploads.push({
         path: first.path,
         json: first.envelopeJson,
         members,
         packed: false,
-      };
+      });
+      continue;
     }
 
     try {
       const expectedEnvelopes = members.map((member) => member.envelopeJson);
       const artifact = parseOperationPackArtifact(
-        createOperationPack(JSON.stringify(expectedEnvelopes)),
+        await domainCore.call(
+          "createOperationPack",
+          JSON.stringify(expectedEnvelopes),
+        ),
       );
       if (
         artifact.member_envelopes.length !== expectedEnvelopes.length ||
@@ -722,12 +914,12 @@ async function buildPendingUploads(
       ) {
         throw new Error("The shared domain core changed the queued envelope bytes.");
       }
-      return {
+      uploads.push({
         path: artifact.path,
         json: artifact.json,
         members,
         packed: true,
-      };
+      });
     } catch (error) {
       if (error instanceof GitHubSyncError) throw error;
       throw new GitHubSyncError(
@@ -735,7 +927,8 @@ async function buildPendingUploads(
         "local_state",
       );
     }
-  });
+  }
+  return uploads;
 }
 
 function chunkPendingBatches(pending: PendingSyncBatch[]): PendingSyncBatch[][] {
@@ -798,8 +991,9 @@ async function unpackRemotePack(
   json: string,
 ): Promise<RemoteOperationPackInput> {
   try {
-    await ensureWasm();
-    const artifact = parseOperationPackArtifact(unpackOperationPack(path, json));
+    const artifact = parseOperationPackArtifact(
+      await domainCore.call("unpackOperationPack", path, json),
+    );
     if (artifact.path !== path || artifact.json !== json) {
       throw new Error("The shared domain core changed the immutable pack bytes.");
     }
@@ -838,6 +1032,48 @@ function parseOperationPackArtifact(json: string): OperationPackArtifact {
   return value as OperationPackArtifact;
 }
 
+function parseCheckpointDescriptor(
+  path: string,
+  blobSha: string,
+  checkpointJson: string,
+  artifactJson: string,
+): CheckpointDescriptor {
+  const value = JSON.parse(artifactJson) as Partial<{
+    path: string;
+    json: string;
+    batch_count: number;
+    checkpoint_id: string;
+  }>;
+  if (
+    value.path !== path ||
+    value.json !== checkpointJson ||
+    typeof value.batch_count !== "number" ||
+    !Number.isSafeInteger(value.batch_count) ||
+    value.batch_count < 0 ||
+    typeof value.checkpoint_id !== "string" ||
+    !/^[0-9a-f]{64}$/.test(value.checkpoint_id)
+  ) {
+    throw new Error("The shared domain core returned an invalid checkpoint artifact.");
+  }
+  return {
+    path,
+    blobSha,
+    json: checkpointJson,
+    batchCount: value.batch_count,
+    checkpointId: value.checkpoint_id,
+  };
+}
+
+function capturedDocumentPath(sha256: string): string {
+  if (!/^[0-9a-f]{64}$/.test(sha256)) {
+    throw new GitHubSyncError(
+      "A save contains an invalid captured-document identity.",
+      "integrity",
+    );
+  }
+  return `${CONTENT_PREFIX}${sha256.slice(0, 2)}/${sha256}.md`;
+}
+
 function remoteFrom(configuration: SyncConfiguration): GitHubRemote {
   return {
     owner: configuration.owner,
@@ -873,9 +1109,9 @@ function normalizeError(error: unknown): GitHubSyncError {
   );
 }
 
-function validatedGenesisLibraryId(genesisJson: string): string {
+async function validatedGenesisLibraryId(genesisJson: string): Promise<string> {
   try {
-    return validateSyncGenesis(genesisJson);
+    return await domainCore.call("validateSyncGenesis", genesisJson);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const upgradeRequired = /unsupported (?:protocol|domain schema|Loro codec|feature)/i.test(


### PR DESCRIPTION
## Summary

- create and restore validated protocol-v1 checkpoints at 100 batches or 2 MiB
- move browser domain restore/application into a worker and apply remote operations in bounded chunks
- keep one native peer identity and persist only affected item projections after bootstrap
- store fetched Markdown as immutable content-addressed objects loaded lazily by Reader
- add the protocol-v2 aggregate and deterministic migration primitives without activating cutover
- prepare the coordinated ResearchPocket 2.1.0 web and CLI release

## User-visible and protocol impact

A fresh browser can restore a large existing private library from the latest compatible checkpoint, then apply only the uncovered tail. The first upgraded native sync may replay current v1 history once and publishes the checkpoint when the threshold is met. Existing v1 operations are neither rewritten nor pruned. Protocol-v2 item aggregate primitives are included but the migration barrier and v2 namespace cutover are not activated in this release.

The hosted UI now performs shared Rust domain work in a dedicated worker, updates only changed IndexedDB item rows, and fetches validated captured Markdown only when Reader needs it.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-targets --all-features`
- `cargo audit --deny warnings`
- `cargo build --locked --release`
- `npm run verify` in `web`
- release binary version/help smoke test
- sanitized 1,000-item checkpoint fixture with 4 MiB of captured content
- read-only benchmark against a 1,016-item, 115-update private corpus: replay 23.3 s; checkpoint validation and materialization 156 ms

The local macOS browser harness selected Safari and its driver was killed before test execution. The required protected `Browser convergence` check runs the same corpus in headless Chrome on Ubuntu.

## UI evidence

No visual layout changes. Sync progress now reports checkpoint selection/publication and bounded remote-application phases; the production artifact and design-system checks pass.

Refs #132