### PR TITLE
Correct v2.1.0 sync command

### DIFF
--- a/docs/releases/v2.1.0.md
+++ b/docs/releases/v2.1.0.md
@@ -43,7 +43,7 @@ Upgrade the native client, verify the version, and run one normal sync:
 ```sh
 cargo install --locked --force research
 research --version
-research sync
+research sync run
 ```
 
 The expected version is `research 2.1.0`. The first sync of an existing


### PR DESCRIPTION
## Summary

Correct the v2.1.0 upgrade example to invoke the required `run` sync subcommand.

The public GitHub release body has already been corrected. This keeps the checked-in historical release note and hosted guide consistent.

## Verification

- `git diff --check`
- `research sync --help` confirms `run` is the one-shot synchronization command

Refs #132