### PR TITLE
Make PWA controls tactile and mobile-responsive

### DIFF
--- a/docs/v2/DESIGN_SYSTEM.md
+++ b/docs/v2/DESIGN_SYSTEM.md
@@ -50,7 +50,9 @@ must have text labels. Color may reinforce state but may not be its only signal.
 
 The interface uses no animations or transitions. Feedback is immediate state,
 text, focus, or a native dialog. Functionality must not depend on hover, motion,
-or a pointer device.
+or a pointer device. A pressed control may change position by at most the
+`--control-press-offset` token while the pointer is down; reduced-motion mode
+keeps the non-positional surface cue and removes that offset.
 
 ### Self-hosted type, native controls
 
@@ -145,6 +147,23 @@ Primary buttons are reserved for the one committing action in a form or task.
 Secondary buttons cancel or remove temporary access. Text actions are suitable
 for record-level edit, restore, and delete controls. Controls use the compact
 system height, remain content-sized, and retain a visible focus outline.
+
+Button tactility takes interaction inspiration from the frontend of
+[Datastar](https://data-star.dev/), inspected on 2026-07-29. Its controls use a
+prominent lower/right inset edge at rest, then invert that edge and redistribute
+content padding while pressed. ResearchPocket adapts the interaction rather
+than the visual brand: a two-pixel internal edge flips from lower/right to
+upper/left, while the control settles by one pixel for a fine pointer and two
+pixels for a coarse pointer. The internal edge and positional offset never
+change layout dimensions.
+
+Pressed, disabled, focus-visible, selected, and hover states remain separate.
+Hover-only decoration is limited to devices with a fine pointer and real hover,
+so touch devices do not retain a sticky hover state after release. Disabled and
+busy controls never receive a pressed transform. Reduced-motion mode removes
+the positional offset while preserving the immediate edge and color change.
+This pattern uses native CSS only: no animation library, vibration, audio,
+decorative shadow, gradient, or third-party runtime asset.
 
 ### Fields
 

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -762,9 +762,11 @@
   color: var(--color-inverse);
 }
 
-.primary-button:hover:not(:disabled) {
-  background: var(--color-accent-strong);
-  border-color: var(--color-accent-strong);
+@media (hover: hover) and (pointer: fine) {
+  .primary-button:hover:not(:disabled) {
+    background: var(--color-accent-strong);
+    border-color: var(--color-accent-strong);
+  }
 }
 
 .secondary-button,
@@ -1112,12 +1114,20 @@ footer,
   z-index: 1;
 }
 
-.item-card-edit-trigger:hover ~ .item-row-copy h3,
 .item-card-edit-trigger:focus-visible ~ .item-row-copy h3 {
   color: var(--color-accent-strong);
   text-decoration: underline;
   text-decoration-thickness: 0.125rem;
   text-underline-offset: 0.2em;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .item-card-edit-trigger:hover ~ .item-row-copy h3 {
+    color: var(--color-accent-strong);
+    text-decoration: underline;
+    text-decoration-thickness: 0.125rem;
+    text-underline-offset: 0.2em;
+  }
 }
 
 .item-card-edit-trigger:focus-visible {
@@ -1175,10 +1185,15 @@ footer,
   text-underline-offset: 0.2em;
 }
 
-.item-inline-tag:hover,
 .item-inline-tag:focus-visible,
 .item-inline-tag[aria-pressed="true"] {
   background: var(--color-accent-soft);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .item-inline-tag:hover {
+    background: var(--color-accent-soft);
+  }
 }
 
 .item-inline-tag:focus-visible {
@@ -1210,7 +1225,6 @@ footer,
   width: 2rem;
 }
 
-.icon-button:hover:not(:disabled),
 .icon-button:focus-visible,
 .icon-button[aria-pressed="true"] {
   background: var(--color-accent-soft);
@@ -1218,14 +1232,28 @@ footer,
   color: var(--color-accent-strong);
 }
 
+@media (hover: hover) and (pointer: fine) {
+  .icon-button:hover:not(:disabled) {
+    background: var(--color-accent-soft);
+    border-color: var(--color-accent);
+    color: var(--color-accent-strong);
+  }
+}
+
 .icon-button.danger-button {
   color: var(--color-danger);
 }
 
-.icon-button.danger-button:hover:not(:disabled),
 .icon-button.danger-button:focus-visible {
   background: var(--color-danger-soft);
   border-color: var(--color-danger);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .icon-button.danger-button:hover:not(:disabled) {
+    background: var(--color-danger-soft);
+    border-color: var(--color-danger);
+  }
 }
 
 .empty-state {
@@ -1834,6 +1862,17 @@ footer {
   *::after {
     scroll-behavior: auto !important;
   }
+
+  .app-shell
+    :where(
+      button:not(.item-card-edit-trigger),
+      a.icon-button
+    ):active:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]),
+  .onboarding-choice:active:not(:disabled):not([aria-disabled="true"]):not(
+    [aria-busy="true"]
+  ) {
+    translate: none !important;
+  }
 }
 
 /* Owner workspace redesign */
@@ -1861,6 +1900,128 @@ footer {
 .app-shell button {
   font-size: var(--font-size-xs);
   min-height: 2rem;
+}
+
+.app-shell :where(button:not(.item-card-edit-trigger), a.icon-button) {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.app-shell
+  :where(
+    button:not(.item-card-edit-trigger),
+    a.icon-button
+  ):active:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]) {
+  translate: 0 var(--control-press-offset);
+}
+
+.app-shell
+  :where(
+    .secondary-button,
+    .text-button,
+    .close-button,
+    .command-trigger,
+    .search-clear,
+    .tag-filter-options button,
+    .tag-suggestions button,
+    .selected-tags button,
+    .item-inline-tag,
+    .icon-button,
+    .workspace-nav button,
+    .rail-nav button,
+    .rail-tag-list button,
+    .rail-utilities button,
+    .rail-heading button,
+    .density-controls button,
+    .command-results button,
+    .reader-list > header button,
+    .reader-list li button,
+    .reader-meta button,
+    .reader-markdown-image-consent button,
+    .mobile-tag-filter-trigger
+  ):active:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]) {
+  background: var(--color-control-pressed);
+  border-color: var(--color-accent);
+  color: var(--color-accent-strong);
+}
+
+.app-shell
+  :where(
+    .primary-button,
+    .mobile-filter-heading button
+  ):active:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]) {
+  background: var(--color-control-primary-pressed);
+  border-color: var(--color-control-primary-pressed);
+}
+
+.app-shell
+  .icon-button.danger-button:active:not(:disabled):not([aria-disabled="true"]):not(
+    [aria-busy="true"]
+  ) {
+  background: var(--color-danger-soft);
+  border-color: var(--color-danger);
+  color: var(--color-danger);
+}
+
+:where(
+  .primary-button,
+  .secondary-button,
+  .command-trigger,
+  .mobile-tag-filter-trigger,
+  .mobile-filter-heading button,
+  .reader-markdown-image-consent button,
+  .reader-image-viewer-close,
+  .onboarding-choice
+) {
+  --control-edge-color: var(--color-control-edge);
+
+  position: relative;
+}
+
+:where(
+  .primary-button,
+  .secondary-button,
+  .command-trigger,
+  .mobile-tag-filter-trigger,
+  .mobile-filter-heading button,
+  .reader-markdown-image-consent button,
+  .reader-image-viewer-close,
+  .onboarding-choice
+)::after {
+  border-bottom: var(--control-press-depth) solid var(--control-edge-color);
+  border-right: var(--control-press-depth) solid var(--control-edge-color);
+  content: "";
+  inset: var(--rule);
+  pointer-events: none;
+  position: absolute;
+}
+
+:where(
+  .primary-button,
+  .secondary-button,
+  .command-trigger,
+  .mobile-tag-filter-trigger,
+  .mobile-filter-heading button,
+  .reader-markdown-image-consent button,
+  .reader-image-viewer-close,
+  .onboarding-choice
+):active:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"])::after {
+  border: 0;
+  border-left: var(--control-press-depth) solid var(--control-edge-color);
+  border-top: var(--control-press-depth) solid var(--control-edge-color);
+}
+
+.primary-button,
+.mobile-filter-heading button {
+  --control-edge-color: var(--color-inverse);
+}
+
+.onboarding-choice:active:not(:disabled):not([aria-disabled="true"]):not(
+    [aria-busy="true"]
+  ) {
+  background: var(--color-control-pressed);
+  border-color: var(--color-accent);
+  translate: 0 var(--control-press-offset);
 }
 
 .masthead {
@@ -2217,9 +2378,14 @@ kbd {
   opacity: 0.45;
 }
 
-.item-card:hover .item-row-actions,
 .item-card:focus-within .item-row-actions {
   opacity: 1;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .item-card:hover .item-row-actions {
+    opacity: 1;
+  }
 }
 
 .keyboard-footer {
@@ -2344,10 +2510,16 @@ kbd {
   width: 100%;
 }
 
-.command-results button:hover,
 .command-results .command-selected {
   background: var(--color-accent-soft);
   border-left-color: var(--color-accent-strong);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .command-results button:hover {
+    background: var(--color-accent-soft);
+    border-left-color: var(--color-accent-strong);
+  }
 }
 
 .command-results strong,

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -38,6 +38,11 @@ input[type="checkbox"] {
   touch-action: manipulation;
 }
 
+button {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
 button,
 a {
   -webkit-tap-highlight-color: transparent;

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -65,6 +65,21 @@
   --color-focus: color-mix(in srgb, var(--accent) 62%, var(--text));
   --color-inverse: var(--background);
   --color-inverse-surface: var(--primary);
+  --color-control-edge: color-mix(
+    in srgb,
+    var(--color-border-strong) 78%,
+    var(--color-canvas)
+  );
+  --color-control-pressed: color-mix(
+    in srgb,
+    var(--color-accent) 18%,
+    var(--color-surface-raised)
+  );
+  --color-control-primary-pressed: color-mix(
+    in srgb,
+    var(--color-accent) 18%,
+    var(--color-inverse-surface)
+  );
 
   --font-size-xs: 0.75rem;
   --font-size-sm: 0.8125rem;
@@ -84,6 +99,8 @@
   --space-8: 2.5rem;
 
   --control-height: 2.5rem;
+  --control-press-depth: 0.125rem;
+  --control-press-offset: 0.0625rem;
   --measure: 72ch;
   --page-width: 100rem;
   --rule: 1px;
@@ -93,6 +110,7 @@
 @media (pointer: coarse) {
   :root {
     --control-height: 2.75rem;
+    --control-press-offset: 0.125rem;
   }
 }
 


### PR DESCRIPTION
Closes #137

## Summary

- add immediate tactile press feedback across owner-app buttons, button-like controls, and mobile actions
- adapt Datastar’s inset-edge interaction to ResearchPocket’s compact no-shadow design language
- use a 2 px touch offset and 1 px fine-pointer offset without changing control dimensions
- keep hover effects off coarse pointers and preserve distinct focus, selected, disabled, busy, danger, and reduced-motion states
- document the frontend reference and reusable interaction contract

## User-visible impact

Buttons and mobile controls now acknowledge a press immediately with an internal edge inversion, pressed color, and pointer-appropriate positional cue. Touch interactions no longer retain the owner app’s affected hover-only presentation after release. Layout, control height, labels, and action behavior are unchanged.

## Protocol, privacy, and compatibility

No domain, CRDT, persistence, synchronization, publication, credential, service-worker, schema, or protocol behavior changes. The implementation is first-party CSS and adds no dependency or runtime request.

## Verification

- `cd web && npm run verify`
- Chrome mobile emulation at 320 px and 390 px: no horizontal overflow
- captured a real coarse-pointer `pointerdown`: 2 px translation, lower/right edge replaced by upper/left edge, unchanged 36 px control height
- captured a real fine-pointer `pointerdown`: 1 px translation with the same edge inversion
- verified mobile **Save a link** still opens the native capture dialog and moves focus to the URL field
- verified keyboard focus retains the 3 px visible outline

## UI evidence

Manual browser inspection covered initialized-empty library, first-run onboarding, mobile bottom actions, capture dialog, desktop command control, resting/pressed states, and the 320 px minimum-width contract in the canonical dark theme.