### PR TITLE
Restore explicit Firecrawl excerpt replacement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "research"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "base64",
  "chrono",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "research-domain"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "base64",
  "chrono",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "research-store"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 rust-version = "1.94"
 keywords = ["bookmarks", "reading-list", "local-first", "knowledge", "cli"]
@@ -22,8 +22,8 @@ crossterm = "0.29.0"
 directories = "6.0.0"
 ratatui = { version = "0.30.2", default-features = false, features = ["crossterm_0_29"] }
 reqwest = { version = "0.13.4", features = ["json"] }
-research-domain = { version = "=2.1.0", path = "crates/research-domain" }
-research-store = { version = "=2.1.0", path = "crates/research-store" }
+research-domain = { version = "=2.1.1", path = "crates/research-domain" }
+research-store = { version = "=2.1.1", path = "crates/research-store" }
 scraper = "0.27.0"
 serde = "1.0.228"
 serde_json = "1.0.150"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ accept one, install [Rust](https://www.rust-lang.org/tools/install) and build th
 matching release tag from source instead of weakening system-wide security:
 
 ```sh
-git clone --branch v2.1.0 --depth 1 \
+git clone --branch v2.1.1 --depth 1 \
   https://github.com/ResearchPocket/researchpocket.github.io.git
 cd researchpocket.github.io
 cargo build --locked --release

--- a/crates/research-domain/Cargo.toml
+++ b/crates/research-domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research-domain"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 rust-version = "1.94"
 authors = ["KorigamiK <korigamik.is-a.dev>"]

--- a/crates/research-store/Cargo.toml
+++ b/crates/research-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research-store"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 rust-version = "1.94"
 authors = ["KorigamiK <korigamik.is-a.dev>"]
@@ -11,7 +11,7 @@ description = "Local SQLite projection, import, enrichment, and outbox for Resea
 [dependencies]
 base64 = "0.22.1"
 chrono = { version = "0.4.45", default-features = false, features = ["clock", "serde"] }
-research-domain = { version = "=2.1.0", path = "../research-domain" }
+research-domain = { version = "=2.1.1", path = "../research-domain" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 sha2 = "0.11.0"

--- a/crates/research-store/migrations/0008_explicit_excerpt_replacement.sql
+++ b/crates/research-store/migrations/0008_explicit_excerpt_replacement.sql
@@ -1,0 +1,6 @@
+-- Firecrawl normally writes its full-page Markdown as a captured document.
+-- Preserve the owner's explicit `--replace-excerpt` intent across leases and
+-- retries so that one deliberate run may also replace the authored excerpt.
+ALTER TABLE item_enrichment_jobs
+    ADD COLUMN replace_excerpt INTEGER NOT NULL DEFAULT 0
+        CHECK (replace_excerpt IN (0, 1));

--- a/crates/research-store/src/enrichment.rs
+++ b/crates/research-store/src/enrichment.rs
@@ -268,14 +268,15 @@ async fn queue_enrichment_on_connection_with_options(
     let updated = sqlx::query(
         "INSERT INTO item_enrichment_jobs \
          (item_id, provider, status, attempts, target_title, target_excerpt, target_language, \
-          expected_title_revision, expected_excerpt_text, expected_language_revision, \
+          replace_excerpt, expected_title_revision, expected_excerpt_text, \
+          expected_language_revision, \
           queued_at, updated_at, next_attempt_at, last_attempt_at, completed_at, lease_token, \
           lease_expires_at, last_error_kind) \
-         VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL, NULL, NULL) \
+         VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL, NULL, NULL) \
          ON CONFLICT(item_id) DO UPDATE SET \
           provider = excluded.provider, status = excluded.status, attempts = 0, \
           target_title = excluded.target_title, target_excerpt = excluded.target_excerpt, \
-          target_language = excluded.target_language, \
+          target_language = excluded.target_language, replace_excerpt = excluded.replace_excerpt, \
           expected_title_revision = excluded.expected_title_revision, \
           expected_excerpt_text = excluded.expected_excerpt_text, \
           expected_language_revision = excluded.expected_language_revision, \
@@ -291,6 +292,7 @@ async fn queue_enrichment_on_connection_with_options(
     .bind(targets.title_revision.is_some())
     .bind(targets.excerpt_text.is_some())
     .bind(targets.language_revision.is_some())
+    .bind(replace_excerpt)
     .bind(&targets.title_revision)
     .bind(&targets.excerpt_text)
     .bind(&targets.language_revision)
@@ -339,7 +341,12 @@ async fn apply_enrichment_on_connection(
                 create_captured_document(markdown, "firecrawl", expected_url, &now_rfc3339())
             })
             .transpose()?;
-        (None, artifact)
+        let excerpt = if current_job.replace_excerpt {
+            fetched_context.clone()
+        } else {
+            None
+        };
+        (excerpt, artifact)
     } else {
         (fetched_context, None)
     };
@@ -352,11 +359,13 @@ async fn apply_enrichment_on_connection(
                 == Some(current_item.language.winner.as_str())
     });
     let applied_title = title.is_some();
-    let applied_excerpt = excerpt.is_some() || captured_document.is_some();
+    let applied_excerpt = excerpt.is_some();
+    let applied_captured_document = captured_document.is_some();
     // Remembered so a later re-queue can tell this excerpt came from a provider.
     let applied_excerpt_text = excerpt.clone();
     let applied_language = language.is_some();
-    let applied_any = applied_title || applied_excerpt || applied_language;
+    let applied_any =
+        applied_title || applied_excerpt || applied_captured_document || applied_language;
 
     let item = if applied_any {
         let mutation_item_id = item_id.to_owned();
@@ -449,6 +458,7 @@ async fn apply_enrichment_on_connection(
         job,
         applied_title,
         applied_excerpt,
+        applied_captured_document,
         applied_language,
     })
 }
@@ -629,7 +639,7 @@ async fn optional_enrichment_job_record(
 ) -> StoreResult<Option<EnrichmentJobRecord>> {
     sqlx::query_as::<_, EnrichmentJobRow>(
         "SELECT item_id, provider, status, attempts, target_title, target_excerpt, \
-         target_language, expected_title_revision, expected_excerpt_text, \
+         target_language, replace_excerpt, expected_title_revision, expected_excerpt_text, \
          expected_language_revision, queued_at, updated_at, next_attempt_at, last_attempt_at, \
          completed_at, lease_token, lease_expires_at, last_error_kind \
          FROM item_enrichment_jobs WHERE item_id = ?",
@@ -765,6 +775,7 @@ struct EnrichmentJobRow {
     target_title: bool,
     target_excerpt: bool,
     target_language: bool,
+    replace_excerpt: bool,
     expected_title_revision: Option<String>,
     expected_excerpt_text: Option<String>,
     expected_language_revision: Option<String>,
@@ -780,6 +791,7 @@ struct EnrichmentJobRow {
 
 struct EnrichmentJobRecord {
     job: EnrichmentJob,
+    replace_excerpt: bool,
     expected_title_revision: Option<String>,
     expected_excerpt_text: Option<String>,
     expected_language_revision: Option<String>,
@@ -817,6 +829,7 @@ impl TryFrom<EnrichmentJobRow> for EnrichmentJobRecord {
                 completed_at: row.completed_at,
                 last_error_kind: row.last_error_kind,
             },
+            replace_excerpt: row.replace_excerpt,
             expected_title_revision: row.expected_title_revision,
             expected_excerpt_text: row.expected_excerpt_text,
             expected_language_revision: row.expected_language_revision,

--- a/crates/research-store/src/model.rs
+++ b/crates/research-store/src/model.rs
@@ -141,6 +141,7 @@ pub struct EnrichmentApplyResult {
     pub job: EnrichmentJob,
     pub applied_title: bool,
     pub applied_excerpt: bool,
+    pub applied_captured_document: bool,
     pub applied_language: bool,
 }
 

--- a/crates/research-store/tests/local_mutation_contract.rs
+++ b/crates/research-store/tests/local_mutation_contract.rs
@@ -5,8 +5,7 @@ use research_store::{
 };
 
 #[tokio::test]
-async fn firecrawl_reenrichment_replaces_captured_content_without_overwriting_authored_excerpt()
-{
+async fn firecrawl_reenrichment_replaces_excerpt_only_when_explicitly_requested() {
     let directory = tempfile::tempdir().expect("library temp directory");
     let store = V2Store::init(directory.path().join("library"))
         .await
@@ -44,7 +43,8 @@ async fn firecrawl_reenrichment_replaces_captured_content_without_overwriting_au
         )
         .await
         .expect("apply initial enrichment");
-    assert!(first.applied_excerpt);
+    assert!(!first.applied_excerpt);
+    assert!(first.applied_captured_document);
     assert!(first.item.excerpt.is_none());
     let first_reference = first
         .item
@@ -63,12 +63,12 @@ async fn firecrawl_reenrichment_replaces_captured_content_without_overwriting_au
     let requeued = store
         .queue_item_enrichment(&item.id, EnrichmentProvider::Firecrawl)
         .await
-        .expect("requeue enrichment-owned excerpt");
+        .expect("requeue captured content");
     assert!(requeued.target_excerpt);
     let second_claim = store
         .claim_item_enrichment(&item.id)
         .await
-        .expect("claim replacement enrichment");
+        .expect("claim captured-content refresh");
     let replaced = store
         .apply_item_enrichment(
             &item.id,
@@ -81,7 +81,9 @@ async fn firecrawl_reenrichment_replaces_captured_content_without_overwriting_au
             },
         )
         .await
-        .expect("replace enrichment-owned excerpt");
+        .expect("refresh captured content");
+    assert!(!replaced.applied_excerpt);
+    assert!(replaced.applied_captured_document);
     assert!(replaced.item.excerpt.is_none());
     let replaced_reference = replaced
         .item
@@ -143,6 +145,7 @@ async fn firecrawl_reenrichment_replaces_captured_content_without_overwriting_au
         .await
         .expect("complete stale replacement safely");
     assert!(!stale.applied_excerpt);
+    assert!(!stale.applied_captured_document);
     assert_eq!(
         stale.item.excerpt.as_deref(),
         Some("Newer authored context")
@@ -152,10 +155,22 @@ async fn firecrawl_reenrichment_replaces_captured_content_without_overwriting_au
         .queue_item_enrichment_replacing_excerpt(&item.id, EnrichmentProvider::Firecrawl)
         .await
         .expect("queue replacement of current revision");
-    let replacement_claim = store
+    let failed_replacement_claim = store
         .claim_item_enrichment(&item.id)
         .await
         .expect("claim current replacement");
+    store
+        .record_enrichment_failure(
+            &item.id,
+            &failed_replacement_claim.lease_token,
+            "request_timeout",
+        )
+        .await
+        .expect("record a retryable replacement failure");
+    let replacement_claim = store
+        .claim_item_enrichment(&item.id)
+        .await
+        .expect("reclaim replacement without losing its intent");
     let replacement = store
         .apply_item_enrichment(
             &item.id,
@@ -170,10 +185,8 @@ async fn firecrawl_reenrichment_replaces_captured_content_without_overwriting_au
         .await
         .expect("replace unchanged authored excerpt explicitly");
     assert!(replacement.applied_excerpt);
-    assert_eq!(
-        replacement.item.excerpt.as_deref(),
-        Some("Newer authored context")
-    );
+    assert!(replacement.applied_captured_document);
+    assert_eq!(replacement.item.excerpt.as_deref(), Some("# Fresh parse"));
     let fresh_reference = replacement
         .item
         .captured_document

--- a/docs/releases/v2.1.1.md
+++ b/docs/releases/v2.1.1.md
@@ -1,0 +1,65 @@
+# ResearchPocket 2.1.1
+
+ResearchPocket 2.1.1 restores the explicit Firecrawl excerpt-replacement
+contract and corrects enrichment reporting.
+
+## Install
+
+With Rust installed:
+
+```sh
+cargo install --locked --force research
+```
+
+Or download the verified archive for Linux, macOS, or Windows from the GitHub
+release and check it against `SHA256SUMS`.
+
+## What changed
+
+- `research enrich run <item-id> --provider firecrawl --replace-excerpt` now
+  replaces the excerpt with the fetched Markdown when the excerpt remains
+  unchanged during the request.
+- The same Firecrawl response remains available as the item's immutable,
+  content-addressed captured document.
+- Explicit replacement intent survives local leases and retries.
+- An ordinary Firecrawl refresh still preserves the authored excerpt and now
+  reports `captured_document` instead of incorrectly reporting `excerpt`.
+- Concurrent excerpt edits continue to win: stale Firecrawl results update
+  neither the excerpt nor its captured-document reference.
+
+There is no domain-schema or synchronization-protocol change. A forward,
+local-only SQLite migration records explicit replacement intent. Once a library
+has been opened by 2.1.1, keep using 2.1.1 or newer with that local data
+directory; older binaries do not recognize newer local migrations. The private
+sync repository remains compatible.
+
+## Upgrade
+
+Replace the 2.1.0 binary or run:
+
+```sh
+cargo install --locked --force research
+research --version
+```
+
+The expected version is `research 2.1.1`. Existing libraries migrate
+automatically on first open.
+
+## GitHub release archives
+
+| Platform | Release asset |
+| --- | --- |
+| Linux GNU/glibc x86-64 (glibc 2.35 or newer) | `research-v2.1.1-linux-amd64.tar.gz` |
+| Windows x86-64 | `research-v2.1.1-windows-amd64.zip` |
+| macOS Intel | `research-v2.1.1-macos-amd64.tar.gz` |
+| macOS Apple Silicon | `research-v2.1.1-macos-arm64.tar.gz` |
+
+The archives remain unsigned. Verify the selected file with `SHA256SUMS`, or
+build the exact tag with the pinned toolchain:
+
+```sh
+git clone --branch v2.1.1 --depth 1 \
+  https://github.com/ResearchPocket/researchpocket.github.io.git
+cd researchpocket.github.io
+cargo build --locked --release
+```

--- a/docs/v2/ADR_0004_BOUNDED_FIRECRAWL_MARKDOWN.md
+++ b/docs/v2/ADR_0004_BOUNDED_FIRECRAWL_MARKDOWN.md
@@ -60,11 +60,12 @@ and field policy.
 
 ## Consequences
 
-ADR 0010 supersedes the storage-location part of this decision. New Firecrawl
-Markdown is now an immutable content-addressed `CapturedDocument`; the authored
-excerpt remains editable and is no longer replaced by Firecrawl. The bounds,
-normalization, private-by-default policy, and Reader safety decisions here
-remain in force.
+ADR 0010 supersedes the default storage-location part of this decision. New
+Firecrawl Markdown is now an immutable content-addressed `CapturedDocument`;
+the authored excerpt remains editable and is not replaced during ordinary
+enrichment. The explicit `--replace-excerpt` action remains the deliberate
+exception described above. The bounds, normalization, private-by-default
+policy, and Reader safety decisions here remain in force.
 
 - A private library, checkpoint, restore, export, and sync history may be much
   larger than a URL-and-metadata-only library.

--- a/docs/v2/ADR_0010_BOUNDED_ITEM_SCOPED_SYNC.md
+++ b/docs/v2/ADR_0010_BOUNDED_ITEM_SCOPED_SYNC.md
@@ -98,7 +98,11 @@ embed them.
 The authored excerpt remains an item field. Existing v1 excerpts remain
 lossless. Migration may externalize an excerpt only when durable enrichment
 provenance proves it is fetched content; ambiguous authored values remain
-excerpt text. New Firecrawl enrichment writes `CapturedDocument`, not excerpt.
+excerpt text. New Firecrawl enrichment writes `CapturedDocument`, not excerpt,
+by default. The owner's explicit `--replace-excerpt` action deliberately writes
+the fetched Markdown to both locations when the excerpt text observed before
+network access is still current. That intent is durable across enrichment
+retries.
 
 Captured documents use a private immutable path:
 

--- a/docs/v2/CLI.md
+++ b/docs/v2/CLI.md
@@ -102,8 +102,9 @@ observed at queue time instead. A later human clear/edit and a concurrent
 unsynchronized human revision both win. `--title ""` and `--language ""` are
 authored values and are not replaced; `--excerpt ""` leaves the excerpt blank,
 which merged text cannot distinguish from unset, so enrichment may still fill
-it. Firecrawl is the exception: its full Markdown is stored separately as
-private captured content and never replaces the authored excerpt.
+it. Firecrawl stores its full Markdown separately as private captured content
+by default. It replaces the authored excerpt only when the owner explicitly
+passes `--replace-excerpt`.
 
 ### Direct public-HTML provider
 
@@ -145,16 +146,17 @@ proxy tier.
 Passing an item ID and `--provider firecrawl` refreshes its captured document.
 The authored excerpt remains untouched.
 
-The historical `--replace-excerpt` flag now means “force a fresh parse” for
-compatibility with existing scripts:
+Pass `--replace-excerpt` when the fresh parse should also replace the authored
+excerpt:
 
 ```sh
 research enrich run <item-id> --provider firecrawl --replace-excerpt
 ```
 
-The job records the current authored excerpt before network access. If that
-context changes while Firecrawl is running, the fetched result is skipped; a
-subsequent run can capture the page without replacing that context.
+The job records the current authored excerpt before network access and preserves
+that replacement intent across local retries. If the excerpt changes while
+Firecrawl is running, neither the captured document nor the excerpt is updated;
+a subsequent run may explicitly replace the newer excerpt.
 
 Store the key in a separate per-library file without placing it in process
 arguments or shell history:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -170,7 +170,7 @@ pub struct EnrichRunArgs {
     #[arg(long, value_enum, value_name = "PROVIDER")]
     pub provider: Option<EnrichmentProviderArg>,
 
-    /// Force a fresh parse; retained name for compatibility (authored excerpt is preserved)
+    /// Force a fresh parse and replace the excerpt if it stays unchanged during the request
     #[arg(long, requires = "item_id")]
     pub replace_excerpt: bool,
 

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -573,6 +573,9 @@ async fn attempt_enrichment(
             if applied.applied_excerpt {
                 applied_fields.push("excerpt");
             }
+            if applied.applied_captured_document {
+                applied_fields.push("captured_document");
+            }
             if applied.applied_language {
                 applied_fields.push("language");
             }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "research-pocket-web",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "research-pocket-web",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "highlight.js": "11.11.1",
         "idb": "8.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "research-pocket-web",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "scripts": {
     "dev": "npm run wasm && vite",


### PR DESCRIPTION
Closes #135.

## Summary

- persist explicit `--replace-excerpt` intent across enrichment leases and retries
- write Firecrawl Markdown to both the excerpt and captured document only for an unchanged explicit replacement
- report ordinary captured-document writes separately from excerpt writes
- add the forward SQLite migration and regression coverage
- prepare the lockstep `v2.1.1` native/web patch release

## User-visible impact

`research enrich run <item-id> --provider firecrawl --replace-excerpt` once again does what it says. Ordinary Firecrawl refreshes still preserve authored excerpts and now report `captured_document` accurately.

## Protocol and migration impact

There is no domain-schema or synchronization-protocol change. Migration 0008 adds one local-only boolean to durable enrichment jobs. A migrated local directory requires 2.1.1 or newer; the private sync repository remains compatible.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-targets --all-features`
- `cargo audit --deny warnings`
- `cargo build --locked --release`
- `npm run verify`
- `cargo package --locked --no-verify --allow-dirty -p research-domain`
- release binary reports `research 2.1.1`
- real Firecrawl replacement on the reported item succeeded; persisted excerpt and captured Markdown were byte-for-byte equal without printing private content