### PR TITLE
Persist zen documents locally

### DIFF
--- a/crates/research-domain/src/aggregate.rs
+++ b/crates/research-domain/src/aggregate.rs
@@ -205,6 +205,51 @@ impl AggregateEnvelope {
     }
 }
 
+/// Wraps one aggregate's CRDT update as a validated, addressable envelope.
+///
+/// Every aggregate kind produces envelopes the same way, so the shape is
+/// written once here and the kinds differ only in what they put in it.
+#[allow(clippy::too_many_arguments)]
+pub fn build_aggregate_envelope(
+    aggregate_kind: AggregateKind,
+    aggregate_id: &str,
+    update: &[u8],
+    from: &VersionVector,
+    library_id: &str,
+    device_id: &str,
+    sequence: u64,
+    created_at: &str,
+) -> DomainResult<AggregateEnvelope> {
+    validate_uuid_v7(library_id, "library ID")?;
+    validate_uuid_v7(device_id, "device ID")?;
+    validate_utc(created_at, "aggregate operation creation time")?;
+    if sequence == 0 {
+        return Err(DomainError::InvalidState(
+            "aggregate operation sequence cannot be zero".into(),
+        ));
+    }
+    let envelope = AggregateEnvelope {
+        protocol_version: AGGREGATE_PROTOCOL_VERSION,
+        domain_schema_version: DOMAIN_SCHEMA_VERSION,
+        loro_codec: LORO_CODEC.to_owned(),
+        required_features: vec![ITEM_AGGREGATES_FEATURE.to_owned()],
+        aggregate_kind,
+        aggregate_id: aggregate_id.to_owned(),
+        library_id: library_id.to_owned(),
+        device_id: device_id.to_owned(),
+        sequence: format!("{sequence:020}"),
+        causal_frontier: from
+            .iter()
+            .map(|(peer, counter)| (peer.to_string(), *counter))
+            .collect(),
+        created_at: created_at.to_owned(),
+        payload: STANDARD.encode(update),
+        payload_sha256: sha256_hex(update),
+    };
+    envelope.validate(&envelope.path()?, library_id, aggregate_id)?;
+    Ok(envelope)
+}
+
 pub struct ItemAggregate {
     item_id: String,
     library: Library,
@@ -293,7 +338,6 @@ impl ItemAggregate {
             .ok_or_else(|| DomainError::InvalidState("item aggregate body is missing".into()))
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn export_envelope(
         &self,
         from: &VersionVector,
@@ -302,35 +346,16 @@ impl ItemAggregate {
         sequence: u64,
         created_at: &str,
     ) -> DomainResult<AggregateEnvelope> {
-        validate_uuid_v7(library_id, "library ID")?;
-        validate_uuid_v7(device_id, "device ID")?;
-        validate_utc(created_at, "aggregate operation creation time")?;
-        if sequence == 0 {
-            return Err(DomainError::InvalidState(
-                "aggregate operation sequence cannot be zero".into(),
-            ));
-        }
-        let update = self.library.export_update(from)?;
-        let envelope = AggregateEnvelope {
-            protocol_version: AGGREGATE_PROTOCOL_VERSION,
-            domain_schema_version: DOMAIN_SCHEMA_VERSION,
-            loro_codec: LORO_CODEC.to_owned(),
-            required_features: vec![ITEM_AGGREGATES_FEATURE.to_owned()],
-            aggregate_kind: AggregateKind::Item,
-            aggregate_id: self.item_id.clone(),
-            library_id: library_id.to_owned(),
-            device_id: device_id.to_owned(),
-            sequence: format!("{sequence:020}"),
-            causal_frontier: from
-                .iter()
-                .map(|(peer, counter)| (peer.to_string(), *counter))
-                .collect(),
-            created_at: created_at.to_owned(),
-            payload: STANDARD.encode(&update),
-            payload_sha256: sha256_hex(&update),
-        };
-        envelope.validate(&envelope.path()?, library_id, &self.item_id)?;
-        Ok(envelope)
+        build_aggregate_envelope(
+            AggregateKind::Item,
+            &self.item_id,
+            &self.library.export_update(from)?,
+            from,
+            library_id,
+            device_id,
+            sequence,
+            created_at,
+        )
     }
 
     pub fn import_envelope(

--- a/crates/research-domain/src/zen.rs
+++ b/crates/research-domain/src/zen.rs
@@ -14,6 +14,7 @@ use std::collections::BTreeSet;
 use loro::{ExportMode, LoroDoc, VersionVector};
 use serde::{Deserialize, Serialize};
 
+use crate::aggregate::{AggregateEnvelope, AggregateKind, build_aggregate_envelope};
 use crate::document::{
     DomainError, DomainResult, add_entity_tag, entity_mut, entity_text_mut, loro_error,
     map_child, map_keys, project_scalar, project_tags, remove_entity_tag, text_child,
@@ -243,6 +244,41 @@ impl ZenAggregate {
 
     pub fn import_update(&self, update: &[u8]) -> DomainResult<()> {
         self.doc.import(update).map_err(loro_error).map(|_| ())
+    }
+
+    pub fn export_envelope(
+        &self,
+        from: &VersionVector,
+        library_id: &str,
+        device_id: &str,
+        sequence: u64,
+        created_at: &str,
+    ) -> DomainResult<AggregateEnvelope> {
+        build_aggregate_envelope(
+            AggregateKind::Zen,
+            &self.document_id,
+            &self.export_update(from)?,
+            from,
+            library_id,
+            device_id,
+            sequence,
+            created_at,
+        )
+    }
+
+    pub fn import_envelope(
+        &self,
+        path: &str,
+        envelope: &AggregateEnvelope,
+        expected_library_id: &str,
+    ) -> DomainResult<()> {
+        if envelope.aggregate_kind != AggregateKind::Zen {
+            return Err(DomainError::UnsupportedAggregateKind(
+                envelope.aggregate_kind.as_str().to_owned(),
+            ));
+        }
+        let payload = envelope.validate(path, expected_library_id, &self.document_id)?;
+        self.import_update(&payload)
     }
 
     pub fn write_title(&self, revision_id: &str, title: Option<&str>) -> DomainResult<()> {

--- a/crates/research-store/migrations/0010_zen_documents.sql
+++ b/crates/research-store/migrations/0010_zen_documents.sql
@@ -1,0 +1,56 @@
+-- Aggregate-scoped operations and their upload queue.
+--
+-- Kept separate from the protocol-v1 `batches`/`outbox` tables: these carry
+-- v2 envelopes addressed by (kind, aggregate), which v1 has no column for.
+CREATE TABLE aggregate_batches (
+    aggregate_kind TEXT NOT NULL,
+    aggregate_id TEXT NOT NULL,
+    device_id TEXT NOT NULL,
+    sequence TEXT NOT NULL CHECK (length(sequence) = 20),
+    path TEXT NOT NULL UNIQUE,
+    payload_sha256 TEXT NOT NULL CHECK (length(payload_sha256) = 64),
+    envelope_json TEXT NOT NULL,
+    origin TEXT NOT NULL CHECK (origin IN ('local', 'remote')),
+    applied_at TEXT NOT NULL,
+    PRIMARY KEY (aggregate_kind, aggregate_id, device_id, sequence)
+);
+
+CREATE TABLE aggregate_outbox (
+    aggregate_kind TEXT NOT NULL,
+    aggregate_id TEXT NOT NULL,
+    device_id TEXT NOT NULL,
+    sequence TEXT NOT NULL,
+    enqueued_at TEXT NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    last_error TEXT,
+    PRIMARY KEY (aggregate_kind, aggregate_id, device_id, sequence),
+    FOREIGN KEY (aggregate_kind, aggregate_id, device_id, sequence)
+        REFERENCES aggregate_batches(aggregate_kind, aggregate_id, device_id, sequence)
+        ON DELETE CASCADE
+);
+
+-- List projection for the zen workspace.
+--
+-- Deliberately excludes the body: opening the workspace must stay proportional
+-- to the number of documents, never their size. Bodies live in
+-- `aggregate_state` and are read only when a document is opened.
+CREATE TABLE zen_documents (
+    document_id TEXT PRIMARY KEY,
+    title TEXT,
+    byte_length INTEGER NOT NULL CHECK (byte_length >= 0),
+    todo_total INTEGER NOT NULL CHECK (todo_total >= 0),
+    todo_done INTEGER NOT NULL CHECK (todo_done >= 0),
+    created_at INTEGER NOT NULL,
+    edited_at TEXT NOT NULL,
+    lifecycle_state TEXT NOT NULL CHECK (lifecycle_state IN ('active', 'deleted'))
+);
+
+CREATE INDEX zen_documents_edited_at ON zen_documents(edited_at DESC, document_id ASC);
+
+CREATE TABLE zen_document_tags (
+    document_id TEXT NOT NULL REFERENCES zen_documents(document_id) ON DELETE CASCADE,
+    tag TEXT NOT NULL,
+    PRIMARY KEY (document_id, tag)
+);
+
+CREATE INDEX zen_document_tags_tag ON zen_document_tags(tag, document_id);

--- a/crates/research-store/src/lib.rs
+++ b/crates/research-store/src/lib.rs
@@ -9,6 +9,7 @@ mod model;
 mod mutation;
 mod store;
 mod sync;
+mod zen;
 
 pub use aggregate::AggregateMigrationReceipt;
 pub use enrichment::ENRICHMENT_MAX_ATTEMPTS;
@@ -23,3 +24,4 @@ pub use model::{
     SyncConfiguration, SyncIdentity,
 };
 pub use store::V2Store;
+pub use zen::{CreateZenDocumentRequest, EditZenDocumentRequest, zen_aggregate_kind};

--- a/crates/research-store/src/zen.rs
+++ b/crates/research-store/src/zen.rs
@@ -1,0 +1,381 @@
+//! Local persistence for zen documents.
+//!
+//! Each document is one aggregate replica in `aggregate_state`. Mutations load
+//! only that replica, so editing one document never costs anything
+//! proportional to the rest of the library, and every mutation atomically
+//! updates the replica, its list projection, and the durable aggregate outbox.
+
+use research_domain::{
+    AggregateKind, LifecycleState, ZenAggregate, ZenDocumentSeed, ZenDocumentSummary,
+    ZenDocumentView,
+};
+use serde::{Deserialize, Serialize};
+use sqlx::{Row, SqliteConnection};
+use uuid::Uuid;
+
+use crate::store::{now_rfc3339, peer_id_for_device, sha256_hex};
+use crate::{StoreError, StoreResult, V2Store};
+
+const KIND: &str = "zen_document";
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CreateZenDocumentRequest {
+    pub title: Option<String>,
+    pub body: String,
+    pub tags: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct EditZenDocumentRequest {
+    pub document_id: String,
+    pub title: Option<Option<String>>,
+    pub body: Option<String>,
+    pub add_tags: Vec<String>,
+    pub remove_tags: Vec<String>,
+}
+
+impl EditZenDocumentRequest {
+    fn has_changes(&self) -> bool {
+        self.title.is_some()
+            || self.body.is_some()
+            || !self.add_tags.is_empty()
+            || !self.remove_tags.is_empty()
+    }
+}
+
+impl V2Store {
+    pub async fn create_zen_document(
+        &self,
+        request: CreateZenDocumentRequest,
+    ) -> StoreResult<ZenDocumentSummary> {
+        let document_id = Uuid::now_v7().to_string();
+        let created_at = chrono::Utc::now().timestamp();
+        self.commit_zen(&document_id, move |context| {
+            let seed = ZenDocumentSeed {
+                document_id: context.document_id.to_owned(),
+                title: request.title.clone(),
+                body: request.body.clone(),
+                created_at,
+                tags: request.tags.clone(),
+            };
+            let aggregate = ZenAggregate::create(&seed, context.prefix, context.peer_id)?;
+            Ok(aggregate)
+        })
+        .await
+    }
+
+    pub async fn edit_zen_document(
+        &self,
+        request: EditZenDocumentRequest,
+    ) -> StoreResult<ZenDocumentSummary> {
+        if !request.has_changes() {
+            return Err(StoreError::NoChanges);
+        }
+        let document_id = request.document_id.clone();
+        self.commit_zen(&document_id.clone(), move |context| {
+            let aggregate = context.load()?;
+            if let Some(title) = &request.title {
+                aggregate
+                    .write_title(&format!("{}/title", context.prefix), title.as_deref())?;
+            }
+            if let Some(body) = &request.body {
+                aggregate.set_body(body)?;
+            }
+            for tag in &request.remove_tags {
+                aggregate.remove_tag(tag)?;
+            }
+            for (index, tag) in request.add_tags.iter().enumerate() {
+                aggregate.add_tag(tag, &format!("{}/tag-add/{index:020}", context.prefix))?;
+            }
+            Ok(aggregate)
+        })
+        .await
+    }
+
+    pub async fn delete_zen_document(
+        &self,
+        document_id: &str,
+    ) -> StoreResult<ZenDocumentSummary> {
+        self.transition_zen(document_id, LifecycleState::Deleted)
+            .await
+    }
+
+    pub async fn restore_zen_document(
+        &self,
+        document_id: &str,
+    ) -> StoreResult<ZenDocumentSummary> {
+        self.transition_zen(document_id, LifecycleState::Active)
+            .await
+    }
+
+    async fn transition_zen(
+        &self,
+        document_id: &str,
+        state: LifecycleState,
+    ) -> StoreResult<ZenDocumentSummary> {
+        self.commit_zen(document_id, move |context| {
+            let aggregate = context.load()?;
+            aggregate.transition_lifecycle(&format!("{}/lifecycle", context.prefix), state)?;
+            Ok(aggregate)
+        })
+        .await
+    }
+
+    /// Reads one document including its body.
+    pub async fn zen_document(&self, document_id: &str) -> StoreResult<ZenDocumentView> {
+        let mut connection = self.pool.acquire().await?;
+        let peer_id = peer_id_for_device(&self.meta("device_id").await?)?;
+        load_aggregate(&mut connection, document_id, peer_id)
+            .await?
+            .view()
+            .map_err(StoreError::from)
+    }
+
+    /// Lists documents from the projection, never touching a body.
+    pub async fn list_zen_documents(&self) -> StoreResult<Vec<ZenDocumentSummary>> {
+        let rows = sqlx::query(
+            "SELECT document_id, title, byte_length, todo_total, todo_done, created_at, \
+             lifecycle_state FROM zen_documents WHERE lifecycle_state = 'active' \
+             ORDER BY edited_at DESC, document_id ASC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        let mut summaries = Vec::with_capacity(rows.len());
+        for row in rows {
+            let document_id: String = row.try_get("document_id")?;
+            let tags = sqlx::query_scalar::<_, String>(
+                "SELECT tag FROM zen_document_tags WHERE document_id = ? ORDER BY tag ASC",
+            )
+            .bind(&document_id)
+            .fetch_all(&self.pool)
+            .await?;
+            summaries.push(ZenDocumentSummary {
+                document_id,
+                title: row.try_get("title")?,
+                created_at: row.try_get("created_at")?,
+                byte_length: usize::try_from(row.try_get::<i64, _>("byte_length")?)
+                    .map_err(|_| StoreError::NumericRange("zen body length"))?,
+                todo_total: usize::try_from(row.try_get::<i64, _>("todo_total")?)
+                    .map_err(|_| StoreError::NumericRange("zen todo total"))?,
+                todo_done: usize::try_from(row.try_get::<i64, _>("todo_done")?)
+                    .map_err(|_| StoreError::NumericRange("zen todo done"))?,
+                tags,
+                lifecycle_state: match row.try_get::<String, _>("lifecycle_state")?.as_str() {
+                    "deleted" => LifecycleState::Deleted,
+                    _ => LifecycleState::Active,
+                },
+            });
+        }
+        Ok(summaries)
+    }
+
+    /// Runs one zen mutation atomically: replica, projection, and outbox.
+    async fn commit_zen<F>(
+        &self,
+        document_id: &str,
+        mutate: F,
+    ) -> StoreResult<ZenDocumentSummary>
+    where
+        F: FnOnce(&ZenContext<'_>) -> StoreResult<ZenAggregate> + Send,
+    {
+        let library_id = self.meta("library_id").await?;
+        let device_id = self.meta("device_id").await?;
+        let peer_id = peer_id_for_device(&device_id)?;
+
+        let mut connection = self.pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *connection)
+            .await?;
+        let result = async {
+            let sequence_text: String =
+                sqlx::query_scalar("SELECT next_sequence FROM devices WHERE device_id = ?")
+                    .bind(&device_id)
+                    .fetch_one(&mut *connection)
+                    .await?;
+            let sequence = sequence_text
+                .parse::<u64>()
+                .map_err(|_| StoreError::InvalidStore("invalid device sequence".into()))?;
+            let prefix = format!("{device_id}/{sequence_text}/zen/{document_id}");
+
+            let existing = read_snapshot(&mut connection, document_id).await?;
+            let before = existing
+                .as_ref()
+                .map(|snapshot| {
+                    ZenAggregate::from_snapshot(document_id, snapshot, peer_id)
+                        .map(|aggregate| aggregate.version())
+                })
+                .transpose()?
+                .unwrap_or_default();
+            let context = ZenContext {
+                document_id,
+                prefix: &prefix,
+                peer_id,
+                snapshot: existing.as_deref(),
+            };
+            let aggregate = mutate(&context)?;
+
+            let now = now_rfc3339();
+            let envelope =
+                aggregate.export_envelope(&before, &library_id, &device_id, sequence, &now)?;
+            let snapshot = aggregate.export_snapshot()?;
+            let view = aggregate.view()?;
+            let summary = view.summary();
+
+            sqlx::query(
+                "INSERT INTO aggregate_state \
+                 (aggregate_kind, aggregate_id, snapshot, snapshot_sha256, updated_at) \
+                 VALUES (?, ?, ?, ?, ?) \
+                 ON CONFLICT(aggregate_kind, aggregate_id) DO UPDATE SET \
+                 snapshot = excluded.snapshot, snapshot_sha256 = excluded.snapshot_sha256, \
+                 updated_at = excluded.updated_at",
+            )
+            .bind(KIND)
+            .bind(document_id)
+            .bind(&snapshot)
+            .bind(sha256_hex(&snapshot))
+            .bind(&now)
+            .execute(&mut *connection)
+            .await?;
+            persist_zen_projection(&mut connection, &summary, &now).await?;
+
+            let path = envelope.path()?;
+            sqlx::query(
+                "INSERT INTO aggregate_batches \
+                 (aggregate_kind, aggregate_id, device_id, sequence, path, payload_sha256, \
+                  envelope_json, origin, applied_at) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, 'local', ?)",
+            )
+            .bind(KIND)
+            .bind(document_id)
+            .bind(&envelope.device_id)
+            .bind(&envelope.sequence)
+            .bind(&path)
+            .bind(&envelope.payload_sha256)
+            .bind(serde_json::to_string(&envelope)?)
+            .bind(&now)
+            .execute(&mut *connection)
+            .await?;
+            sqlx::query(
+                "INSERT INTO aggregate_outbox \
+                 (aggregate_kind, aggregate_id, device_id, sequence, enqueued_at) \
+                 VALUES (?, ?, ?, ?, ?)",
+            )
+            .bind(KIND)
+            .bind(document_id)
+            .bind(&envelope.device_id)
+            .bind(&envelope.sequence)
+            .bind(&now)
+            .execute(&mut *connection)
+            .await?;
+            let next = sequence
+                .checked_add(1)
+                .ok_or(StoreError::NumericRange("device sequence"))?;
+            sqlx::query("UPDATE devices SET next_sequence = ? WHERE device_id = ?")
+                .bind(format!("{next:020}"))
+                .bind(&device_id)
+                .execute(&mut *connection)
+                .await?;
+            Ok(summary)
+        }
+        .await;
+        match result {
+            Ok(summary) => {
+                sqlx::query("COMMIT").execute(&mut *connection).await?;
+                Ok(summary)
+            }
+            Err(error) => {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *connection).await;
+                Err(error)
+            }
+        }
+    }
+}
+
+/// What a zen mutation is given: identity, a unique operation prefix, and the
+/// replica it is editing.
+struct ZenContext<'a> {
+    document_id: &'a str,
+    prefix: &'a str,
+    peer_id: u64,
+    snapshot: Option<&'a [u8]>,
+}
+
+impl ZenContext<'_> {
+    fn load(&self) -> StoreResult<ZenAggregate> {
+        let snapshot = self
+            .snapshot
+            .ok_or_else(|| StoreError::ItemNotFound(self.document_id.to_owned()))?;
+        ZenAggregate::from_snapshot(self.document_id, snapshot, self.peer_id)
+            .map_err(StoreError::from)
+    }
+}
+
+async fn read_snapshot(
+    connection: &mut SqliteConnection,
+    document_id: &str,
+) -> StoreResult<Option<Vec<u8>>> {
+    Ok(sqlx::query_scalar(
+        "SELECT snapshot FROM aggregate_state WHERE aggregate_kind = ? AND aggregate_id = ?",
+    )
+    .bind(KIND)
+    .bind(document_id)
+    .fetch_optional(&mut *connection)
+    .await?)
+}
+
+async fn load_aggregate(
+    connection: &mut SqliteConnection,
+    document_id: &str,
+    peer_id: u64,
+) -> StoreResult<ZenAggregate> {
+    let snapshot = read_snapshot(connection, document_id)
+        .await?
+        .ok_or_else(|| StoreError::ItemNotFound(document_id.to_owned()))?;
+    ZenAggregate::from_snapshot(document_id, &snapshot, peer_id).map_err(StoreError::from)
+}
+
+async fn persist_zen_projection(
+    connection: &mut SqliteConnection,
+    summary: &ZenDocumentSummary,
+    now: &str,
+) -> StoreResult<()> {
+    sqlx::query(
+        "INSERT INTO zen_documents \
+         (document_id, title, byte_length, todo_total, todo_done, created_at, edited_at, \
+          lifecycle_state) VALUES (?, ?, ?, ?, ?, ?, ?, ?) \
+         ON CONFLICT(document_id) DO UPDATE SET title = excluded.title, \
+         byte_length = excluded.byte_length, todo_total = excluded.todo_total, \
+         todo_done = excluded.todo_done, edited_at = excluded.edited_at, \
+         lifecycle_state = excluded.lifecycle_state",
+    )
+    .bind(&summary.document_id)
+    .bind(&summary.title)
+    .bind(i64::try_from(summary.byte_length).unwrap_or(i64::MAX))
+    .bind(i64::try_from(summary.todo_total).unwrap_or(i64::MAX))
+    .bind(i64::try_from(summary.todo_done).unwrap_or(i64::MAX))
+    .bind(summary.created_at)
+    .bind(now)
+    .bind(match summary.lifecycle_state {
+        LifecycleState::Active => "active",
+        LifecycleState::Deleted => "deleted",
+    })
+    .execute(&mut *connection)
+    .await?;
+    sqlx::query("DELETE FROM zen_document_tags WHERE document_id = ?")
+        .bind(&summary.document_id)
+        .execute(&mut *connection)
+        .await?;
+    for tag in &summary.tags {
+        sqlx::query("INSERT INTO zen_document_tags (document_id, tag) VALUES (?, ?)")
+            .bind(&summary.document_id)
+            .bind(tag)
+            .execute(&mut *connection)
+            .await?;
+    }
+    Ok(())
+}
+
+/// Exposed so the aggregate kind is named once.
+pub fn zen_aggregate_kind() -> AggregateKind {
+    AggregateKind::Zen
+}

--- a/crates/research-store/tests/zen_contract.rs
+++ b/crates/research-store/tests/zen_contract.rs
@@ -1,0 +1,82 @@
+use research_store::{CreateZenDocumentRequest, EditZenDocumentRequest, V2Store};
+
+/// The workspace list must stay metadata-only and every edit must queue exactly
+/// one aggregate-scoped operation.
+#[tokio::test]
+async fn zen_documents_project_metadata_and_queue_one_operation_per_edit() {
+    let root = tempfile::tempdir().expect("temporary test root");
+    let store = V2Store::init(root.path().join("library"))
+        .await
+        .expect("store");
+
+    let created = store
+        .create_zen_document(CreateZenDocumentRequest {
+            title: Some("Today".into()),
+            body: "- [x] Ship it\n- [ ] Review #132\n\nGrocery run.".into(),
+            tags: vec!["reading".into()],
+        })
+        .await
+        .expect("create document");
+    assert_eq!((created.todo_total, created.todo_done), (2, 1));
+
+    let listed = store.list_zen_documents().await.expect("list");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].title.as_deref(), Some("Today"));
+    assert_eq!(listed[0].tags, ["reading"]);
+    assert_eq!(listed[0].byte_length, created.byte_length);
+
+    let edited = store
+        .edit_zen_document(EditZenDocumentRequest {
+            document_id: created.document_id.clone(),
+            body: Some("- [x] Ship it\n- [x] Review #132\n\nGrocery run.".into()),
+            add_tags: vec!["crdt".into()],
+            ..EditZenDocumentRequest::default()
+        })
+        .await
+        .expect("edit document");
+    assert_eq!(
+        (edited.todo_total, edited.todo_done),
+        (2, 2),
+        "todo counts follow the body rather than a stored counter"
+    );
+    assert_eq!(edited.tags, ["crdt", "reading"]);
+
+    let reopened = store
+        .zen_document(&created.document_id)
+        .await
+        .expect("read document body");
+    assert!(reopened.body.contains("- [x] Review #132"));
+
+    // Deleting hides the document from the workspace without destroying it.
+    store
+        .delete_zen_document(&created.document_id)
+        .await
+        .expect("delete");
+    assert!(store.list_zen_documents().await.expect("list").is_empty());
+    store
+        .restore_zen_document(&created.document_id)
+        .await
+        .expect("restore");
+    assert_eq!(store.list_zen_documents().await.expect("list").len(), 1);
+
+    // One operation per mutation: create, edit, delete, restore.
+    let queued: i64 = sqlx_scalar(&store, "SELECT COUNT(*) FROM aggregate_outbox").await;
+    assert_eq!(queued, 4);
+    let items: i64 = sqlx_scalar(&store, "SELECT COUNT(*) FROM outbox").await;
+    assert_eq!(items, 0, "zen work never lands in the protocol-v1 outbox");
+}
+
+async fn sqlx_scalar(store: &V2Store, query: &'static str) -> i64 {
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(&format!(
+            "sqlite://{}",
+            store.database_path().to_string_lossy()
+        ))
+        .await
+        .expect("open database");
+    sqlx::query_scalar(query)
+        .fetch_one(&pool)
+        .await
+        .expect("scalar query")
+}


### PR DESCRIPTION
## Summary

Local persistence for zen documents (#140), on the aggregate foundation from #146/#147. This is the last layer before the surfaces themselves.

- **One replica per document.** Each document is an `aggregate_state` row, so a mutation loads only that document — editing one never costs anything proportional to the rest of the library, which is the ADR 0010 property zen inherits by being an aggregate.
- **Metadata-only list projection.** `zen_documents` carries title, byte length, todo counts, tags, and lifecycle, and deliberately has no body column. Opening the workspace stays proportional to document count rather than document size — design screen 1b's "titles and metadata only — bodies load on open". Bodies are read from the replica only when a document is opened.
- **Aggregate outbox.** `aggregate_batches`/`aggregate_outbox` hold v2 envelopes addressed by `(kind, aggregate)`, which the protocol-v1 tables have no column for. Every mutation atomically updates the replica, the projection, and the queue, so the v2 sync driver has durable work waiting when it lands.
- CRUD: create, edit (title/body/tags), delete, restore, read-one, list.

## Simplification

Envelope construction was about to be restated for a second kind, so `build_aggregate_envelope` is now shared: kinds differ only in what they put in the envelope, not how it is built or validated.

## Impact

Additive. No existing surface constructs a zen document yet, and zen work never touches the protocol-v1 outbox — asserted in the test.

## Verification

New `zen_contract.rs`: todo counts follow the body rather than a stored counter across an edit, tags canonicalize, the list stays metadata-only, delete hides from the workspace without destroying, restore brings it back, and exactly one aggregate operation is queued per mutation with zero landing in the v1 outbox.

`cargo fmt --all -- --check`, `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`, and `cargo test --locked --workspace --all-targets --all-features` all pass.

Refs #140, #132
