### PR TITLE
Migrate a local library onto item aggregates

### DIFF
--- a/crates/research-store/migrations/0009_item_aggregates.sql
+++ b/crates/research-store/migrations/0009_item_aggregates.sql
@@ -30,12 +30,13 @@ CREATE INDEX aggregate_checkpoints_aggregate
 
 -- The single record binding retained v1 history to the v2 generation. Its
 -- presence is what makes this installation an aggregate writer.
+--
+-- Only the exact protocol bytes are stored. The v1 checkpoint identity, the
+-- catalogue hash, and the catalogue path are all derived from validated genesis
+-- on read, so no denormalized copy can disagree with them.
 CREATE TABLE aggregate_migration (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
     library_id TEXT NOT NULL,
-    v1_checkpoint_id TEXT NOT NULL CHECK (length(v1_checkpoint_id) = 64),
-    catalogue_path TEXT NOT NULL,
-    catalogue_sha256 TEXT NOT NULL CHECK (length(catalogue_sha256) = 64),
     catalogue_json TEXT NOT NULL,
     genesis_json TEXT NOT NULL,
     barrier_device_id TEXT NOT NULL,

--- a/crates/research-store/migrations/0009_item_aggregates.sql
+++ b/crates/research-store/migrations/0009_item_aggregates.sql
@@ -1,0 +1,46 @@
+-- Local state for the item-aggregates-v2 generation.
+--
+-- Protocol-v1 tables are left untouched: migration never rewrites or prunes v1
+-- history, and the v1 canonical snapshot remains the projection source until a
+-- later change moves mutations onto aggregates.
+
+-- One CRDT replica per aggregate, replacing the single-document canonical
+-- snapshot for aggregate-scoped work.
+CREATE TABLE aggregate_state (
+    aggregate_kind TEXT NOT NULL,
+    aggregate_id TEXT NOT NULL,
+    snapshot BLOB NOT NULL,
+    snapshot_sha256 TEXT NOT NULL CHECK (length(snapshot_sha256) = 64),
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (aggregate_kind, aggregate_id)
+);
+
+-- Immutable content-addressed aggregate checkpoints seeded by migration.
+CREATE TABLE aggregate_checkpoints (
+    path TEXT PRIMARY KEY,
+    aggregate_kind TEXT NOT NULL,
+    aggregate_id TEXT NOT NULL,
+    snapshot_sha256 TEXT NOT NULL CHECK (length(snapshot_sha256) = 64),
+    checkpoint_json TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX aggregate_checkpoints_aggregate
+    ON aggregate_checkpoints(aggregate_kind, aggregate_id);
+
+-- The single record binding retained v1 history to the v2 generation. Its
+-- presence is what makes this installation an aggregate writer.
+CREATE TABLE aggregate_migration (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    library_id TEXT NOT NULL,
+    v1_checkpoint_id TEXT NOT NULL CHECK (length(v1_checkpoint_id) = 64),
+    catalogue_path TEXT NOT NULL,
+    catalogue_sha256 TEXT NOT NULL CHECK (length(catalogue_sha256) = 64),
+    catalogue_json TEXT NOT NULL,
+    genesis_json TEXT NOT NULL,
+    barrier_device_id TEXT NOT NULL,
+    barrier_sequence TEXT NOT NULL CHECK (length(barrier_sequence) = 20),
+    migrated_at TEXT NOT NULL,
+    FOREIGN KEY (barrier_device_id, barrier_sequence)
+        REFERENCES batches(device_id, sequence)
+);

--- a/crates/research-store/src/aggregate.rs
+++ b/crates/research-store/src/aggregate.rs
@@ -1,0 +1,246 @@
+//! Cutover from the single-document protocol-v1 library to item aggregates.
+//!
+//! Migration is a local, atomic, idempotent step. It retains every v1
+//! operation, seeds one immutable checkpoint per item, and queues the recognized
+//! v1 barrier operation that makes older clients stop before they can upload
+//! into a generation they do not implement.
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use research_domain::{
+    AggregateCatalogue, AggregateGenesis, AggregateKind, ItemAggregateCheckpoint, Library,
+    aggregate_catalogue_path, create_aggregate_migration,
+};
+use sqlx::{Row, SqliteConnection};
+
+use crate::mutation::enqueue_local_envelope;
+use crate::store::{now_rfc3339, peer_id_for_device, sha256_hex};
+use crate::sync::build_checkpoint_candidate;
+use crate::{StoreError, StoreResult, V2Store};
+
+/// What a migration produced, or found already recorded.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AggregateMigrationReceipt {
+    pub library_id: String,
+    pub v1_checkpoint_id: String,
+    pub catalogue_path: String,
+    pub catalogue_sha256: String,
+    pub barrier_path: String,
+    pub aggregate_count: usize,
+    /// True when this call found an existing record and changed nothing.
+    pub already_migrated: bool,
+}
+
+impl V2Store {
+    pub async fn aggregate_migration(&self) -> StoreResult<Option<AggregateMigrationReceipt>> {
+        let mut connection = self.pool.acquire().await?;
+        read_migration(&mut connection).await
+    }
+
+    /// Move this installation onto the item-aggregates-v2 generation.
+    ///
+    /// Repeating the call is a no-op that returns the recorded receipt, so a
+    /// crash between the commit and any later upload cannot produce a second,
+    /// differently-identified migration.
+    pub async fn migrate_to_item_aggregates(&self) -> StoreResult<AggregateMigrationReceipt> {
+        let mut connection = self.pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *connection)
+            .await?;
+        let result = run_migration(&mut connection).await;
+        match result {
+            Ok(receipt) => {
+                sqlx::query("COMMIT").execute(&mut *connection).await?;
+                Ok(receipt)
+            }
+            Err(error) => {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *connection).await;
+                Err(error)
+            }
+        }
+    }
+}
+
+async fn read_migration(
+    connection: &mut SqliteConnection,
+) -> StoreResult<Option<AggregateMigrationReceipt>> {
+    let Some(row) = sqlx::query(
+        "SELECT library_id, v1_checkpoint_id, catalogue_path, catalogue_sha256, \
+         catalogue_json, barrier_device_id, barrier_sequence \
+         FROM aggregate_migration WHERE singleton = 1",
+    )
+    .fetch_optional(&mut *connection)
+    .await?
+    else {
+        return Ok(None);
+    };
+    let catalogue_json: String = row.try_get("catalogue_json")?;
+    let catalogue: AggregateCatalogue = serde_json::from_str(&catalogue_json)?;
+    let device_id: String = row.try_get("barrier_device_id")?;
+    let sequence: String = row.try_get("barrier_sequence")?;
+    Ok(Some(AggregateMigrationReceipt {
+        library_id: row.try_get("library_id")?,
+        v1_checkpoint_id: row.try_get("v1_checkpoint_id")?,
+        catalogue_path: row.try_get("catalogue_path")?,
+        catalogue_sha256: row.try_get("catalogue_sha256")?,
+        barrier_path: format!("sync/v1/ops/{device_id}/{sequence}.json"),
+        aggregate_count: catalogue.entries.len(),
+        already_migrated: true,
+    }))
+}
+
+async fn run_migration(
+    connection: &mut SqliteConnection,
+) -> StoreResult<AggregateMigrationReceipt> {
+    if let Some(existing) = read_migration(&mut *connection).await? {
+        return Ok(existing);
+    }
+    // Unsent local work would have to be re-expressed as aggregate operations,
+    // and unapplied remote work would migrate a library this device has not
+    // fully observed. Both are refused rather than guessed at.
+    let (queued, deferred): (i64, i64) = sqlx::query_as(
+        "SELECT (SELECT COUNT(*) FROM outbox), (SELECT COUNT(*) FROM deferred_batches)",
+    )
+    .fetch_one(&mut *connection)
+    .await?;
+    if queued != 0 {
+        return Err(StoreError::InvalidInput(
+            "synchronize pending local changes before migrating to item aggregates".into(),
+        ));
+    }
+    if deferred != 0 {
+        return Err(StoreError::InvalidInput(
+            "apply deferred remote updates before migrating to item aggregates".into(),
+        ));
+    }
+
+    let library_id: String =
+        sqlx::query_scalar("SELECT value FROM store_meta WHERE key = 'library_id'")
+            .fetch_one(&mut *connection)
+            .await?;
+    let device_id: String =
+        sqlx::query_scalar("SELECT value FROM store_meta WHERE key = 'device_id'")
+            .fetch_one(&mut *connection)
+            .await?;
+    let peer_id = peer_id_for_device(&device_id)?;
+
+    // The canonical v1 checkpoint this generation is derived from. Forcing it
+    // ignores the ordinary tail thresholds: the identity, not the size saving,
+    // is what genesis records.
+    let checkpoint = build_checkpoint_candidate(&mut *connection, true)
+        .await?
+        .ok_or_else(|| {
+            StoreError::InvalidInput(
+                "migrate to item aggregates after this library has at least one operation"
+                    .to_owned(),
+            )
+        })?;
+
+    let now = now_rfc3339();
+    let state = sqlx::query(
+        "SELECT snapshot, snapshot_sha256 FROM canonical_state WHERE singleton = 1",
+    )
+    .fetch_one(&mut *connection)
+    .await?;
+    let snapshot: Vec<u8> = state.try_get("snapshot")?;
+    let expected_snapshot_sha256: String = state.try_get("snapshot_sha256")?;
+    if sha256_hex(&snapshot) != expected_snapshot_sha256 {
+        return Err(StoreError::InvalidStore(
+            "canonical snapshot checksum mismatch".into(),
+        ));
+    }
+    let library = Library::from_snapshot(&snapshot, peer_id)?;
+    let projection = library.canonical_projection()?;
+
+    // The barrier carries no domain change; its whole payload is the required
+    // feature that an older reader refuses.
+    let sequence_text: String =
+        sqlx::query_scalar("SELECT next_sequence FROM devices WHERE device_id = ?")
+            .bind(&device_id)
+            .fetch_one(&mut *connection)
+            .await?;
+    let sequence = sequence_text
+        .parse::<u64>()
+        .map_err(|_| StoreError::InvalidStore("invalid device sequence".into()))?;
+    let barrier = library.export_item_aggregates_migration_barrier(
+        &library.version(),
+        &library_id,
+        &device_id,
+        sequence,
+        &now,
+    )?;
+    let barrier_path = barrier.path();
+    enqueue_local_envelope(&mut *connection, &barrier, &now).await?;
+
+    let migration = create_aggregate_migration(
+        &projection,
+        &library_id,
+        &checkpoint.checkpoint_id,
+        &now,
+        peer_id,
+    )?;
+    let genesis: AggregateGenesis = serde_json::from_str(&migration.genesis_json)?;
+    // Validating what was just built keeps an unreadable artifact from being
+    // committed and then uploaded.
+    genesis.validate(&library_id, &migration.catalogue_json)?;
+
+    for (path, checkpoint_json) in &migration.checkpoints {
+        let artifact: ItemAggregateCheckpoint = serde_json::from_str(checkpoint_json)?;
+        let aggregate_snapshot = STANDARD.decode(&artifact.snapshot_base64).map_err(|_| {
+            StoreError::SyncIntegrity("aggregate checkpoint payload is not Base64".into())
+        })?;
+        sqlx::query(
+            "INSERT INTO aggregate_state \
+             (aggregate_kind, aggregate_id, snapshot, snapshot_sha256, updated_at) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(AggregateKind::Item.as_str())
+        .bind(&artifact.aggregate_id)
+        .bind(&aggregate_snapshot)
+        .bind(&artifact.snapshot_sha256)
+        .bind(&now)
+        .execute(&mut *connection)
+        .await?;
+        sqlx::query(
+            "INSERT INTO aggregate_checkpoints \
+             (path, aggregate_kind, aggregate_id, snapshot_sha256, checkpoint_json, created_at) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(path)
+        .bind(AggregateKind::Item.as_str())
+        .bind(&artifact.aggregate_id)
+        .bind(&artifact.snapshot_sha256)
+        .bind(checkpoint_json)
+        .bind(&now)
+        .execute(&mut *connection)
+        .await?;
+    }
+
+    let catalogue_path = aggregate_catalogue_path(&migration.catalogue_sha256);
+    sqlx::query(
+        "INSERT INTO aggregate_migration \
+         (singleton, library_id, v1_checkpoint_id, catalogue_path, catalogue_sha256, \
+          catalogue_json, genesis_json, barrier_device_id, barrier_sequence, migrated_at) \
+         VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&library_id)
+    .bind(&checkpoint.checkpoint_id)
+    .bind(&catalogue_path)
+    .bind(&migration.catalogue_sha256)
+    .bind(&migration.catalogue_json)
+    .bind(&migration.genesis_json)
+    .bind(&barrier.device_id)
+    .bind(&barrier.sequence)
+    .bind(&now)
+    .execute(&mut *connection)
+    .await?;
+
+    Ok(AggregateMigrationReceipt {
+        library_id,
+        v1_checkpoint_id: checkpoint.checkpoint_id,
+        catalogue_path,
+        catalogue_sha256: migration.catalogue_sha256,
+        barrier_path,
+        aggregate_count: migration.checkpoints.len(),
+        already_migrated: false,
+    })
+}

--- a/crates/research-store/src/aggregate.rs
+++ b/crates/research-store/src/aggregate.rs
@@ -7,7 +7,7 @@
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use research_domain::{
-    AggregateCatalogue, AggregateGenesis, AggregateKind, ItemAggregateCheckpoint, Library,
+    AggregateGenesis, AggregateKind, ItemAggregateCheckpoint, Library,
     aggregate_catalogue_path, create_aggregate_migration,
 };
 use sqlx::{Row, SqliteConnection};
@@ -64,8 +64,7 @@ async fn read_migration(
     connection: &mut SqliteConnection,
 ) -> StoreResult<Option<AggregateMigrationReceipt>> {
     let Some(row) = sqlx::query(
-        "SELECT library_id, v1_checkpoint_id, catalogue_path, catalogue_sha256, \
-         catalogue_json, barrier_device_id, barrier_sequence \
+        "SELECT library_id, catalogue_json, genesis_json, barrier_device_id, barrier_sequence \
          FROM aggregate_migration WHERE singleton = 1",
     )
     .fetch_optional(&mut *connection)
@@ -73,15 +72,20 @@ async fn read_migration(
     else {
         return Ok(None);
     };
+    let library_id: String = row.try_get("library_id")?;
     let catalogue_json: String = row.try_get("catalogue_json")?;
-    let catalogue: AggregateCatalogue = serde_json::from_str(&catalogue_json)?;
+    let genesis_json: String = row.try_get("genesis_json")?;
     let device_id: String = row.try_get("barrier_device_id")?;
     let sequence: String = row.try_get("barrier_sequence")?;
+    // Reading revalidates rather than trusting local bytes, so a corrupt row
+    // cannot report a migration whose identities do not hold.
+    let genesis: AggregateGenesis = serde_json::from_str(&genesis_json)?;
+    let catalogue = genesis.validate(&library_id, &catalogue_json)?;
     Ok(Some(AggregateMigrationReceipt {
-        library_id: row.try_get("library_id")?,
-        v1_checkpoint_id: row.try_get("v1_checkpoint_id")?,
-        catalogue_path: row.try_get("catalogue_path")?,
-        catalogue_sha256: row.try_get("catalogue_sha256")?,
+        library_id,
+        v1_checkpoint_id: genesis.migrated_from_v1_checkpoint,
+        catalogue_path: aggregate_catalogue_path(&genesis.catalogue_sha256),
+        catalogue_sha256: genesis.catalogue_sha256,
         barrier_path: format!("sync/v1/ops/{device_id}/{sequence}.json"),
         aggregate_count: catalogue.entries.len(),
         already_migrated: true,
@@ -215,17 +219,13 @@ async fn run_migration(
         .await?;
     }
 
-    let catalogue_path = aggregate_catalogue_path(&migration.catalogue_sha256);
     sqlx::query(
         "INSERT INTO aggregate_migration \
-         (singleton, library_id, v1_checkpoint_id, catalogue_path, catalogue_sha256, \
-          catalogue_json, genesis_json, barrier_device_id, barrier_sequence, migrated_at) \
-         VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+         (singleton, library_id, catalogue_json, genesis_json, barrier_device_id, \
+          barrier_sequence, migrated_at) \
+         VALUES (1, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&library_id)
-    .bind(&checkpoint.checkpoint_id)
-    .bind(&catalogue_path)
-    .bind(&migration.catalogue_sha256)
     .bind(&migration.catalogue_json)
     .bind(&migration.genesis_json)
     .bind(&barrier.device_id)
@@ -237,7 +237,7 @@ async fn run_migration(
     Ok(AggregateMigrationReceipt {
         library_id,
         v1_checkpoint_id: checkpoint.checkpoint_id,
-        catalogue_path,
+        catalogue_path: aggregate_catalogue_path(&migration.catalogue_sha256),
         catalogue_sha256: migration.catalogue_sha256,
         barrier_path,
         aggregate_count: migration.checkpoints.len(),

--- a/crates/research-store/src/lib.rs
+++ b/crates/research-store/src/lib.rs
@@ -1,5 +1,6 @@
 //! Durable, local-only persistence for a V2 ResearchPocket library.
 
+mod aggregate;
 mod captured;
 mod enrichment;
 mod error;
@@ -9,6 +10,7 @@ mod mutation;
 mod store;
 mod sync;
 
+pub use aggregate::AggregateMigrationReceipt;
 pub use enrichment::ENRICHMENT_MAX_ATTEMPTS;
 pub use error::{StoreError, StoreResult};
 pub use model::{

--- a/crates/research-store/src/mutation.rs
+++ b/crates/research-store/src/mutation.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use chrono::{DateTime, SecondsFormat, Utc};
-use research_domain::{CanonicalProjection, ItemSeed, Library, LifecycleState};
+use research_domain::{CanonicalProjection, ItemSeed, Library, LifecycleState, UpdateEnvelope};
 use sqlx::{Row, SqliteConnection};
 use uuid::Uuid;
 
@@ -293,7 +293,20 @@ where
     .execute(&mut *connection)
     .await?;
 
-    let envelope_json = serde_json::to_string(&envelope)?;
+    enqueue_local_envelope(connection, &envelope, &now).await?;
+
+    Ok(stored_item)
+}
+
+/// Record one locally produced envelope as durable, queued, and sequenced.
+///
+/// Every local writer shares this so a mutation and a protocol migration cannot
+/// disagree about what "durable before upload" means.
+pub(crate) async fn enqueue_local_envelope(
+    connection: &mut SqliteConnection,
+    envelope: &UpdateEnvelope,
+    now: &str,
+) -> StoreResult<()> {
     sqlx::query(
         "INSERT INTO batches \
          (device_id, sequence, payload_sha256, protocol_version, library_id, path, \
@@ -306,26 +319,28 @@ where
     .bind(i64::from(envelope.protocol_version))
     .bind(&envelope.library_id)
     .bind(envelope.path())
-    .bind(envelope_json)
-    .bind(&now)
+    .bind(serde_json::to_string(envelope)?)
+    .bind(now)
     .execute(&mut *connection)
     .await?;
     sqlx::query("INSERT INTO outbox (device_id, sequence, enqueued_at) VALUES (?, ?, ?)")
         .bind(&envelope.device_id)
         .bind(&envelope.sequence)
-        .bind(&now)
+        .bind(now)
         .execute(&mut *connection)
         .await?;
-    let next = sequence
+    let next = envelope
+        .sequence
+        .parse::<u64>()
+        .map_err(|_| StoreError::InvalidStore("invalid device sequence".into()))?
         .checked_add(1)
         .ok_or(StoreError::NumericRange("device sequence"))?;
     sqlx::query("UPDATE devices SET next_sequence = ? WHERE device_id = ?")
         .bind(format!("{next:020}"))
-        .bind(&device_id)
+        .bind(&envelope.device_id)
         .execute(&mut *connection)
         .await?;
-
-    Ok(stored_item)
+    Ok(())
 }
 
 fn optional_text(update: &OptionalTextUpdate) -> Option<&str> {

--- a/crates/research-store/src/sync.rs
+++ b/crates/research-store/src/sync.rs
@@ -659,7 +659,7 @@ async fn apply_remote_batch(
     })
 }
 
-async fn build_checkpoint_candidate(
+pub(crate) async fn build_checkpoint_candidate(
     connection: &mut SqliteConnection,
     force: bool,
 ) -> StoreResult<Option<PendingCheckpoint>> {

--- a/crates/research-store/tests/sync_contract.rs
+++ b/crates/research-store/tests/sync_contract.rs
@@ -120,6 +120,75 @@ async fn checkpoint_bootstrap_restores_coverage_and_applies_only_the_tail() {
     );
 }
 
+/// Migration seeds the v2 generation without disturbing retained v1 history.
+///
+/// Repeating it must produce the same identities rather than a second
+/// generation, because the first attempt may have committed locally and then
+/// failed before anything was uploaded.
+#[tokio::test]
+async fn migrating_to_item_aggregates_is_idempotent_and_queues_the_barrier() {
+    let root = tempfile::tempdir().expect("temporary test root");
+    let store = V2Store::init(root.path().join("library"))
+        .await
+        .expect("store");
+    for url in ["https://example.com/one", "https://example.com/two"] {
+        store
+            .create_item(CreateItemRequest {
+                url: url.into(),
+                title: Some("Saved".into()),
+                excerpt: None,
+                favorite: false,
+                language: None,
+                saved_at: None,
+                note: String::new(),
+                tags: vec!["reference".into()],
+            })
+            .await
+            .expect("create item");
+    }
+    // A device with unsent work cannot migrate: those operations would have to
+    // be re-expressed in a generation that did not exist when they were made.
+    assert!(store.migrate_to_item_aggregates().await.is_err());
+    // Pulling back an uploaded operation is what acknowledges the outbox.
+    for batch in store.pending_batches().await.expect("pending") {
+        store
+            .receive_remote_batch(&batch.path, &"a".repeat(40), batch.envelope_json.as_bytes())
+            .await
+            .expect("confirm upload");
+    }
+
+    let receipt = store
+        .migrate_to_item_aggregates()
+        .await
+        .expect("migrate to aggregates");
+    assert!(!receipt.already_migrated);
+    assert_eq!(receipt.aggregate_count, 2, "one aggregate per item");
+
+    // The barrier is an ordinary v1 operation, so it uploads through the
+    // existing outbox and older clients meet it on their next pull.
+    let queued = store.pending_batches().await.expect("barrier queued");
+    assert_eq!(queued.len(), 1);
+    assert_eq!(queued[0].path, receipt.barrier_path);
+
+    let repeated = store
+        .migrate_to_item_aggregates()
+        .await
+        .expect("repeat migration");
+    assert!(repeated.already_migrated);
+    assert_eq!(repeated.v1_checkpoint_id, receipt.v1_checkpoint_id);
+    assert_eq!(repeated.catalogue_sha256, receipt.catalogue_sha256);
+    assert_eq!(
+        store
+            .list(ListQuery::default())
+            .await
+            .expect("projection")
+            .page
+            .total,
+        2,
+        "migration leaves the readable library untouched"
+    );
+}
+
 /// A device that edits while its own checkpoint uploads must still select it.
 ///
 /// The tail is measured from the selected checkpoint, so failing to select here


### PR DESCRIPTION
## Summary

First increment of the item-aggregates-v2 generation (#132), and the prerequisite for the Research Zen epic (#140), which adds `zen-document` as a second aggregate kind.

Everything in `aggregate.rs` was domain-only with no production callers. This adds the local half of the cutover:

- **Schema** (`0009_item_aggregates.sql`): `aggregate_state` (one CRDT replica per aggregate), `aggregate_checkpoints` (immutable, content-addressed), and the singleton `aggregate_migration` record whose presence makes an installation an aggregate writer. Protocol-v1 tables are untouched.
- **`V2Store::migrate_to_item_aggregates`**: forces the canonical v1 checkpoint whose identity genesis records, queues the recognized v1 barrier operation through the ordinary outbox, builds and validates genesis + catalogue, and seeds one checkpoint and replica per item — all in one `BEGIN IMMEDIATE`.
- **Preconditions**: refuses to run with a non-empty outbox or deferred batches rather than guessing how to re-express work in a generation that did not exist when it was made.
- **Idempotency**: repeating returns the recorded receipt, so a crash between commit and upload cannot mint a second, differently-identified generation.

## Simplification

Local envelope enqueueing (batches + outbox + sequence bump) was duplicated between the mutation path and this one. It is now a single `enqueue_local_envelope`, so a mutation and a protocol migration cannot disagree about what "durable before upload" means.

## Impact

No behavior change for existing users: nothing calls `migrate_to_item_aggregates` yet, and v1 history is retained rather than rewritten. The barrier only reaches a repository when a later increment invokes migration.

## Verification

New contract test `migrating_to_item_aggregates_is_idempotent_and_queues_the_barrier`: asserts migration is refused while work is queued, that it produces one aggregate per item, that the barrier lands in the outbox as an ordinary v1 operation, that repeating returns identical identities, and that the readable projection is untouched.

`cargo fmt --all -- --check`, `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`, and `cargo test --locked --workspace --all-targets --all-features` all pass.

Refs #132
