### PR TITLE
Select a checkpoint whose coverage is already applied

### DIFF
--- a/crates/research-store/src/sync.rs
+++ b/crates/research-store/src/sync.rs
@@ -190,12 +190,6 @@ impl V2Store {
             .execute(&mut *connection)
             .await?;
         let result = async {
-            let state = sqlx::query(
-                "SELECT snapshot_sha256 FROM canonical_state WHERE singleton = 1",
-            )
-            .fetch_one(&mut *connection)
-            .await?;
-            let current_snapshot_sha256: String = state.try_get("snapshot_sha256")?;
             let pristine = store_is_pristine(&mut connection).await?;
             let restored = if pristine {
                 let library = Library::from_snapshot(&snapshot, peer_id)?;
@@ -221,10 +215,12 @@ impl V2Store {
                 .await?;
                 true
             } else {
-                current_snapshot_sha256 == artifact.checkpoint_id
+                false
             };
             persist_checkpoint(&mut connection, &artifact, "remote").await?;
-            if restored {
+            if restored
+                || coverage_is_locally_applied(&mut connection, &artifact.coverage).await?
+            {
                 select_checkpoint(&mut connection, &artifact).await?;
             }
             observe_remote(&mut connection, path, blob_sha).await?;
@@ -834,6 +830,66 @@ async fn select_checkpoint(
     .execute(&mut *connection)
     .await?;
     Ok(())
+}
+
+/// True when every operation this checkpoint covers has already been applied
+/// here.
+///
+/// Selection only decides which operations a later pull may skip, so a
+/// checkpoint whose coverage this replica already contains is safe to select
+/// even when local state has moved past it. Requiring the canonical snapshot to
+/// equal the checkpoint instead would leave a self-created checkpoint
+/// unselected whenever a concurrent local edit landed while it uploaded. The
+/// tail is measured from the selected checkpoint, so it would never reset and
+/// every later sync would mint and upload another full snapshot.
+async fn coverage_is_locally_applied(
+    connection: &mut SqliteConnection,
+    coverage: &CheckpointCoverage,
+) -> StoreResult<bool> {
+    let mut intervals = Vec::new();
+    for (device_id, ranges) in selected_coverage(&mut *connection).await? {
+        for range in &ranges {
+            let (start, end) = interval_bounds(range)?;
+            intervals.push((device_id.clone(), start, end));
+        }
+    }
+    let rows = sqlx::query("SELECT device_id, sequence FROM batches")
+        .fetch_all(&mut *connection)
+        .await?;
+    for row in rows {
+        let device_id: String = row.try_get("device_id")?;
+        let sequence: String = row.try_get("sequence")?;
+        let sequence = parse_sequence(&sequence)?;
+        intervals.push((device_id, sequence, sequence));
+    }
+    let applied = merge_coverage(intervals)?;
+    for (device_id, ranges) in coverage {
+        let Some(applied_ranges) = applied.get(device_id) else {
+            return Ok(false);
+        };
+        let applied_bounds = applied_ranges
+            .iter()
+            .map(interval_bounds)
+            .collect::<StoreResult<Vec<_>>>()?;
+        for range in ranges {
+            let (start, end) = interval_bounds(range)?;
+            // Merged intervals never overlap, so a covered range that is
+            // applied at all sits inside exactly one of them.
+            if !applied_bounds.iter().any(|(applied_start, applied_end)| {
+                *applied_start <= start && end <= *applied_end
+            }) {
+                return Ok(false);
+            }
+        }
+    }
+    Ok(true)
+}
+
+fn interval_bounds(interval: &CoverageInterval) -> StoreResult<(u64, u64)> {
+    Ok((
+        parse_sequence(&interval.start)?,
+        parse_sequence(&interval.end)?,
+    ))
 }
 
 async fn selected_coverage(

--- a/crates/research-store/tests/sync_contract.rs
+++ b/crates/research-store/tests/sync_contract.rs
@@ -120,6 +120,71 @@ async fn checkpoint_bootstrap_restores_coverage_and_applies_only_the_tail() {
     );
 }
 
+/// A device that edits while its own checkpoint uploads must still select it.
+///
+/// The tail is measured from the selected checkpoint, so failing to select here
+/// would mint and upload another full snapshot on every later sync, growing the
+/// data repository without bound.
+#[tokio::test]
+async fn a_self_created_checkpoint_is_selected_after_a_concurrent_local_edit() {
+    let root = tempfile::tempdir().expect("temporary test root");
+    let store = V2Store::init(root.path().join("library"))
+        .await
+        .expect("store");
+    let item = store
+        .create_item(CreateItemRequest {
+            url: "https://example.com/racing-edit".into(),
+            title: Some("Before checkpoint".into()),
+            excerpt: None,
+            favorite: false,
+            language: None,
+            saved_at: None,
+            note: String::new(),
+            tags: Vec::new(),
+        })
+        .await
+        .expect("create item");
+    let covered = store.pending_batches().await.expect("covered batches");
+    let checkpoint = store
+        .checkpoint_candidate(true)
+        .await
+        .expect("build checkpoint")
+        .expect("checkpoint candidate");
+
+    // The edit lands between building the checkpoint and confirming its upload,
+    // so canonical state no longer equals the checkpoint snapshot.
+    store
+        .edit_item(EditItemRequest {
+            item_id: item.id,
+            title: Some(OptionalTextUpdate::Set("During upload".into())),
+            ..EditItemRequest::default()
+        })
+        .await
+        .expect("edit during upload");
+
+    let confirmed = store
+        .receive_remote_checkpoint(
+            &checkpoint.path,
+            &"d".repeat(40),
+            checkpoint.checkpoint_json.as_bytes(),
+        )
+        .await
+        .expect("confirm own checkpoint");
+    assert!(
+        !confirmed.restored,
+        "a non-pristine store must not replace its own newer state"
+    );
+    for batch in &covered {
+        assert!(
+            store
+                .batch_is_checkpoint_covered(&batch.device_id, &batch.sequence)
+                .await
+                .expect("coverage lookup"),
+            "the checkpoint must be selected so its coverage counts as covered"
+        );
+    }
+}
+
 #[tokio::test]
 async fn native_mutations_reuse_one_durable_loro_peer() {
     let root = tempfile::tempdir().expect("temporary test root");


### PR DESCRIPTION
## Problem

`receive_remote_checkpoint` selected a checkpoint only when the local canonical snapshot still hashed to the checkpoint ID. A device that made any local edit between building its checkpoint and confirming the upload — a concurrent capture, TUI edit, or second CLI invocation — therefore uploaded a checkpoint it never selected.

The tail thresholds are measured from the *selected* checkpoint, so the tail never reset. Every later sync cycle exceeded the threshold again, minted another full-library snapshot, and uploaded it. Protocol v1 never prunes, so those redundant snapshots accumulate in the private data repository permanently.

## Fix

Selection only decides which operations a later pull may skip, so the real precondition is that this replica has already applied everything the checkpoint covers. `coverage_is_locally_applied` builds the applied coverage (selected checkpoint ∪ batch rows, merged with the existing `merge_coverage`) and checks the checkpoint's coverage is a subset.

This is strictly safer than the equality it replaces: a remote checkpoint covering operations this replica lacks is no longer selectable even if its snapshot happens to hash equal. `restored` now means only "local state was replaced from this checkpoint" — it was previously true in a non-pristine case where nothing was restored. Nothing outside the store reads it.

## Verification

New contract test `a_self_created_checkpoint_is_selected_after_a_concurrent_local_edit` reproduces the race. Confirmed it **fails** against the old predicate (`the checkpoint must be selected so its coverage counts as covered`) and passes with the fix.

`cargo fmt --all -- --check`, `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`, and `cargo test --locked --workspace --all-targets --all-features` all pass.

Refs #132
