### PR TITLE
Make the v2 aggregate catalogue kind-aware and fail closed

### DIFF
--- a/crates/research-domain/src/aggregate.rs
+++ b/crates/research-domain/src/aggregate.rs
@@ -16,6 +16,16 @@ pub const ITEM_AGGREGATES_FEATURE: &str = "item-aggregates-v2";
 pub const AGGREGATE_GENESIS_PATH: &str = "sync/v2/library.json";
 pub const AGGREGATE_OPS_ROOT: &str = "sync/v2/ops/";
 pub const AGGREGATE_CHECKPOINTS_ROOT: &str = "sync/v2/checkpoints/";
+pub const AGGREGATE_CATALOGUE_PREFIX: &str = "sync/v2/catalogue/";
+
+/// Location of a catalogue.
+///
+/// Genesis binds the catalogue by hash rather than by name, so the artifact is
+/// addressed by that same hash. A catalogue is immutable like every other v2
+/// object: a new library state produces a new path, never a rewrite.
+pub fn aggregate_catalogue_path(catalogue_sha256: &str) -> String {
+    format!("{AGGREGATE_CATALOGUE_PREFIX}{catalogue_sha256}.json")
+}
 pub const ITEM_OPS_PREFIX: &str = "sync/v2/ops/items/";
 pub const ITEM_CHECKPOINTS_PREFIX: &str = "sync/v2/checkpoints/items/";
 
@@ -395,6 +405,13 @@ pub struct AggregateCatalogue {
 }
 
 impl AggregateCatalogue {
+    /// Content-addressed location of this catalogue's exact serialized bytes.
+    pub fn path(&self) -> DomainResult<String> {
+        Ok(aggregate_catalogue_path(&sha256_hex(
+            serde_json::to_string(self)?.as_bytes(),
+        )))
+    }
+
     /// Validates a catalogue before any of its aggregates are trusted.
     ///
     /// Entries are required to be strictly ascending by `(kind, aggregate_id)`
@@ -408,7 +425,7 @@ impl AggregateCatalogue {
         validate_uuid_v7(expected_library_id, "expected library ID")?;
         if self.library_id != expected_library_id {
             return Err(DomainError::Integrity {
-                path: AGGREGATE_GENESIS_PATH.to_owned(),
+                path: self.path()?,
                 expected: expected_library_id.to_owned(),
                 actual: self.library_id.clone(),
             });
@@ -427,6 +444,8 @@ impl AggregateCatalogue {
             let expected_path = entry
                 .aggregate_kind
                 .checkpoint_path(&entry.aggregate_id, &entry.snapshot_sha256)?;
+            // Anchored on the entry's own checkpoint path, so a mismatch names
+            // the object a reader would go fetch.
             if entry.checkpoint_path != expected_path {
                 return Err(DomainError::Integrity {
                     path: entry.checkpoint_path.clone(),
@@ -468,21 +487,24 @@ impl AggregateGenesis {
         if self.protocol_version != AGGREGATE_PROTOCOL_VERSION {
             return Err(DomainError::UnsupportedProtocol(self.protocol_version));
         }
-        if !self
-            .required_features
-            .iter()
-            .any(|feature| feature == ITEM_AGGREGATES_FEATURE)
-        {
-            return Err(DomainError::UnsupportedFeature(
-                "missing-item-aggregates-v2".into(),
-            ));
-        }
+        // Unknown features are reported before exactness so a newer writer
+        // always surfaces as "upgrade", never as "malformed".
         if let Some(unknown) = self
             .required_features
             .iter()
             .find(|feature| feature.as_str() != ITEM_AGGREGATES_FEATURE)
         {
             return Err(DomainError::UnsupportedFeature(unknown.clone()));
+        }
+        if self.required_features.is_empty() {
+            return Err(DomainError::UnsupportedFeature(
+                "missing-item-aggregates-v2".into(),
+            ));
+        }
+        if self.required_features != [ITEM_AGGREGATES_FEATURE] {
+            return Err(DomainError::InvalidState(
+                "genesis required features are not canonical".into(),
+            ));
         }
         validate_uuid_v7(&self.library_id, "genesis library ID")?;
         validate_uuid_v7(expected_library_id, "expected library ID")?;
@@ -838,6 +860,17 @@ mod tests {
             genesis.validate(LIBRARY, &future),
             Err(DomainError::Integrity { .. })
         ));
+        let mut duplicated = genesis.clone();
+        duplicated
+            .required_features
+            .push(ITEM_AGGREGATES_FEATURE.to_owned());
+        assert!(
+            matches!(
+                duplicated.validate(LIBRARY, &migration.catalogue_json),
+                Err(DomainError::InvalidState(_))
+            ),
+            "a non-canonical feature list must not validate"
+        );
 
         let aggregate =
             ItemAggregate::from_canonical(ITEM, &item(), CHECKPOINT, 52).expect("aggregate");

--- a/crates/research-domain/src/aggregate.rs
+++ b/crates/research-domain/src/aggregate.rs
@@ -14,13 +14,85 @@ use crate::{
 pub const AGGREGATE_PROTOCOL_VERSION: u8 = 2;
 pub const ITEM_AGGREGATES_FEATURE: &str = "item-aggregates-v2";
 pub const AGGREGATE_GENESIS_PATH: &str = "sync/v2/library.json";
+pub const AGGREGATE_OPS_ROOT: &str = "sync/v2/ops/";
+pub const AGGREGATE_CHECKPOINTS_ROOT: &str = "sync/v2/checkpoints/";
 pub const ITEM_OPS_PREFIX: &str = "sync/v2/ops/items/";
 pub const ITEM_CHECKPOINTS_PREFIX: &str = "sync/v2/checkpoints/items/";
 
+/// Which kind of aggregate an operation, checkpoint, or catalogue entry
+/// describes.
+///
+/// An unrecognized kind deserializes into [`AggregateKind::Unsupported`] rather
+/// than failing to parse. That distinction matters: a client that cannot tell
+/// "written by a newer client" from "malformed" would either reject a valid
+/// repository or, worse, skip the entry and materialize a partial library.
+/// Carrying the unknown name lets every consumer fail closed with an
+/// upgrade-shaped error instead.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(from = "String", into = "String")]
 pub enum AggregateKind {
     Item,
+    Unsupported(String),
+}
+
+impl AggregateKind {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Item => "item",
+            Self::Unsupported(value) => value,
+        }
+    }
+
+    /// Repository path segment for this kind.
+    ///
+    /// Fails closed for a kind this build does not implement, which is what
+    /// stops an older client from writing to or reading around a namespace it
+    /// does not understand.
+    pub fn path_segment(&self) -> DomainResult<&'static str> {
+        match self {
+            Self::Item => Ok("items"),
+            Self::Unsupported(value) => {
+                Err(DomainError::UnsupportedAggregateKind(value.clone()))
+            }
+        }
+    }
+
+    pub fn ops_prefix(&self) -> DomainResult<String> {
+        Ok(format!("{AGGREGATE_OPS_ROOT}{}/", self.path_segment()?))
+    }
+
+    pub fn checkpoints_prefix(&self) -> DomainResult<String> {
+        Ok(format!(
+            "{AGGREGATE_CHECKPOINTS_ROOT}{}/",
+            self.path_segment()?
+        ))
+    }
+
+    pub fn checkpoint_path(
+        &self,
+        aggregate_id: &str,
+        snapshot_sha256: &str,
+    ) -> DomainResult<String> {
+        Ok(format!(
+            "{}{aggregate_id}/{snapshot_sha256}.json",
+            self.checkpoints_prefix()?
+        ))
+    }
+}
+
+impl From<String> for AggregateKind {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "item" => Self::Item,
+            _ => Self::Unsupported(value),
+        }
+    }
+}
+
+impl From<AggregateKind> for String {
+    fn from(value: AggregateKind) -> Self {
+        value.as_str().to_owned()
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -42,11 +114,14 @@ pub struct AggregateEnvelope {
 }
 
 impl AggregateEnvelope {
-    pub fn path(&self) -> String {
-        format!(
-            "{ITEM_OPS_PREFIX}{}/{}/{}.json",
-            self.aggregate_id, self.device_id, self.sequence
-        )
+    pub fn path(&self) -> DomainResult<String> {
+        Ok(format!(
+            "{}{}/{}/{}.json",
+            self.aggregate_kind.ops_prefix()?,
+            self.aggregate_id,
+            self.device_id,
+            self.sequence
+        ))
     }
 
     pub fn validate(
@@ -74,11 +149,7 @@ impl AggregateEnvelope {
                     .unwrap_or_else(|| "missing-item-aggregates-v2".into()),
             ));
         }
-        if self.aggregate_kind != AggregateKind::Item {
-            return Err(DomainError::InvalidState(
-                "unsupported aggregate kind".into(),
-            ));
-        }
+        self.aggregate_kind.path_segment()?;
         for (value, label) in [
             (self.aggregate_id.as_str(), "aggregate ID"),
             (self.library_id.as_str(), "library ID"),
@@ -96,10 +167,11 @@ impl AggregateEnvelope {
                 actual: format!("{}/{}", self.library_id, self.aggregate_id),
             });
         }
-        if path != self.path() {
+        let expected_path = self.path()?;
+        if path != expected_path {
             return Err(DomainError::Integrity {
                 path: path.to_owned(),
-                expected: self.path(),
+                expected: expected_path,
                 actual: path.to_owned(),
             });
         }
@@ -243,7 +315,7 @@ impl ItemAggregate {
             payload: STANDARD.encode(&update),
             payload_sha256: sha256_hex(&update),
         };
-        envelope.validate(&envelope.path(), library_id, &self.item_id)?;
+        envelope.validate(&envelope.path()?, library_id, &self.item_id)?;
         Ok(envelope)
     }
 
@@ -253,6 +325,11 @@ impl ItemAggregate {
         envelope: &AggregateEnvelope,
         expected_library_id: &str,
     ) -> DomainResult<bool> {
+        if envelope.aggregate_kind != AggregateKind::Item {
+            return Err(DomainError::UnsupportedAggregateKind(
+                envelope.aggregate_kind.as_str().to_owned(),
+            ));
+        }
         let payload = envelope.validate(path, expected_library_id, &self.item_id)?;
         self.library.import_update(&payload)
     }
@@ -300,6 +377,7 @@ impl ItemAggregateCheckpoint {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CatalogueEntry {
+    pub aggregate_kind: AggregateKind,
     pub aggregate_id: String,
     pub saved_at: i64,
     pub state: LifecycleState,
@@ -316,6 +394,59 @@ pub struct AggregateCatalogue {
     pub entries: Vec<CatalogueEntry>,
 }
 
+impl AggregateCatalogue {
+    /// Validates a catalogue before any of its aggregates are trusted.
+    ///
+    /// Entries are required to be strictly ascending by `(kind, aggregate_id)`
+    /// so the artifact is byte-identical for a given library state and so
+    /// duplicates cannot hide a second definition of one aggregate.
+    pub fn validate(&self, expected_library_id: &str) -> DomainResult<()> {
+        if self.protocol_version != AGGREGATE_PROTOCOL_VERSION {
+            return Err(DomainError::UnsupportedProtocol(self.protocol_version));
+        }
+        validate_uuid_v7(&self.library_id, "catalogue library ID")?;
+        validate_uuid_v7(expected_library_id, "expected library ID")?;
+        if self.library_id != expected_library_id {
+            return Err(DomainError::Integrity {
+                path: AGGREGATE_GENESIS_PATH.to_owned(),
+                expected: expected_library_id.to_owned(),
+                actual: self.library_id.clone(),
+            });
+        }
+        validate_sha256(
+            &self.migrated_from_v1_checkpoint,
+            "catalogue v1 checkpoint ID",
+        )?;
+        let mut previous: Option<(&str, &str)> = None;
+        for entry in &self.entries {
+            // Fails closed: a kind this build does not implement must stop the
+            // whole catalogue rather than materialize a partial library.
+            entry.aggregate_kind.path_segment()?;
+            validate_uuid_v7(&entry.aggregate_id, "catalogue aggregate ID")?;
+            validate_sha256(&entry.snapshot_sha256, "catalogue snapshot SHA-256")?;
+            let expected_path = entry
+                .aggregate_kind
+                .checkpoint_path(&entry.aggregate_id, &entry.snapshot_sha256)?;
+            if entry.checkpoint_path != expected_path {
+                return Err(DomainError::Integrity {
+                    path: entry.checkpoint_path.clone(),
+                    expected: expected_path,
+                    actual: entry.checkpoint_path.clone(),
+                });
+            }
+            let current = (entry.aggregate_kind.as_str(), entry.aggregate_id.as_str());
+            if previous.is_some_and(|previous| previous >= current) {
+                return Err(DomainError::InvalidState(
+                    "catalogue entries are not strictly ascending by kind and aggregate ID"
+                        .into(),
+                ));
+            }
+            previous = Some(current);
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AggregateGenesis {
@@ -325,6 +456,68 @@ pub struct AggregateGenesis {
     pub created_at: String,
     pub migrated_from_v1_checkpoint: String,
     pub catalogue_sha256: String,
+}
+
+impl AggregateGenesis {
+    /// Validates genesis and binds it to the exact catalogue bytes it declares.
+    pub fn validate(
+        &self,
+        expected_library_id: &str,
+        catalogue_json: &str,
+    ) -> DomainResult<AggregateCatalogue> {
+        if self.protocol_version != AGGREGATE_PROTOCOL_VERSION {
+            return Err(DomainError::UnsupportedProtocol(self.protocol_version));
+        }
+        if !self
+            .required_features
+            .iter()
+            .any(|feature| feature == ITEM_AGGREGATES_FEATURE)
+        {
+            return Err(DomainError::UnsupportedFeature(
+                "missing-item-aggregates-v2".into(),
+            ));
+        }
+        if let Some(unknown) = self
+            .required_features
+            .iter()
+            .find(|feature| feature.as_str() != ITEM_AGGREGATES_FEATURE)
+        {
+            return Err(DomainError::UnsupportedFeature(unknown.clone()));
+        }
+        validate_uuid_v7(&self.library_id, "genesis library ID")?;
+        validate_uuid_v7(expected_library_id, "expected library ID")?;
+        if self.library_id != expected_library_id {
+            return Err(DomainError::Integrity {
+                path: AGGREGATE_GENESIS_PATH.to_owned(),
+                expected: expected_library_id.to_owned(),
+                actual: self.library_id.clone(),
+            });
+        }
+        validate_utc(&self.created_at, "aggregate genesis creation time")?;
+        validate_sha256(
+            &self.migrated_from_v1_checkpoint,
+            "genesis v1 checkpoint ID",
+        )?;
+        validate_sha256(&self.catalogue_sha256, "genesis catalogue SHA-256")?;
+        let actual = sha256_hex(catalogue_json.as_bytes());
+        if actual != self.catalogue_sha256 {
+            return Err(DomainError::Integrity {
+                path: AGGREGATE_GENESIS_PATH.to_owned(),
+                expected: self.catalogue_sha256.clone(),
+                actual,
+            });
+        }
+        let catalogue: AggregateCatalogue = serde_json::from_str(catalogue_json)?;
+        catalogue.validate(expected_library_id)?;
+        if catalogue.migrated_from_v1_checkpoint != self.migrated_from_v1_checkpoint {
+            return Err(DomainError::Integrity {
+                path: AGGREGATE_GENESIS_PATH.to_owned(),
+                expected: self.migrated_from_v1_checkpoint.clone(),
+                actual: catalogue.migrated_from_v1_checkpoint,
+            });
+        }
+        Ok(catalogue)
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -358,6 +551,7 @@ pub fn create_aggregate_migration(
         };
         let checkpoint_path = checkpoint.path();
         entries.push(CatalogueEntry {
+            aggregate_kind: AggregateKind::Item,
             aggregate_id: item_id.clone(),
             saved_at: item.saved_at.value,
             state: item.lifecycle.state,
@@ -372,6 +566,7 @@ pub fn create_aggregate_migration(
         migrated_from_v1_checkpoint: v1_checkpoint_id.to_owned(),
         entries,
     };
+    catalogue.validate(library_id)?;
     let catalogue_json = serde_json::to_string(&catalogue)?;
     let catalogue_sha256 = sha256_hex(catalogue_json.as_bytes());
     let genesis = AggregateGenesis {
@@ -382,8 +577,10 @@ pub fn create_aggregate_migration(
         migrated_from_v1_checkpoint: v1_checkpoint_id.to_owned(),
         catalogue_sha256: catalogue_sha256.clone(),
     };
+    let genesis_json = serde_json::to_string(&genesis)?;
+    genesis.validate(library_id, &catalogue_json)?;
     Ok(AggregateMigration {
-        genesis_json: serde_json::to_string(&genesis)?,
+        genesis_json,
         catalogue_json,
         catalogue_sha256,
         checkpoints,
@@ -531,7 +728,8 @@ mod tests {
         let envelope = aggregate
             .export_envelope(&before, LIBRARY, DEVICE, 1, "2026-07-28T00:00:01Z")
             .expect("envelope");
-        assert!(envelope.path().contains(ITEM));
+        let path = envelope.path().expect("path");
+        assert!(path.contains(ITEM));
         assert!(
             !serde_json::to_string(&envelope)
                 .unwrap()
@@ -539,7 +737,7 @@ mod tests {
         );
 
         let base = ItemAggregate::from_snapshot(ITEM, &base_snapshot, 22).expect("base");
-        base.import_envelope(&envelope.path(), &envelope, LIBRARY)
+        base.import_envelope(&path, &envelope, LIBRARY)
             .expect("apply");
         assert_eq!(
             base.canonical_item().unwrap().title.value.as_deref(),
@@ -577,6 +775,91 @@ mod tests {
         let (path, json) = &migration.checkpoints[0];
         let checkpoint: ItemAggregateCheckpoint = serde_json::from_str(json).unwrap();
         checkpoint.validate(path, 32).expect("checkpoint");
+    }
+
+    /// A newer client's aggregate kind must stop an older client outright.
+    ///
+    /// Ignoring the entry would silently materialize a partial library, which
+    /// is the failure mode the fail-closed migration boundary exists to
+    /// prevent.
+    #[test]
+    fn unknown_aggregate_kind_fails_closed_everywhere() {
+        assert_eq!(
+            AggregateKind::Item.ops_prefix().unwrap(),
+            ITEM_OPS_PREFIX,
+            "item paths must stay byte-identical now that they are kind-derived"
+        );
+        assert_eq!(
+            AggregateKind::Item
+                .checkpoint_path(ITEM, &"c".repeat(64))
+                .unwrap(),
+            ItemAggregateCheckpoint {
+                aggregate_id: ITEM.to_owned(),
+                snapshot_sha256: "c".repeat(64),
+                snapshot_base64: String::new(),
+            }
+            .path()
+        );
+
+        let projection = CanonicalProjection {
+            schema_version: 3,
+            items: BTreeMap::from([(ITEM.to_owned(), item())]),
+        };
+        let migration = create_aggregate_migration(
+            &projection,
+            LIBRARY,
+            CHECKPOINT,
+            "2026-07-28T00:00:00Z",
+            51,
+        )
+        .expect("migration");
+
+        // An unrecognized kind still parses, so the client can report an
+        // upgrade rather than a corrupt repository.
+        let future = migration
+            .catalogue_json
+            .replace(r#""item""#, r#""zen_document""#);
+        let catalogue: AggregateCatalogue =
+            serde_json::from_str(&future).expect("unknown kind still parses");
+        assert_eq!(
+            catalogue.entries[0].aggregate_kind,
+            AggregateKind::Unsupported("zen_document".into())
+        );
+        assert!(matches!(
+            catalogue.validate(LIBRARY),
+            Err(DomainError::UnsupportedAggregateKind(kind)) if kind == "zen_document"
+        ));
+
+        let genesis: AggregateGenesis =
+            serde_json::from_str(&migration.genesis_json).expect("genesis");
+        assert!(genesis.validate(LIBRARY, &migration.catalogue_json).is_ok());
+        // Genesis is bound to exact catalogue bytes.
+        assert!(matches!(
+            genesis.validate(LIBRARY, &future),
+            Err(DomainError::Integrity { .. })
+        ));
+
+        let aggregate =
+            ItemAggregate::from_canonical(ITEM, &item(), CHECKPOINT, 52).expect("aggregate");
+        let mut envelope = aggregate
+            .export_envelope(
+                &aggregate.version(),
+                LIBRARY,
+                DEVICE,
+                1,
+                "2026-07-28T00:00:01Z",
+            )
+            .expect("envelope");
+        let path = envelope.path().expect("path");
+        envelope.aggregate_kind = AggregateKind::Unsupported("zen_document".into());
+        assert!(matches!(
+            envelope.path(),
+            Err(DomainError::UnsupportedAggregateKind(_))
+        ));
+        assert!(matches!(
+            aggregate.import_envelope(&path, &envelope, LIBRARY),
+            Err(DomainError::UnsupportedAggregateKind(_))
+        ));
     }
 
     #[test]

--- a/crates/research-domain/src/document.rs
+++ b/crates/research-domain/src/document.rs
@@ -52,6 +52,8 @@ pub enum DomainError {
     UnsupportedFeature(String),
     #[error("unsupported operation pack version {0}")]
     UnsupportedOperationPackVersion(u8),
+    #[error("unsupported aggregate kind {0}")]
+    UnsupportedAggregateKind(String),
     #[error("integrity failure at {path}: expected {expected}, got {actual}")]
     Integrity {
         path: String,

--- a/crates/research-domain/src/lib.rs
+++ b/crates/research-domain/src/lib.rs
@@ -287,10 +287,11 @@ pub fn run_wasm_convergence_scenario() -> Result<String, wasm_bindgen::JsValue> 
         .map_err(|error| wasm_bindgen::JsValue::from_str(&error.to_string()))
 }
 pub use aggregate::{
-    AGGREGATE_GENESIS_PATH, AGGREGATE_PROTOCOL_VERSION, AggregateCatalogue, AggregateEnvelope,
-    AggregateGenesis, AggregateKind, AggregateMigration, CatalogueEntry,
-    ITEM_AGGREGATES_FEATURE, ITEM_CHECKPOINTS_PREFIX, ITEM_OPS_PREFIX, ItemAggregate,
-    ItemAggregateCheckpoint, create_aggregate_migration,
+    AGGREGATE_CHECKPOINTS_ROOT, AGGREGATE_GENESIS_PATH, AGGREGATE_OPS_ROOT,
+    AGGREGATE_PROTOCOL_VERSION, AggregateCatalogue, AggregateEnvelope, AggregateGenesis,
+    AggregateKind, AggregateMigration, CatalogueEntry, ITEM_AGGREGATES_FEATURE,
+    ITEM_CHECKPOINTS_PREFIX, ITEM_OPS_PREFIX, ItemAggregate, ItemAggregateCheckpoint,
+    create_aggregate_migration,
 };
 pub use captured::{
     CAPTURED_CONTENT_PREFIX, CAPTURED_MARKDOWN_MEDIA_TYPE, CapturedDocumentArtifact,

--- a/crates/research-domain/src/lib.rs
+++ b/crates/research-domain/src/lib.rs
@@ -287,11 +287,11 @@ pub fn run_wasm_convergence_scenario() -> Result<String, wasm_bindgen::JsValue> 
         .map_err(|error| wasm_bindgen::JsValue::from_str(&error.to_string()))
 }
 pub use aggregate::{
-    AGGREGATE_CHECKPOINTS_ROOT, AGGREGATE_GENESIS_PATH, AGGREGATE_OPS_ROOT,
-    AGGREGATE_PROTOCOL_VERSION, AggregateCatalogue, AggregateEnvelope, AggregateGenesis,
-    AggregateKind, AggregateMigration, CatalogueEntry, ITEM_AGGREGATES_FEATURE,
-    ITEM_CHECKPOINTS_PREFIX, ITEM_OPS_PREFIX, ItemAggregate, ItemAggregateCheckpoint,
-    create_aggregate_migration,
+    AGGREGATE_CATALOGUE_PREFIX, AGGREGATE_CHECKPOINTS_ROOT, AGGREGATE_GENESIS_PATH,
+    AGGREGATE_OPS_ROOT, AGGREGATE_PROTOCOL_VERSION, AggregateCatalogue, AggregateEnvelope,
+    AggregateGenesis, AggregateKind, AggregateMigration, CatalogueEntry,
+    ITEM_AGGREGATES_FEATURE, ITEM_CHECKPOINTS_PREFIX, ITEM_OPS_PREFIX, ItemAggregate,
+    ItemAggregateCheckpoint, aggregate_catalogue_path, create_aggregate_migration,
 };
 pub use captured::{
     CAPTURED_CONTENT_PREFIX, CAPTURED_MARKDOWN_MEDIA_TYPE, CapturedDocumentArtifact,

--- a/docs/v2/SYNC_PROTOCOL.md
+++ b/docs/v2/SYNC_PROTOCOL.md
@@ -398,8 +398,9 @@ hash, Loro snapshot mode, and snapshot frontier before use.
 Create a checkpoint after either 100 newly applied batches or 2 MiB of
 decoded update tail since the selected checkpoint. Checkpoint creation is an
 optimization and may be repeated by several devices. Clients select a compatible
-valid checkpoint with the greatest `batch_count`, breaking ties by lowercase
-checkpoint ID, then apply every discovered operation outside its exact coverage.
+valid checkpoint with the greatest `batch_count`, breaking ties by the
+lexicographically smallest lowercase checkpoint ID, then apply every discovered
+operation outside its exact coverage.
 Selection order cannot change final state.
 
 Every operation remains in the repository. A client can rebuild from the full
@@ -434,12 +435,25 @@ The negotiated `item-aggregates-v2` generation scopes an envelope to
 operations at:
 
 ```text
-sync/v2/ops/items/<item-uuid>/<device-uuid>/<20-digit-sequence>.json
+sync/v2/ops/<kind-segment>/<aggregate-uuid>/<device-uuid>/<20-digit-sequence>.json
 ```
 
-An immutable compact catalogue lists item aggregate IDs, saved ordering,
-lifecycle state, and content-addressed item-checkpoint paths; it contains no
-captured-document bytes. Each item checkpoint validates that its full Loro
+The path segment is derived from `aggregate_kind`; item aggregates use `items`,
+so item operations live at `sync/v2/ops/items/…` and item checkpoints at
+`sync/v2/checkpoints/items/…`.
+
+An immutable compact catalogue lists each aggregate's kind and ID, saved
+ordering, lifecycle state, and content-addressed checkpoint path; it contains no
+captured-document bytes. Entries are strictly ascending by `(kind,
+aggregate_id)`, so the artifact is byte-identical for a given library state and
+one aggregate cannot be defined twice. Genesis binds the catalogue by SHA-256
+over its exact bytes.
+
+An unrecognized `aggregate_kind` is a recognized protocol object a client cannot
+implement, not a malformed one. Clients parse it, then fail closed with an
+upgrade-shaped error before applying or uploading. Ignoring the entry would
+silently materialize a partial library, so a catalogue containing any
+unimplemented kind is rejected whole. Each item checkpoint validates that its full Loro
 snapshot contains exactly its declared item. Migration deterministically seeds
 these checkpoints from one selected v1 canonical checkpoint, retains all v1
 history, and records that checkpoint identity in v2 genesis.

--- a/docs/v2/SYNC_PROTOCOL.md
+++ b/docs/v2/SYNC_PROTOCOL.md
@@ -447,7 +447,14 @@ ordering, lifecycle state, and content-addressed checkpoint path; it contains no
 captured-document bytes. Entries are strictly ascending by `(kind,
 aggregate_id)`, so the artifact is byte-identical for a given library state and
 one aggregate cannot be defined twice. Genesis binds the catalogue by SHA-256
-over its exact bytes.
+over its exact bytes, and the catalogue is addressed by that same hash:
+
+```text
+sync/v2/catalogue/<sha256>.json
+```
+
+A catalogue is immutable like every other v2 object. A new library state
+produces a new path; a catalogue is never rewritten in place.
 
 An unrecognized `aggregate_kind` is a recognized protocol object a client cannot
 implement, not a malformed one. Clients parse it, then fail closed with an

--- a/web/src/data/sync.ts
+++ b/web/src/data/sync.ts
@@ -672,10 +672,16 @@ class BrowserSyncService {
       }
     }
     if (candidates.length === 0) return;
+    // Greatest coverage wins; ties go to the smallest checkpoint ID so this
+    // client selects the same object the native client would.
     candidates.sort(
       (left, right) =>
         right.batchCount - left.batchCount ||
-        right.checkpointId.localeCompare(left.checkpointId),
+        (left.checkpointId < right.checkpointId
+          ? -1
+          : left.checkpointId > right.checkpointId
+            ? 1
+            : 0),
     );
     const selected = candidates[0]!;
     for (const candidate of candidates.slice(1)) {


### PR DESCRIPTION
## Summary

Implements the kind-aware catalogue requirement ADR 0011 adds to #132, plus the validation the v2 aggregate artifacts never had.

**Why now:** nothing in production reads or writes the `sync/v2/` namespace yet, so changing the catalogue shape is free today. Once the aggregate generation ships, adding a second kind (zen documents, collections) would need its own migration.

- `CatalogueEntry` declares `aggregate_kind`; ops and checkpoint paths derive from the kind's segment instead of hard-coding `items/`. Item paths stay byte-identical, asserted in a test.
- `AggregateKind` gains a forward-compatible `Unsupported(String)` variant. An unrecognized kind still parses, so a client can distinguish "written by a newer client" from "malformed", then fails closed with `UnsupportedAggregateKind` at every consumer: catalogue validation, envelope path derivation, envelope validation, and `ItemAggregate::import_envelope`. Skipping the entry instead would silently materialize a partial library.
- New `AggregateCatalogue::validate` and `AggregateGenesis::validate`: protocol version, library binding, v1 checkpoint identity, per-entry checkpoint-path derivation, strictly ascending `(kind, aggregate_id)` entries (deterministic bytes + no duplicate aggregate definitions), and genesis bound to the exact catalogue bytes by SHA-256. `create_aggregate_migration` now validates what it produces.

## Incidental fix

Native broke checkpoint ties by ascending ID (`src/sync.rs:553`) while the browser broke them descending (`web/src/data/sync.ts:678`); `SYNC_PROTOCOL.md` never pinned a direction, so two clients could select different checkpoints on equal coverage. Pinned to the smallest ID and matched the browser to native.

## Impact

No shipped behavior changes: the v2 aggregate namespace has no production readers or writers yet, and the tie-break only affects which of two equally-valid checkpoints is chosen. `AggregateEnvelope::path()` is now fallible — no callers outside the domain crate.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`, `cargo test --locked --workspace --all-targets --all-features` (all pass), plus `npm test` and `npx tsc --noEmit` in `web/`. One new contract test covers unknown-kind fail-closed across all four consumers and genesis/catalogue hash binding.

Refs #132
