### PR TITLE
Add the zen document aggregate

### DIFF
--- a/crates/research-domain/src/aggregate.rs
+++ b/crates/research-domain/src/aggregate.rs
@@ -815,6 +815,21 @@ mod tests {
             ITEM_OPS_PREFIX,
             "item paths must stay byte-identical now that they are kind-derived"
         );
+        // The zen kind's wire name and namespace are protocol surface: changing
+        // either would strand documents already written under the old one.
+        assert_eq!(AggregateKind::Zen.as_str(), "zen_document");
+        assert_eq!(
+            AggregateKind::from("zen_document".to_owned()),
+            AggregateKind::Zen,
+            "the wire name must round-trip"
+        );
+        assert_eq!(AggregateKind::Zen.ops_prefix().unwrap(), "sync/v2/ops/zen/");
+        assert_eq!(
+            AggregateKind::Zen
+                .checkpoint_path(ITEM, &"c".repeat(64))
+                .unwrap(),
+            format!("sync/v2/checkpoints/zen/{ITEM}/{}.json", "c".repeat(64))
+        );
         assert_eq!(
             AggregateKind::Item
                 .checkpoint_path(ITEM, &"c".repeat(64))

--- a/crates/research-domain/src/aggregate.rs
+++ b/crates/research-domain/src/aggregate.rs
@@ -42,6 +42,7 @@ pub const ITEM_CHECKPOINTS_PREFIX: &str = "sync/v2/checkpoints/items/";
 #[serde(from = "String", into = "String")]
 pub enum AggregateKind {
     Item,
+    Zen,
     Unsupported(String),
 }
 
@@ -49,6 +50,7 @@ impl AggregateKind {
     pub fn as_str(&self) -> &str {
         match self {
             Self::Item => "item",
+            Self::Zen => "zen_document",
             Self::Unsupported(value) => value,
         }
     }
@@ -61,6 +63,7 @@ impl AggregateKind {
     pub fn path_segment(&self) -> DomainResult<&'static str> {
         match self {
             Self::Item => Ok("items"),
+            Self::Zen => Ok("zen"),
             Self::Unsupported(value) => {
                 Err(DomainError::UnsupportedAggregateKind(value.clone()))
             }
@@ -94,6 +97,7 @@ impl From<String> for AggregateKind {
     fn from(value: String) -> Self {
         match value.as_str() {
             "item" => Self::Item,
+            "zen_document" => Self::Zen,
             _ => Self::Unsupported(value),
         }
     }
@@ -840,16 +844,16 @@ mod tests {
         // upgrade rather than a corrupt repository.
         let future = migration
             .catalogue_json
-            .replace(r#""item""#, r#""zen_document""#);
+            .replace(r#""item""#, r#""collection""#);
         let catalogue: AggregateCatalogue =
             serde_json::from_str(&future).expect("unknown kind still parses");
         assert_eq!(
             catalogue.entries[0].aggregate_kind,
-            AggregateKind::Unsupported("zen_document".into())
+            AggregateKind::Unsupported("collection".into())
         );
         assert!(matches!(
             catalogue.validate(LIBRARY),
-            Err(DomainError::UnsupportedAggregateKind(kind)) if kind == "zen_document"
+            Err(DomainError::UnsupportedAggregateKind(kind)) if kind == "collection"
         ));
 
         let genesis: AggregateGenesis =
@@ -884,7 +888,7 @@ mod tests {
             )
             .expect("envelope");
         let path = envelope.path().expect("path");
-        envelope.aggregate_kind = AggregateKind::Unsupported("zen_document".into());
+        envelope.aggregate_kind = AggregateKind::Unsupported("collection".into());
         assert!(matches!(
             envelope.path(),
             Err(DomainError::UnsupportedAggregateKind(_))

--- a/crates/research-domain/src/document.rs
+++ b/crates/research-domain/src/document.rs
@@ -345,39 +345,15 @@ impl Library {
     where
         T: Clone + DeserializeOwned + Serialize,
     {
-        let revisions = self.scalar_revisions_mut(item_id, field)?;
-        let existing = read_records::<ScalarRevision<T>>(&revisions)?;
-        let revision = ScalarRevision {
-            parents: causal_heads(&existing, |revision| &revision.parents),
-            value,
-        };
-        insert_immutable_record(&revisions, revision_id, &revision)
+        write_entity_scalar(&self.item_mut(item_id)?, field, revision_id, value)
     }
 
     pub fn add_tag(&self, item_id: &str, tag: &str, add_dot: &str) -> DomainResult<()> {
-        let tag = validate_tag(tag)?;
-        let tags = self
-            .item_mut(item_id)?
-            .ensure_mergeable_map(TAGS)
-            .map_err(loro_error)?;
-        let state = tags.ensure_mergeable_map(&tag).map_err(loro_error)?;
-        let adds = state.ensure_mergeable_map(ADDS).map_err(loro_error)?;
-        insert_boolean_dot(&adds, add_dot)
+        add_entity_tag(&self.item_mut(item_id)?, tag, add_dot)
     }
 
     pub fn remove_tag(&self, item_id: &str, tag: &str) -> DomainResult<()> {
-        let tag = validate_tag(tag)?;
-        let tags = self
-            .item_mut(item_id)?
-            .ensure_mergeable_map(TAGS)
-            .map_err(loro_error)?;
-        let state = tags.ensure_mergeable_map(&tag).map_err(loro_error)?;
-        let adds = state.ensure_mergeable_map(ADDS).map_err(loro_error)?;
-        let removes = state.ensure_mergeable_map(REMOVES).map_err(loro_error)?;
-        for add_dot in map_keys(&adds) {
-            insert_boolean_dot(&removes, &add_dot)?;
-        }
-        Ok(())
+        remove_entity_tag(&self.item_mut(item_id)?, tag)
     }
 
     pub fn transition_lifecycle(
@@ -386,37 +362,7 @@ impl Library {
         revision_id: &str,
         state: LifecycleState,
     ) -> DomainResult<()> {
-        let revisions = self.lifecycle_revisions_mut(item_id)?;
-        let existing = read_records::<LifecycleRevision>(&revisions)?;
-        let parents = causal_heads(&existing, |revision| &revision.parents);
-        if !existing.is_empty() {
-            let visible = lifecycle_view(existing.clone())?;
-            match (visible.state, state) {
-                (LifecycleState::Active, LifecycleState::Active) => {
-                    return Err(DomainError::InvalidState(
-                        "restore requires an observed deleted lifecycle head".into(),
-                    ));
-                }
-                (LifecycleState::Deleted, LifecycleState::Deleted) => {
-                    return Err(DomainError::InvalidState(
-                        "delete requires an observed active lifecycle head".into(),
-                    ));
-                }
-                _ => {}
-            }
-        }
-        let generation = parents
-            .iter()
-            .filter_map(|parent| existing.get(parent))
-            .map(|revision| revision.generation)
-            .max()
-            .map_or(0, |generation| generation + 1);
-        let revision = LifecycleRevision {
-            generation,
-            parents,
-            state,
-        };
-        insert_immutable_record(&revisions, revision_id, &revision)
+        transition_entity_lifecycle(&self.item_mut(item_id)?, revision_id, state)
     }
 
     pub fn export_envelope(
@@ -479,7 +425,7 @@ impl Library {
             let tags = project_tags(map_child(&item, TAGS)?)?;
             let lifecycle = map_child(&item, LIFECYCLE)?;
             let lifecycle_revisions = map_child(&lifecycle, REVISIONS)?;
-            let lifecycle = lifecycle_view(read_records(&lifecycle_revisions)?)?;
+            let lifecycle = lifecycle_view(read_entity_records(&lifecycle_revisions)?)?;
             projected.insert(
                 item_id,
                 CanonicalItem {
@@ -503,22 +449,15 @@ impl Library {
     }
 
     fn item_mut(&self, item_id: &str) -> DomainResult<LoroMap> {
-        self.doc
-            .get_map(ITEMS)
-            .ensure_mergeable_map(item_id)
-            .map_err(loro_error)
+        entity_mut(&self.doc, ITEMS, item_id)
     }
 
     fn note_mut(&self, item_id: &str) -> DomainResult<LoroText> {
-        self.item_mut(item_id)?
-            .ensure_mergeable_text(NOTE)
-            .map_err(loro_error)
+        entity_text_mut(&self.item_mut(item_id)?, NOTE)
     }
 
     fn excerpt_mut(&self, item_id: &str) -> DomainResult<LoroText> {
-        self.item_mut(item_id)?
-            .ensure_mergeable_text(EXCERPT)
-            .map_err(loro_error)
+        entity_text_mut(&self.item_mut(item_id)?, EXCERPT)
     }
 
     /// Reads the excerpt container without creating it, so that merely looking
@@ -532,24 +471,114 @@ impl Library {
             )),
         }
     }
+}
 
-    fn scalar_revisions_mut(&self, item_id: &str, field: &str) -> DomainResult<LoroMap> {
-        self.item_mut(item_id)?
-            .ensure_mergeable_map(SCALARS)
-            .map_err(loro_error)?
-            .ensure_mergeable_map(field)
-            .map_err(loro_error)?
-            .ensure_mergeable_map(REVISIONS)
-            .map_err(loro_error)
-    }
+/// Operations shared by every entity a library holds.
+///
+/// An entity is one `LoroMap` carrying causal scalar registers, add-wins tag
+/// sets, lifecycle generations, and character-level text. Items live under one
+/// root and zen documents under another, but the convergence rules are the
+/// same, so they are written once here rather than per root.
+pub(crate) fn entity_mut(doc: &LoroDoc, root: &str, entity_id: &str) -> DomainResult<LoroMap> {
+    doc.get_map(root)
+        .ensure_mergeable_map(entity_id)
+        .map_err(loro_error)
+}
 
-    fn lifecycle_revisions_mut(&self, item_id: &str) -> DomainResult<LoroMap> {
-        self.item_mut(item_id)?
-            .ensure_mergeable_map(LIFECYCLE)
-            .map_err(loro_error)?
-            .ensure_mergeable_map(REVISIONS)
-            .map_err(loro_error)
+pub(crate) fn entity_text_mut(entity: &LoroMap, field: &str) -> DomainResult<LoroText> {
+    entity.ensure_mergeable_text(field).map_err(loro_error)
+}
+
+pub(crate) fn write_entity_scalar<T>(
+    entity: &LoroMap,
+    field: &str,
+    revision_id: &str,
+    value: T,
+) -> DomainResult<()>
+where
+    T: Clone + DeserializeOwned + Serialize,
+{
+    let revisions = entity
+        .ensure_mergeable_map(SCALARS)
+        .map_err(loro_error)?
+        .ensure_mergeable_map(field)
+        .map_err(loro_error)?
+        .ensure_mergeable_map(REVISIONS)
+        .map_err(loro_error)?;
+    let existing = read_entity_records::<ScalarRevision<T>>(&revisions)?;
+    let revision = ScalarRevision {
+        parents: causal_heads(&existing, |revision| &revision.parents),
+        value,
+    };
+    insert_immutable_record(&revisions, revision_id, &revision)
+}
+
+pub(crate) fn add_entity_tag(entity: &LoroMap, tag: &str, add_dot: &str) -> DomainResult<()> {
+    let tag = validate_tag(tag)?;
+    let state = entity
+        .ensure_mergeable_map(TAGS)
+        .map_err(loro_error)?
+        .ensure_mergeable_map(&tag)
+        .map_err(loro_error)?;
+    let adds = state.ensure_mergeable_map(ADDS).map_err(loro_error)?;
+    insert_boolean_dot(&adds, add_dot)
+}
+
+pub(crate) fn remove_entity_tag(entity: &LoroMap, tag: &str) -> DomainResult<()> {
+    let tag = validate_tag(tag)?;
+    let state = entity
+        .ensure_mergeable_map(TAGS)
+        .map_err(loro_error)?
+        .ensure_mergeable_map(&tag)
+        .map_err(loro_error)?;
+    let adds = state.ensure_mergeable_map(ADDS).map_err(loro_error)?;
+    let removes = state.ensure_mergeable_map(REMOVES).map_err(loro_error)?;
+    for add_dot in map_keys(&adds) {
+        insert_boolean_dot(&removes, &add_dot)?;
     }
+    Ok(())
+}
+
+pub(crate) fn transition_entity_lifecycle(
+    entity: &LoroMap,
+    revision_id: &str,
+    state: LifecycleState,
+) -> DomainResult<()> {
+    let revisions = entity
+        .ensure_mergeable_map(LIFECYCLE)
+        .map_err(loro_error)?
+        .ensure_mergeable_map(REVISIONS)
+        .map_err(loro_error)?;
+    let existing = read_entity_records::<LifecycleRevision>(&revisions)?;
+    let parents = causal_heads(&existing, |revision| &revision.parents);
+    if !existing.is_empty() {
+        let visible = lifecycle_view(existing.clone())?;
+        match (visible.state, state) {
+            (LifecycleState::Active, LifecycleState::Active) => {
+                return Err(DomainError::InvalidState(
+                    "restore requires an observed deleted lifecycle head".into(),
+                ));
+            }
+            (LifecycleState::Deleted, LifecycleState::Deleted) => {
+                return Err(DomainError::InvalidState(
+                    "delete requires an observed active lifecycle head".into(),
+                ));
+            }
+            _ => {}
+        }
+    }
+    let generation = parents
+        .iter()
+        .filter_map(|parent| existing.get(parent))
+        .map(|revision| revision.generation)
+        .max()
+        .map_or(0, |generation| generation + 1);
+    let revision = LifecycleRevision {
+        generation,
+        parents,
+        state,
+    };
+    insert_immutable_record(&revisions, revision_id, &revision)
 }
 
 impl Default for Library {
@@ -558,7 +587,7 @@ impl Default for Library {
     }
 }
 
-fn loro_error(error: impl std::fmt::Display) -> DomainError {
+pub(crate) fn loro_error(error: impl std::fmt::Display) -> DomainError {
     DomainError::Loro(error.to_string())
 }
 
@@ -681,7 +710,9 @@ fn insert_immutable_record<T: serde::Serialize>(
     map.insert(id, encoded).map_err(loro_error)
 }
 
-fn read_records<T: DeserializeOwned>(map: &LoroMap) -> DomainResult<BTreeMap<String, T>> {
+pub(crate) fn read_entity_records<T: DeserializeOwned>(
+    map: &LoroMap,
+) -> DomainResult<BTreeMap<String, T>> {
     let mut raw = Vec::new();
     map.for_each(|key, value| {
         raw.push((key.to_owned(), value.get_deep_value().to_json_value()));
@@ -696,14 +727,14 @@ fn read_records<T: DeserializeOwned>(map: &LoroMap) -> DomainResult<BTreeMap<Str
         .collect()
 }
 
-fn map_keys(map: &LoroMap) -> Vec<String> {
+pub(crate) fn map_keys(map: &LoroMap) -> Vec<String> {
     let mut keys = Vec::new();
     map.for_each(|key, _| keys.push(key.to_owned()));
     keys.sort();
     keys
 }
 
-fn map_child(parent: &LoroMap, key: &str) -> DomainResult<LoroMap> {
+pub(crate) fn map_child(parent: &LoroMap, key: &str) -> DomainResult<LoroMap> {
     match parent.get(key) {
         Some(ValueOrContainer::Container(Container::Map(map))) => Ok(map),
         _ => Err(DomainError::InvalidState(format!(
@@ -712,7 +743,7 @@ fn map_child(parent: &LoroMap, key: &str) -> DomainResult<LoroMap> {
     }
 }
 
-fn text_child(parent: &LoroMap, key: &str) -> DomainResult<LoroText> {
+pub(crate) fn text_child(parent: &LoroMap, key: &str) -> DomainResult<LoroText> {
     match parent.get(key) {
         Some(ValueOrContainer::Container(Container::Text(text))) => Ok(text),
         _ => Err(DomainError::InvalidState(format!(
@@ -721,13 +752,13 @@ fn text_child(parent: &LoroMap, key: &str) -> DomainResult<LoroText> {
     }
 }
 
-fn project_scalar<T>(scalars: &LoroMap, field: &str) -> DomainResult<ScalarView<T>>
+pub(crate) fn project_scalar<T>(scalars: &LoroMap, field: &str) -> DomainResult<ScalarView<T>>
 where
     T: Clone + DeserializeOwned,
 {
     let scalar = map_child(scalars, field)?;
     let revisions = map_child(&scalar, REVISIONS)?;
-    scalar_view(read_records(&revisions)?)
+    scalar_view(read_entity_records(&revisions)?)
 }
 
 fn project_optional_scalar<T>(
@@ -760,7 +791,7 @@ fn project_excerpt(item: &LoroMap, scalars: &LoroMap) -> DomainResult<String> {
     }
 }
 
-fn project_tags(tags: LoroMap) -> DomainResult<Vec<String>> {
+pub(crate) fn project_tags(tags: LoroMap) -> DomainResult<Vec<String>> {
     let mut visible = Vec::new();
     for tag in map_keys(&tags) {
         let state = map_child(&tags, &tag)?;

--- a/crates/research-domain/src/lib.rs
+++ b/crates/research-domain/src/lib.rs
@@ -14,6 +14,7 @@ mod pack;
 mod projection;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
+mod zen;
 
 pub use document::{
     DomainError, DomainResult, ItemSeed, Library, TextSplice, validate_item_url,
@@ -32,6 +33,9 @@ pub use projection::{
 #[cfg(target_arch = "wasm32")]
 pub use wasm::{
     apply_mutation, apply_remote_envelopes, initialize_library, materialize_library,
+};
+pub use zen::{
+    MAX_ZEN_BODY_BYTES, ZenAggregate, ZenDocumentSeed, ZenDocumentSummary, ZenDocumentView,
 };
 
 const ITEM_ID: &str = "0197f2b5-93d7-7ad4-8c67-21e98f0c7341";

--- a/crates/research-domain/src/zen.rs
+++ b/crates/research-domain/src/zen.rs
@@ -9,6 +9,8 @@
 //! character splice, which is what lets two devices flip different boxes and
 //! keep both.
 
+use std::collections::BTreeSet;
+
 use loro::{ExportMode, LoroDoc, VersionVector};
 use serde::{Deserialize, Serialize};
 
@@ -89,6 +91,30 @@ pub struct ZenDocumentSummary {
     pub lifecycle_state: LifecycleState,
 }
 
+/// Strips a GFM list marker, bulleted or ordered, and returns what follows.
+fn strip_list_marker(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    for bullet in ["- ", "* ", "+ "] {
+        if let Some(rest) = trimmed.strip_prefix(bullet) {
+            return Some(rest);
+        }
+    }
+    let digits = trimmed.len()
+        - trimmed
+            .trim_start_matches(|c: char| c.is_ascii_digit())
+            .len();
+    if digits == 0 {
+        return None;
+    }
+    let after_digits = &trimmed[digits..];
+    for delimiter in [". ", ") "] {
+        if let Some(rest) = after_digits.strip_prefix(delimiter) {
+            return Some(rest);
+        }
+    }
+    None
+}
+
 /// Counts GFM task-list items, and how many are checked.
 ///
 /// Derived from the body rather than stored, so a hand-edited checkbox and a
@@ -97,16 +123,10 @@ fn count_todos(body: &str) -> (usize, usize) {
     let mut total = 0;
     let mut done = 0;
     for line in body.lines() {
-        let trimmed = line.trim_start();
-        let Some(rest) = trimmed
-            .strip_prefix("- ")
-            .or_else(|| trimmed.strip_prefix("* "))
-            .or_else(|| trimmed.strip_prefix("+ "))
-        else {
+        let Some(rest) = strip_list_marker(line) else {
             continue;
         };
-        let rest = rest.trim_start();
-        let checked = match rest.as_bytes() {
+        let checked = match rest.trim_start().as_bytes() {
             [b'[', mark, b']', ..] => match mark {
                 b' ' => Some(false),
                 b'x' | b'X' => Some(true),
@@ -167,7 +187,10 @@ impl ZenAggregate {
             seed.created_at,
         )?;
         entity.ensure_mergeable_map(TAGS).map_err(loro_error)?;
-        for (index, tag) in seed.tags.iter().enumerate() {
+        // Sorted and deduplicated like item creation, so two replicas seeded
+        // from the same tags produce the same bytes and no redundant dots.
+        let tags = seed.tags.iter().collect::<BTreeSet<_>>();
+        for (index, tag) in tags.into_iter().enumerate() {
             add_entity_tag(&entity, tag, &format!("{operation_prefix}/tag/{index:020}"))?;
         }
         transition_entity_lifecycle(
@@ -319,7 +342,11 @@ mod tests {
             title: Some("Today".to_owned()),
             body: "- [x] Ship it\n- [ ] Review #132\n\nGrocery run.".to_owned(),
             created_at: 1_700_000_000,
-            tags: vec!["reading".to_owned()],
+            tags: vec![
+                "reading".to_owned(),
+                "crdt".to_owned(),
+                "reading".to_owned(),
+            ],
         }
     }
 
@@ -352,7 +379,21 @@ mod tests {
         let summary = alice.view().expect("view").summary();
         assert_eq!((summary.todo_total, summary.todo_done), (2, 2));
         assert_eq!(summary.title.as_deref(), Some("Today"));
-        assert_eq!(summary.tags, ["reading"]);
+        assert_eq!(
+            summary.tags,
+            ["crdt", "reading"],
+            "tags are canonicalized, so replicas seeded alike agree"
+        );
+    }
+
+    /// Ordered task items are GFM task lists too, so they must count.
+    #[test]
+    fn todos_are_counted_in_bulleted_and_ordered_lists() {
+        let mut ordered = seed();
+        ordered.body = "1. [x] first\n2) [ ] second\n- [ ] third\n\n- not a todo".to_owned();
+        let aggregate = ZenAggregate::create(&ordered, "alice/1", 11).expect("create");
+        let summary = aggregate.view().expect("view").summary();
+        assert_eq!((summary.todo_total, summary.todo_done), (3, 1));
     }
 
     #[test]

--- a/crates/research-domain/src/zen.rs
+++ b/crates/research-domain/src/zen.rs
@@ -1,0 +1,375 @@
+//! Zen documents: authored prose, lists, and todos as their own aggregate.
+//!
+//! A zen document reuses the entity primitives items are built from — causal
+//! scalar registers, add-wins tag sets, lifecycle generations, and
+//! character-level text — so concurrent prose edits and todo toggles merge
+//! under semantics that are already proven, rather than a second set of rules.
+//!
+//! Structure is Markdown inside the body text. A checkbox toggle is therefore a
+//! character splice, which is what lets two devices flip different boxes and
+//! keep both.
+
+use loro::{ExportMode, LoroDoc, VersionVector};
+use serde::{Deserialize, Serialize};
+
+use crate::document::{
+    DomainError, DomainResult, add_entity_tag, entity_mut, entity_text_mut, loro_error,
+    map_child, map_keys, project_scalar, project_tags, remove_entity_tag, text_child,
+    transition_entity_lifecycle, write_entity_scalar,
+};
+use crate::identity::validate_uuid_v7;
+use crate::projection::{LifecycleState, LifecycleView, ScalarView, lifecycle_view};
+use crate::{LifecycleRevision, TextSplice};
+
+const ZEN: &str = "zen";
+const BODY: &str = "body";
+const TITLE: &str = "title";
+const CREATED_AT: &str = "created_at";
+const SCALARS: &str = "scalars";
+const TAGS: &str = "tags";
+const LIFECYCLE: &str = "lifecycle";
+const REVISIONS: &str = "revisions";
+
+/// Largest body this build accepts, in UTF-8 bytes.
+///
+/// Raising it is a protocol decision, not a configuration knob: a larger body
+/// changes what every replica must be able to hold and transport.
+pub const MAX_ZEN_BODY_BYTES: usize = 256 * 1024;
+
+/// Complete input for creating one zen document.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ZenDocumentSeed {
+    pub document_id: String,
+    pub title: Option<String>,
+    pub body: String,
+    pub created_at: i64,
+    pub tags: Vec<String>,
+}
+
+/// Everything a reader needs about one document, including its body.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ZenDocumentView {
+    pub document_id: String,
+    pub title: ScalarView<Option<String>>,
+    pub created_at: ScalarView<i64>,
+    pub body: String,
+    pub tags: Vec<String>,
+    pub lifecycle: LifecycleView,
+}
+
+impl ZenDocumentView {
+    pub fn summary(&self) -> ZenDocumentSummary {
+        let (todo_total, todo_done) = count_todos(&self.body);
+        ZenDocumentSummary {
+            document_id: self.document_id.clone(),
+            title: self.title.value.clone(),
+            created_at: self.created_at.value,
+            byte_length: self.body.len(),
+            todo_total,
+            todo_done,
+            tags: self.tags.clone(),
+            lifecycle_state: self.lifecycle.state,
+        }
+    }
+}
+
+/// List-shaped metadata that never carries body bytes.
+///
+/// The workspace index is built from these so opening it stays proportional to
+/// the number of documents rather than their size.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ZenDocumentSummary {
+    pub document_id: String,
+    pub title: Option<String>,
+    pub created_at: i64,
+    pub byte_length: usize,
+    pub todo_total: usize,
+    pub todo_done: usize,
+    pub tags: Vec<String>,
+    pub lifecycle_state: LifecycleState,
+}
+
+/// Counts GFM task-list items, and how many are checked.
+///
+/// Derived from the body rather than stored, so a hand-edited checkbox and a
+/// clicked one are indistinguishable — there is no counter to fall out of step.
+fn count_todos(body: &str) -> (usize, usize) {
+    let mut total = 0;
+    let mut done = 0;
+    for line in body.lines() {
+        let trimmed = line.trim_start();
+        let Some(rest) = trimmed
+            .strip_prefix("- ")
+            .or_else(|| trimmed.strip_prefix("* "))
+            .or_else(|| trimmed.strip_prefix("+ "))
+        else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let checked = match rest.as_bytes() {
+            [b'[', mark, b']', ..] => match mark {
+                b' ' => Some(false),
+                b'x' | b'X' => Some(true),
+                _ => None,
+            },
+            _ => None,
+        };
+        if let Some(checked) = checked {
+            total += 1;
+            if checked {
+                done += 1;
+            }
+        }
+    }
+    (total, done)
+}
+
+/// One zen document's replica.
+pub struct ZenAggregate {
+    document_id: String,
+    doc: LoroDoc,
+}
+
+impl ZenAggregate {
+    pub fn create(
+        seed: &ZenDocumentSeed,
+        operation_prefix: &str,
+        peer_id: u64,
+    ) -> DomainResult<Self> {
+        validate_uuid_v7(&seed.document_id, "zen document ID")?;
+        validate_body(&seed.body)?;
+        if operation_prefix.trim().is_empty() {
+            return Err(DomainError::InvalidState(
+                "operation prefix cannot be blank".into(),
+            ));
+        }
+        let doc = LoroDoc::new();
+        doc.set_peer_id(peer_id).map_err(loro_error)?;
+        let aggregate = Self {
+            document_id: seed.document_id.clone(),
+            doc,
+        };
+
+        let entity = aggregate.entity()?;
+        entity_text_mut(&entity, BODY)?
+            .splice_utf16(0, 0, &seed.body)
+            .map_err(loro_error)?;
+        write_entity_scalar(
+            &entity,
+            TITLE,
+            &format!("{operation_prefix}/{TITLE}"),
+            seed.title.clone(),
+        )?;
+        write_entity_scalar(
+            &entity,
+            CREATED_AT,
+            &format!("{operation_prefix}/{CREATED_AT}"),
+            seed.created_at,
+        )?;
+        entity.ensure_mergeable_map(TAGS).map_err(loro_error)?;
+        for (index, tag) in seed.tags.iter().enumerate() {
+            add_entity_tag(&entity, tag, &format!("{operation_prefix}/tag/{index:020}"))?;
+        }
+        transition_entity_lifecycle(
+            &entity,
+            &format!("{operation_prefix}/{LIFECYCLE}"),
+            LifecycleState::Active,
+        )?;
+        Ok(aggregate)
+    }
+
+    pub fn from_snapshot(
+        document_id: &str,
+        snapshot: &[u8],
+        peer_id: u64,
+    ) -> DomainResult<Self> {
+        validate_uuid_v7(document_id, "zen document ID")?;
+        let doc = LoroDoc::new();
+        doc.set_peer_id(peer_id).map_err(loro_error)?;
+        doc.import(snapshot).map_err(loro_error)?;
+        let aggregate = Self {
+            document_id: document_id.to_owned(),
+            doc,
+        };
+        let present = map_keys(&aggregate.doc.get_map(ZEN));
+        if present != [document_id.to_owned()] {
+            return Err(DomainError::InvalidState(
+                "zen snapshot does not contain exactly its declared document".into(),
+            ));
+        }
+        Ok(aggregate)
+    }
+
+    pub fn document_id(&self) -> &str {
+        &self.document_id
+    }
+
+    pub fn version(&self) -> VersionVector {
+        self.doc.oplog_vv()
+    }
+
+    pub fn export_snapshot(&self) -> DomainResult<Vec<u8>> {
+        self.doc.export(ExportMode::Snapshot).map_err(loro_error)
+    }
+
+    pub fn export_update(&self, from: &VersionVector) -> DomainResult<Vec<u8>> {
+        self.doc
+            .export(ExportMode::updates(from))
+            .map_err(loro_error)
+    }
+
+    pub fn import_update(&self, update: &[u8]) -> DomainResult<()> {
+        self.doc.import(update).map_err(loro_error).map(|_| ())
+    }
+
+    pub fn write_title(&self, revision_id: &str, title: Option<&str>) -> DomainResult<()> {
+        write_entity_scalar(
+            &self.entity()?,
+            TITLE,
+            revision_id,
+            title.map(str::to_owned),
+        )
+    }
+
+    pub fn add_tag(&self, tag: &str, add_dot: &str) -> DomainResult<()> {
+        add_entity_tag(&self.entity()?, tag, add_dot)
+    }
+
+    pub fn remove_tag(&self, tag: &str) -> DomainResult<()> {
+        remove_entity_tag(&self.entity()?, tag)
+    }
+
+    pub fn transition_lifecycle(
+        &self,
+        revision_id: &str,
+        state: LifecycleState,
+    ) -> DomainResult<()> {
+        transition_entity_lifecycle(&self.entity()?, revision_id, state)
+    }
+
+    pub fn splice_body_utf16(
+        &self,
+        position: usize,
+        length: usize,
+        replacement: &str,
+    ) -> DomainResult<()> {
+        entity_text_mut(&self.entity()?, BODY)?
+            .splice_utf16(position, length, replacement)
+            .map_err(loro_error)
+    }
+
+    /// Rewrites the body by splicing only the range that actually changed.
+    ///
+    /// Replacing the whole text would make two devices editing different
+    /// sections conflict over the entire document instead of merging, and would
+    /// carry the whole body in every update.
+    pub fn set_body(&self, replacement: &str) -> DomainResult<()> {
+        validate_body(replacement)?;
+        let current = self.body()?;
+        let Some(splice) = TextSplice::between(&current, replacement) else {
+            return Ok(());
+        };
+        self.splice_body_utf16(splice.position, splice.length, &splice.insert)
+    }
+
+    pub fn body(&self) -> DomainResult<String> {
+        Ok(text_child(&self.entity()?, BODY)?.to_string())
+    }
+
+    pub fn view(&self) -> DomainResult<ZenDocumentView> {
+        let entity = map_child(&self.doc.get_map(ZEN), &self.document_id)?;
+        let scalars = map_child(&entity, SCALARS)?;
+        let lifecycle = map_child(&entity, LIFECYCLE)?;
+        Ok(ZenDocumentView {
+            document_id: self.document_id.clone(),
+            title: project_scalar::<Option<String>>(&scalars, TITLE)?,
+            created_at: project_scalar::<i64>(&scalars, CREATED_AT)?,
+            body: text_child(&entity, BODY)?.to_string(),
+            tags: project_tags(map_child(&entity, TAGS)?)?,
+            lifecycle: lifecycle_view(crate::document::read_entity_records::<
+                LifecycleRevision,
+            >(&map_child(&lifecycle, REVISIONS)?)?)?,
+        })
+    }
+
+    fn entity(&self) -> DomainResult<loro::LoroMap> {
+        entity_mut(&self.doc, ZEN, &self.document_id)
+    }
+}
+
+fn validate_body(body: &str) -> DomainResult<()> {
+    if body.len() > MAX_ZEN_BODY_BYTES {
+        return Err(DomainError::InvalidState(format!(
+            "zen document body is {} bytes, over the {MAX_ZEN_BODY_BYTES} byte bound",
+            body.len()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DOCUMENT: &str = "0197f2b5-93d7-7ad4-8c67-21e98f0c7341";
+
+    fn seed() -> ZenDocumentSeed {
+        ZenDocumentSeed {
+            document_id: DOCUMENT.to_owned(),
+            title: Some("Today".to_owned()),
+            body: "- [x] Ship it\n- [ ] Review #132\n\nGrocery run.".to_owned(),
+            created_at: 1_700_000_000,
+            tags: vec!["reading".to_owned()],
+        }
+    }
+
+    /// Concurrent toggles and prose edits must both survive, because structure
+    /// lives in the text rather than in a per-todo register.
+    #[test]
+    fn concurrent_todo_toggle_and_prose_edit_both_land() {
+        let alice = ZenAggregate::create(&seed(), "alice/1", 11).expect("create");
+        let snapshot = alice.export_snapshot().expect("snapshot");
+        let bob = ZenAggregate::from_snapshot(DOCUMENT, &snapshot, 22).expect("replica");
+
+        let alice_before = alice.version();
+        let bob_before = bob.version();
+        alice
+            .set_body("- [x] Ship it\n- [x] Review #132\n\nGrocery run.")
+            .expect("toggle the second todo");
+        bob.set_body("- [x] Ship it\n- [ ] Review #132\n\nGrocery run after standup.")
+            .expect("extend the prose");
+
+        let from_alice = alice.export_update(&alice_before).expect("alice update");
+        let from_bob = bob.export_update(&bob_before).expect("bob update");
+        alice.import_update(&from_bob).expect("apply bob");
+        bob.import_update(&from_alice).expect("apply alice");
+
+        let merged = alice.body().expect("merged body");
+        assert_eq!(merged, bob.body().expect("bob body"), "replicas converge");
+        assert!(merged.contains("- [x] Review #132"), "toggle survives");
+        assert!(merged.contains("after standup"), "prose edit survives");
+
+        let summary = alice.view().expect("view").summary();
+        assert_eq!((summary.todo_total, summary.todo_done), (2, 2));
+        assert_eq!(summary.title.as_deref(), Some("Today"));
+        assert_eq!(summary.tags, ["reading"]);
+    }
+
+    #[test]
+    fn a_body_over_the_bound_is_refused() {
+        let mut oversized = seed();
+        oversized.body = "x".repeat(MAX_ZEN_BODY_BYTES + 1);
+        assert!(ZenAggregate::create(&oversized, "alice/1", 11).is_err());
+
+        let aggregate = ZenAggregate::create(&seed(), "alice/1", 11).expect("create");
+        assert!(
+            aggregate
+                .set_body(&"x".repeat(MAX_ZEN_BODY_BYTES + 1))
+                .is_err()
+        );
+        assert!(
+            aggregate.body().expect("body").contains("Ship it"),
+            "a refused write leaves the document untouched"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The domain half of Research Zen (#140), on top of the aggregate generation from #146.

**Refactor first.** The entity primitives — causal scalar registers, add-wins tag sets, lifecycle generations, and character-level text — were welded to `get_map(ITEMS)` and keyed by `item_id`. They are now free functions over any entity map, with the item methods as thin wrappers. Convergence rules are written once, so zen documents inherit them rather than restating them. `GOLDEN_CANONICAL_JSON` still passes, which is the check that the CRDT structure is byte-identical.

**Zen documents** are then a small addition:
- Title as a causal scalar, tags as an add-wins set, lifecycle by generation, body as character-level text — exactly the item semantics, per ADR 0011.
- Structure lives in the Markdown body, so **a checkbox toggle is a character splice**. The contract test proves a concurrent todo toggle and prose edit on two replicas both survive and converge.
- **Todo counts are derived** from the body, never stored, so a hand-edited checkbox and a clicked one are indistinguishable and no counter can fall out of step.
- `ZenDocumentSummary` carries list metadata with **no body bytes**, so opening the workspace stays proportional to document count rather than document size — the "titles and metadata only" line in design screen 1b.
- Bodies bounded at 256 KiB; an oversized write is refused and leaves the document untouched.

**`AggregateKind::Zen`** lands as a known kind (`zen_document`, path segment `zen/`) — purely additive, which is what the kind-aware catalogue in #144 was built for. The unknown-kind fail-closed test now uses `collection` as its example of a future kind.

## Impact

No behavior change to shipped surfaces: nothing constructs a `ZenAggregate` yet. The refactor is internal to the domain crate and preserves every public signature.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`, and `cargo test --locked --workspace --all-targets --all-features` all pass.

Refs #140, #132
