### PR TITLE
Ship the Research Zen web workspace

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -81,10 +81,12 @@
 
         <p class="landing-footnote">
           Restoring first avoids merges. Keep browser storage enabled.
+          <a href="./app/">Open an existing library</a> ·
           <a href="./overview/">Product overview</a> ·
           <a href="./docs/">Reference guide</a>
         </p>
       </section>
     </main>
+    <script type="module" src="./src/landing.ts"></script>
   </body>
 </html>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,10 +12,16 @@ import {
   type MarkdownImage,
 } from "./components/MarkdownDocument.tsx";
 import {
+  ZenWorkspace,
+  type ZenMentionTarget,
+} from "./components/ZenWorkspace.tsx";
+import type { PersistedZenDocument } from "./data/db";
+import {
   type LibraryState,
   type CapturedDocumentReference,
   type PendingSyncChange,
   type UndoableChange,
+  type ZenDocumentView,
   libraryRepository,
 } from "./data/library.ts";
 import {
@@ -56,7 +62,7 @@ type LifecycleFilter = "active" | "deleted" | "all";
 type SearchScope = "all" | "title" | "url" | "context" | "tags";
 type SortMode = "recent" | "oldest" | "title";
 type TagMatchMode = "any" | "all";
-type WorkspaceView = "library" | "settings" | "sync";
+type WorkspaceView = "library" | "settings" | "sync" | "zen";
 type Density = "comfortable" | "compact";
 
 interface ThemeColors {
@@ -208,6 +214,11 @@ export function App() {
   const [announcement, setAnnouncement] = useState("");
   const [localError, setLocalError] = useState<string | null>(null);
   const [undoNotice, setUndoNotice] = useState<UndoNotice | null>(null);
+  const [zenDocuments, setZenDocuments] = useState<PersistedZenDocument[]>([]);
+  const [openZen, setOpenZen] = useState<{
+    documentId: string;
+    view: ZenDocumentView;
+  } | null>(null);
   const [profiles, setProfiles] = useState<LibraryProfile[]>([]);
   const [activeProfileId, setActiveProfileId] = useState<string | null>(null);
   const captureOpenerRef = useRef<HTMLButtonElement | null>(null);
@@ -238,6 +249,16 @@ export function App() {
       unsubscribeProfile();
     };
   }, []);
+
+  // The workspace index is metadata only, so refreshing it on entry is cheap
+  // no matter how large the documents are.
+  useEffect(() => {
+    if (view !== "zen" || !libraryState.initialized) return;
+    void libraryRepository
+      .listZenDocuments()
+      .then(setZenDocuments)
+      .catch(() => setZenDocuments([]));
+  }, [view, libraryState.initialized]);
 
   useEffect(() => {
     try {
@@ -467,6 +488,79 @@ export function App() {
       window.history.pushState(window.history.state, "", nextUrl);
     }
     setView(nextView);
+  }
+
+  async function refreshZenDocuments() {
+    setZenDocuments(await libraryRepository.listZenDocuments());
+  }
+
+  async function openZenDocument(documentId: string) {
+    try {
+      setOpenZen({
+        documentId,
+        view: await libraryRepository.zenDocument(documentId),
+      });
+    } catch (error) {
+      setLocalError(error instanceof Error ? error.message : "That document could not be opened.");
+    }
+  }
+
+  async function createZenDocument(title: string) {
+    await runZen(async () => {
+      const documentId = await libraryRepository.createZenDocument({
+        title: title.trim() || null,
+        body: "",
+        tags: [],
+      });
+      await refreshZenDocuments();
+      await openZenDocument(documentId);
+    });
+  }
+
+  async function saveZenBody(documentId: string, body: string) {
+    await runZen(async () => {
+      await libraryRepository.setZenBody(documentId, body);
+      await refreshZenDocuments();
+      await openZenDocument(documentId);
+    });
+  }
+
+  async function saveZenTitle(documentId: string, title: string | null) {
+    await runZen(async () => {
+      await libraryRepository.setZenTitle(documentId, title);
+      await refreshZenDocuments();
+      await openZenDocument(documentId);
+    });
+  }
+
+  async function removeZenDocument(documentId: string) {
+    await runZen(async () => {
+      await libraryRepository.deleteZenDocument(documentId);
+      setOpenZen(null);
+      await refreshZenDocuments();
+    });
+  }
+
+  /** Shared busy/error handling so every zen action reports the same way. */
+  async function runZen(action: () => Promise<void>) {
+    setBusyAction("zen");
+    setLocalError(null);
+    try {
+      await action();
+    } catch (error) {
+      setLocalError(
+        error instanceof Error ? error.message : "That change was not saved.",
+      );
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  /** Mentions resolve against the loaded library, so deletes stay visible. */
+  function resolveZenMention(itemId: string): ZenMentionTarget | null {
+    const item = items.find((candidate) => candidate.id === itemId);
+    if (!item) return null;
+    return { title: item.title ?? null, url: item.url, deleted: item.deleted };
   }
 
   async function refreshProfiles() {
@@ -719,9 +813,6 @@ export function App() {
               rp
             </span>
             <p className="brand-name">ResearchPocket</p>
-            {view === "library" ? null : (
-              <p className="brand-context">← library</p>
-            )}
           </button>
 
           <div className="masthead-actions">
@@ -768,6 +859,7 @@ export function App() {
 
       <div className="workspace-layout">
         <aside className="tag-rail">
+          {view === "library" && (
           <nav aria-label="Library views" className="rail-nav">
             <button
               aria-current={view === "library" && filter === "active" && !favoriteOnly ? "page" : undefined}
@@ -807,7 +899,26 @@ export function App() {
               <span>Archive</span><small>{deletedCount}</small>
             </button>
           </nav>
+          )}
 
+          <div className="rail-tags">
+            <div className="rail-heading">
+              <p>Zen</p>
+            </div>
+            <nav aria-label="Zen" className="rail-nav">
+              <button
+                aria-current={view === "zen" ? "page" : undefined}
+                onClick={() => navigateToView("zen")}
+                type="button"
+              >
+                <span>Documents</span>
+                <small>{zenDocuments.length}</small>
+              </button>
+            </nav>
+          </div>
+
+          {view === "library" && (
+          <>
           <div className="rail-tags">
             <div className="rail-heading">
               <p>Tags</p>
@@ -838,6 +949,8 @@ export function App() {
           >
             Tags{selectedTags.length > 0 ? ` · ${selectedTags.length}` : ""}
           </button>
+          </>
+          )}
 
           <nav aria-label="Workspace utilities" className="rail-utilities">
             <button onClick={() => navigateToView("sync")} type="button">
@@ -880,6 +993,20 @@ export function App() {
           onThemeChange={setTheme}
           profiles={profiles}
           theme={theme}
+        />
+
+        <ZenWorkspace
+          busy={busyAction !== null}
+          documents={zenDocuments}
+          hidden={view !== "zen"}
+          onClose={() => setOpenZen(null)}
+          onCreate={(title) => void createZenDocument(title)}
+          onDelete={(documentId) => void removeZenDocument(documentId)}
+          onOpen={(documentId) => void openZenDocument(documentId)}
+          onSaveBody={(documentId, body) => void saveZenBody(documentId, body)}
+          onSaveTitle={(documentId, title) => void saveZenTitle(documentId, title)}
+          open={openZen}
+          resolveMention={resolveZenMention}
         />
 
           <section
@@ -3161,6 +3288,7 @@ function readWorkspaceView(): WorkspaceView {
   ) {
     return "sync";
   }
+  if (window.location.hash === "#zen") return "zen";
   return window.location.hash === "#settings" ? "settings" : "library";
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,5 @@
 import {
+  Fragment,
   type SubmitEvent,
   type ReactNode,
   useDeferredValue,
@@ -250,10 +251,11 @@ export function App() {
     };
   }, []);
 
-  // The workspace index is metadata only, so refreshing it on entry is cheap
-  // no matter how large the documents are.
+  // Loaded for every view, not just Zen: the command palette and the mobile
+  // navigation both surface documents from anywhere. The index is metadata
+  // only, so this stays cheap no matter how large the documents are.
   useEffect(() => {
-    if (view !== "zen" || !libraryState.initialized) return;
+    if (!libraryState.initialized) return;
     void libraryRepository
       .listZenDocuments()
       .then(setZenDocuments)
@@ -1269,6 +1271,7 @@ export function App() {
         </main>
         <nav aria-label="Mobile actions" className="mobile-actions">
           <button className="primary-button" onClick={(event) => openCapture(event.currentTarget)} type="button">＋ Save a link</button>
+          <button className="secondary-button" onClick={() => { setOpenZen(null); navigateToView("zen"); }} type="button">Zen {zenDocuments.length}</button>
           <button className="secondary-button" onClick={() => navigateToView("sync")} type="button">Sync {libraryState.pendingCount}</button>
           <button className="secondary-button" onClick={() => navigateToView("settings")} type="button">Settings</button>
         </nav>
@@ -1351,14 +1354,30 @@ export function App() {
             setCommandOpen(false);
             setCapturing(true);
           }}
+          onNewZenDocument={() => {
+            setCommandOpen(false);
+            navigateToView("zen");
+            void createZenDocument("");
+          }}
           onOpenItem={(item) => {
             openReader(item);
             setCommandOpen(false);
+          }}
+          onOpenZenDocument={(documentId) => {
+            setCommandOpen(false);
+            navigateToView("zen");
+            void openZenDocument(documentId);
+          }}
+          onOpenZenWorkspace={() => {
+            setCommandOpen(false);
+            setOpenZen(null);
+            navigateToView("zen");
           }}
           onSwitchLibrary={(profileId) => {
             setCommandOpen(false);
             void switchLibrary(profileId);
           }}
+          zenDocuments={zenDocuments}
           onSync={() => {
             navigateToView("sync");
             setCommandOpen(false);
@@ -2098,6 +2117,15 @@ function QuickAdd({
   );
 }
 
+interface CommandOption {
+  key: string;
+  group: string;
+  primary: string;
+  detail?: string;
+  hint?: string;
+  run(): void;
+}
+
 function CommandPalette({
   items,
   libraries,
@@ -2105,10 +2133,14 @@ function CommandPalette({
   onFilterTag,
   onNewLibrary,
   onNewSave,
+  onNewZenDocument,
   onOpenItem,
+  onOpenZenDocument,
+  onOpenZenWorkspace,
   onSwitchLibrary,
   onSync,
   tags,
+  zenDocuments,
 }: {
   items: LibraryItemView[];
   libraries: LibraryProfile[];
@@ -2116,56 +2148,118 @@ function CommandPalette({
   onFilterTag: (tag: string) => void;
   onNewSave: () => void;
   onNewLibrary: () => void;
+  onNewZenDocument: () => void;
   onOpenItem: (item: LibraryItemView) => void;
+  onOpenZenDocument: (documentId: string) => void;
+  onOpenZenWorkspace: () => void;
   onSwitchLibrary: (profileId: string) => void;
   onSync: () => void;
   tags: { count: number; tag: string }[];
+  zenDocuments: PersistedZenDocument[];
 }) {
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
   const dialogRef = useRef<HTMLDialogElement>(null);
   const normalized = query.trim().toLocaleLowerCase();
-  const matchingTags = tags
-    .filter(({ tag }) => !normalized || tag.toLocaleLowerCase().includes(normalized))
-    .slice(0, 5);
-  const matchingItems = items
-    .filter((item) =>
-      !normalized || [item.title, item.url, ...item.tags]
-        .filter(Boolean)
-        .some((value) => value!.toLocaleLowerCase().includes(normalized)),
-    )
-    .slice(0, 6);
-  const matchingLibraries = libraries
-    .filter((profile) => !normalized || profile.name.toLocaleLowerCase().includes(normalized))
-    .slice(0, 4);
-  const optionCount =
-    matchingTags.length + matchingItems.length + matchingLibraries.length + 3;
 
-  function runOption(index: number) {
-    if (index < matchingTags.length) {
-      onFilterTag(matchingTags[index]!.tag);
-      return;
-    }
-
-    const itemIndex = index - matchingTags.length;
-    if (itemIndex < matchingItems.length) {
-      onOpenItem(matchingItems[itemIndex]!);
-      return;
-    }
-
-    const libraryIndex = itemIndex - matchingItems.length;
-    if (libraryIndex < matchingLibraries.length) {
-      onSwitchLibrary(matchingLibraries[libraryIndex]!.id);
-      return;
-    }
-
-    if (libraryIndex === matchingLibraries.length) onSync();
-    else if (libraryIndex === matchingLibraries.length + 1) onNewSave();
-    else onNewLibrary();
-  }
+  // One flat list drives selection, keyboard movement, and rendering. Offsets
+  // per section used to be recomputed in four places, so every new kind of
+  // result was a chance to mis-index one of them.
+  const options: CommandOption[] = [
+    ...tags
+      .filter(({ tag }) => !normalized || tag.toLocaleLowerCase().includes(normalized))
+      .slice(0, 5)
+      .map(({ count, tag }) => ({
+        key: `tag-${tag}`,
+        group: "Tags",
+        primary: `#${tag}`,
+        detail: pluralize(count, "save"),
+        hint: "↵ filter library",
+        run: () => onFilterTag(tag),
+      })),
+    ...items
+      .filter((item) =>
+        !normalized || [item.title, item.url, ...item.tags]
+          .filter(Boolean)
+          .some((value) => value!.toLocaleLowerCase().includes(normalized)),
+      )
+      .slice(0, 6)
+      .map((item) => ({
+        key: `item-${item.id}`,
+        group: "Saves",
+        primary: item.title?.trim() || item.url,
+        detail: readHostname(item.url),
+        hint: item.tags.map((tag) => `#${tag}`).join(" "),
+        run: () => onOpenItem(item),
+      })),
+    ...zenDocuments
+      .filter(
+        (document) =>
+          !normalized ||
+          (document.title ?? "").toLocaleLowerCase().includes(normalized) ||
+          document.tags.some((tag) => tag.toLocaleLowerCase().includes(normalized)),
+      )
+      .slice(0, 5)
+      .map((document) => ({
+        key: `zen-${document.documentId}`,
+        group: "Documents",
+        primary: document.title?.trim() || "Untitled document",
+        detail:
+          document.todoTotal > 0
+            ? `${document.todoDone}/${document.todoTotal} todos`
+            : "document",
+        hint: "↵ open document",
+        run: () => onOpenZenDocument(document.documentId),
+      })),
+    ...libraries
+      .filter((profile) => !normalized || profile.name.toLocaleLowerCase().includes(normalized))
+      .slice(0, 4)
+      .map((profile) => ({
+        key: `library-${profile.id}`,
+        group: "Libraries",
+        primary: profile.name,
+        hint: "↵ open library",
+        run: () => onSwitchLibrary(profile.id),
+      })),
+    {
+      key: "action-sync",
+      group: "Actions",
+      primary: "Sync",
+      hint: "open status",
+      run: onSync,
+    },
+    {
+      key: "action-save",
+      group: "Actions",
+      primary: "Save a URL",
+      hint: "new save",
+      run: onNewSave,
+    },
+    {
+      key: "action-zen",
+      group: "Actions",
+      primary: "Zen",
+      hint: "open documents",
+      run: onOpenZenWorkspace,
+    },
+    {
+      key: "action-zen-new",
+      group: "Actions",
+      primary: "New document",
+      hint: "prose, lists, todos",
+      run: onNewZenDocument,
+    },
+    {
+      key: "action-library",
+      group: "Actions",
+      primary: "New library",
+      hint: "create and open",
+      run: onNewLibrary,
+    },
+  ];
 
   function moveSelection(offset: number) {
-    setActiveIndex((current) => (current + offset + optionCount) % optionCount);
+    setActiveIndex((current) => (current + offset + options.length) % options.length);
   }
 
   useEffect(() => {
@@ -2200,7 +2294,7 @@ function CommandPalette({
           aria-activedescendant={`command-option-${activeIndex}`}
           aria-controls="command-results"
           aria-expanded="true"
-          aria-label="Search saves, tags, and commands"
+          aria-label="Search saves, documents, and commands"
           onChange={(event) => {
             setQuery(event.target.value);
             setActiveIndex(0);
@@ -2222,41 +2316,35 @@ function CommandPalette({
               moveSelection(-1);
             } else if (event.key === "Enter" && !event.nativeEvent.isComposing) {
               event.preventDefault();
-              runOption(activeIndex);
+              options[activeIndex]?.run();
             }
           }}
-          placeholder="Search saves, tags, and commands"
+          placeholder="Search saves, documents, and commands"
           role="combobox"
           value={query}
         />
       </div>
       <div className="command-results" id="command-results" role="listbox">
-        {matchingTags.length > 0 ? <p role="presentation">Tags</p> : null}
-        {matchingTags.map(({ count, tag }, index) => (
-          <button aria-selected={activeIndex === index} className={activeIndex === index ? "command-selected" : undefined} id={`command-option-${index}`} key={tag} onClick={() => onFilterTag(tag)} onPointerEnter={() => setActiveIndex(index)} role="option" type="button">
-            <span>#{tag}</span><small>{pluralize(count, "save")}</small><em>↵ filter library</em>
-          </button>
+        {options.map((option, index) => (
+          <Fragment key={option.key}>
+            {index === 0 || options[index - 1]!.group !== option.group ? (
+              <p role="presentation">{option.group}</p>
+            ) : null}
+            <button
+              aria-selected={activeIndex === index}
+              className={activeIndex === index ? "command-selected" : undefined}
+              id={`command-option-${index}`}
+              onClick={option.run}
+              onPointerEnter={() => setActiveIndex(index)}
+              role="option"
+              type="button"
+            >
+              <span>{option.primary}</span>
+              {option.detail ? <small>{option.detail}</small> : null}
+              {option.hint ? <em>{option.hint}</em> : null}
+            </button>
+          </Fragment>
         ))}
-        {matchingItems.length > 0 ? <p role="presentation">Saves</p> : null}
-        {matchingItems.map((item, itemIndex) => {
-          const index = matchingTags.length + itemIndex;
-          return <button aria-selected={activeIndex === index} className={activeIndex === index ? "command-selected" : undefined} id={`command-option-${index}`} key={item.id} onClick={() => onOpenItem(item)} onPointerEnter={() => setActiveIndex(index)} role="option" type="button">
-            <strong>{item.title?.trim() || item.url}</strong>
-            <small>{readHostname(item.url)}</small>
-            <em>{item.tags.map((tag) => `#${tag}`).join(" ")}</em>
-          </button>;
-        })}
-        {matchingLibraries.length > 0 ? <p role="presentation">Libraries</p> : null}
-        {matchingLibraries.map((profile, libraryIndex) => {
-          const index = matchingTags.length + matchingItems.length + libraryIndex;
-          return <button aria-selected={activeIndex === index} className={activeIndex === index ? "command-selected" : undefined} id={`command-option-${index}`} key={profile.id} onClick={() => onSwitchLibrary(profile.id)} onPointerEnter={() => setActiveIndex(index)} role="option" type="button">
-            <span>{profile.name}</span><em>↵ open library</em>
-          </button>;
-        })}
-        <p role="presentation">Actions</p>
-        <button aria-selected={activeIndex === optionCount - 3} className={activeIndex === optionCount - 3 ? "command-selected" : undefined} id={`command-option-${optionCount - 3}`} onClick={onSync} onPointerEnter={() => setActiveIndex(optionCount - 3)} role="option" type="button"><span>Sync</span><em>open status</em></button>
-        <button aria-selected={activeIndex === optionCount - 2} className={activeIndex === optionCount - 2 ? "command-selected" : undefined} id={`command-option-${optionCount - 2}`} onClick={onNewSave} onPointerEnter={() => setActiveIndex(optionCount - 2)} role="option" type="button"><span>Save a URL</span><em>new save</em></button>
-        <button aria-selected={activeIndex === optionCount - 1} className={activeIndex === optionCount - 1 ? "command-selected" : undefined} id={`command-option-${optionCount - 1}`} onClick={onNewLibrary} onPointerEnter={() => setActiveIndex(optionCount - 1)} role="option" type="button"><span>New library</span><em>create and open</em></button>
       </div>
       <footer className="command-footer"><span><b>Ctrl P/N · ↑↓</b> navigate</span><span><b>↵</b> select</span><span><b>esc</b> close</span></footer>
     </dialog>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1276,7 +1276,7 @@ export function App() {
         </main>
         <nav aria-label="Mobile actions" className="mobile-actions">
           <button className="primary-button" onClick={(event) => openCapture(event.currentTarget)} type="button">＋ Save a link</button>
-          <button className="secondary-button" onClick={() => { setOpenZen(null); navigateToView("zen"); }} type="button">Zen {zenDocuments.length}</button>
+          <button className="secondary-button" onClick={() => { setOpenZen(null); navigateToView("zen"); }} type="button">Zen</button>
           <button className="secondary-button" onClick={() => navigateToView("settings")} type="button">Settings</button>
         </nav>
       </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -841,13 +841,18 @@ export function App() {
                 </select>
               </div>
             ) : null}
-            <div className="local-status" role="status">
+            <button
+              aria-label={`Sync — ${formatHeaderStatus(libraryState.status, libraryState.pendingCount)}`}
+              className="local-status"
+              onClick={() => navigateToView("sync")}
+              type="button"
+            >
               <span aria-hidden="true" className="status-dot" />
               <span className="status-label">local</span>
-              <span className="status-copy">
+              <span aria-live="polite" className="status-copy" role="status">
                 {formatHeaderStatus(libraryState.status, libraryState.pendingCount)}
               </span>
-            </div>
+            </button>
             <button
               className="command-trigger"
               onClick={() => setCommandOpen(true)}
@@ -1272,7 +1277,6 @@ export function App() {
         <nav aria-label="Mobile actions" className="mobile-actions">
           <button className="primary-button" onClick={(event) => openCapture(event.currentTarget)} type="button">＋ Save a link</button>
           <button className="secondary-button" onClick={() => { setOpenZen(null); navigateToView("zen"); }} type="button">Zen {zenDocuments.length}</button>
-          <button className="secondary-button" onClick={() => navigateToView("sync")} type="button">Sync {libraryState.pendingCount}</button>
           <button className="secondary-button" onClick={() => navigateToView("settings")} type="button">Settings</button>
         </nav>
       </div>

--- a/web/src/components/ZenWorkspace.tsx
+++ b/web/src/components/ZenWorkspace.tsx
@@ -1,0 +1,443 @@
+import { useMemo, useState } from "react";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import type { PersistedZenDocument } from "../data/db";
+import type { ZenDocumentView } from "../data/library.ts";
+
+/** Bound from ADR 0011. Shown so the budget is visible before it is hit. */
+const MAX_BODY_BYTES = 256 * 1024;
+
+export interface ZenMentionTarget {
+  title: string | null;
+  url: string;
+  deleted: boolean;
+}
+
+interface ZenWorkspaceProps {
+  hidden: boolean;
+  documents: PersistedZenDocument[];
+  open: { documentId: string; view: ZenDocumentView } | null;
+  busy: boolean;
+  /** Resolves `research:item/<uuid>` mentions against the local library. */
+  resolveMention(itemId: string): ZenMentionTarget | null;
+  onCreate(title: string): void;
+  onOpen(documentId: string): void;
+  onClose(): void;
+  onDelete(documentId: string): void;
+  onSaveTitle(documentId: string, title: string | null): void;
+  onSaveBody(documentId: string, body: string): void;
+}
+
+type SortMode = "edited" | "created" | "title";
+
+export function ZenWorkspace(props: ZenWorkspaceProps) {
+  if (props.hidden) return null;
+  return props.open ? <ZenEditor {...props} open={props.open} /> : <ZenList {...props} />;
+}
+
+function ZenList({
+  documents,
+  busy,
+  onCreate,
+  onOpen,
+  onDelete,
+}: ZenWorkspaceProps) {
+  const [draftTitle, setDraftTitle] = useState("");
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<SortMode>("edited");
+
+  const visible = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    const matched = needle
+      ? documents.filter((document) =>
+          (document.title ?? "").toLowerCase().includes(needle),
+        )
+      : documents;
+    const ordered = [...matched];
+    if (sort === "created") ordered.sort((left, right) => right.createdAt - left.createdAt);
+    if (sort === "title") {
+      ordered.sort((left, right) =>
+        (left.title ?? "").localeCompare(right.title ?? ""),
+      );
+    }
+    return ordered;
+  }, [documents, search, sort]);
+
+  return (
+    <section aria-labelledby="zen-heading" className="library-section zen-list" id="zen">
+      <div className="zen-heading-row">
+        <div className="zen-title">
+          <h2 id="zen-heading">Zen</h2>
+          <p className="zen-count">
+            {documents.length} {documents.length === 1 ? "document" : "documents"} · titles
+            and metadata only — bodies load on open
+          </p>
+        </div>
+        <select
+          aria-label="Sort documents"
+          onChange={(event) => setSort(event.target.value as SortMode)}
+          value={sort}
+        >
+          <option value="edited">edited ↓</option>
+          <option value="created">created ↓</option>
+          <option value="title">title A–Z</option>
+        </select>
+      </div>
+
+      <form
+        className="quick-capture"
+        onSubmit={(event) => {
+          event.preventDefault();
+          onCreate(draftTitle.trim());
+          setDraftTitle("");
+        }}
+      >
+        <span aria-hidden="true">+</span>
+        <input
+          aria-label="New document title"
+          disabled={busy}
+          onChange={(event) => setDraftTitle(event.target.value)}
+          placeholder="New document — title optional, ↵ creates and opens."
+          type="text"
+          value={draftTitle}
+        />
+        <span className="quick-capture-hint">or research zen add</span>
+      </form>
+
+      <div className="library-search-row">
+        <label className="library-search">
+          <input
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search document titles"
+            type="search"
+            value={search}
+          />
+        </label>
+      </div>
+
+      {visible.length === 0 ? (
+        <p className="library-empty">
+          No documents yet. Prose, lists, and todos live here — saves stay in the library.
+        </p>
+      ) : (
+        <ol className="zen-rows">
+          {visible.map((document) => (
+            <li key={document.documentId}>
+              <article className="zen-row">
+                <span aria-hidden="true" className="zen-glyph">
+                  ≡
+                </span>
+                <div className="zen-row-copy">
+                  <h3>
+                    <button
+                      className="zen-open"
+                      onClick={() => onOpen(document.documentId)}
+                      type="button"
+                    >
+                      {document.title?.trim() || "Untitled document"}
+                    </button>
+                  </h3>
+                  <p className="zen-row-meta">
+                    <span>Edited {formatEdited(document.editedAt)}</span>
+                    <span aria-hidden="true">·</span>
+                    <span>{formatBytes(document.byteLength)}</span>
+                    {document.todoTotal > 0 && (
+                      <>
+                        <span aria-hidden="true">·</span>
+                        <span className="zen-todo-count">
+                          {document.todoDone}/{document.todoTotal} todos
+                        </span>
+                      </>
+                    )}
+                    {document.tags.length > 0 && (
+                      <span className="zen-row-tags">
+                        {document.tags.map((tag) => (
+                          <span key={tag}>#{tag}</span>
+                        ))}
+                      </span>
+                    )}
+                  </p>
+                </div>
+                <div className="zen-row-actions">
+                  <button
+                    aria-label={`Edit ${document.title ?? "document"}`}
+                    disabled={busy}
+                    onClick={() => onOpen(document.documentId)}
+                    title="Edit markdown"
+                    type="button"
+                  >
+                    ✎
+                  </button>
+                  <button
+                    aria-label={`Delete ${document.title ?? "document"}`}
+                    disabled={busy}
+                    onClick={() => onDelete(document.documentId)}
+                    title="Delete"
+                    type="button"
+                  >
+                    ⌫
+                  </button>
+                </div>
+              </article>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+function ZenEditor({
+  open,
+  busy,
+  resolveMention,
+  onClose,
+  onSaveTitle,
+  onSaveBody,
+}: ZenWorkspaceProps & { open: { documentId: string; view: ZenDocumentView } }) {
+  const [mode, setMode] = useState<"edit" | "view">("view");
+  const [draft, setDraft] = useState(open.view.body);
+  const [title, setTitle] = useState(open.view.title.value ?? "");
+  const byteLength = new TextEncoder().encode(draft).length;
+  const overBound = byteLength > MAX_BODY_BYTES;
+
+  /**
+   * A checkbox toggle rewrites one line, which the domain turns into a
+   * character splice — the same operation typing produces. That is why the
+   * boxes stay live in view mode.
+   */
+  function toggleTodo(lineIndex: number) {
+    const lines = open.view.body.split("\n");
+    const line = lines[lineIndex];
+    if (line === undefined) return;
+    const toggled = line.includes("[ ]")
+      ? line.replace("[ ]", "[x]")
+      : line.replace(/\[[xX]\]/, "[ ]");
+    if (toggled === line) return;
+    lines[lineIndex] = toggled;
+    const next = lines.join("\n");
+    setDraft(next);
+    onSaveBody(open.documentId, next);
+  }
+
+  return (
+    <section aria-labelledby="zen-doc-heading" className="zen-editor" id="zen-document">
+      <div className="zen-toolbar">
+        <nav aria-label="Breadcrumb" className="zen-breadcrumb">
+          <button onClick={onClose} type="button">
+            Zen
+          </button>
+          <span aria-hidden="true">/</span>
+          <span className="zen-breadcrumb-current">
+            {open.view.title.value?.trim() || "Untitled document"}
+          </span>
+        </nav>
+        <span className="zen-budget">
+          {formatBytes(byteLength)} of {formatBytes(MAX_BODY_BYTES)}
+        </span>
+        <div className="zen-mode" role="group" aria-label="Document mode">
+          <button
+            aria-pressed={mode === "edit"}
+            onClick={() => setMode("edit")}
+            type="button"
+          >
+            edit
+          </button>
+          <button
+            aria-pressed={mode === "view"}
+            onClick={() => {
+              if (draft !== open.view.body) onSaveBody(open.documentId, draft);
+              setMode("view");
+            }}
+            type="button"
+          >
+            view
+          </button>
+        </div>
+      </div>
+
+      <div className="zen-canvas">
+        {mode === "view" ? (
+          <article className="zen-reader">
+            <h1 id="zen-doc-heading">
+              {open.view.title.value?.trim() || "Untitled document"}
+            </h1>
+            {open.view.tags.length > 0 && (
+              <p className="zen-tags">
+                {open.view.tags.map((tag) => (
+                  <span key={tag}>#{tag}</span>
+                ))}
+              </p>
+            )}
+            <ZenBody
+              body={open.view.body}
+              onToggleTodo={toggleTodo}
+              resolveMention={resolveMention}
+            />
+          </article>
+        ) : (
+          <div className="zen-edit">
+            <input
+              aria-label="Document title"
+              className="zen-title-input"
+              disabled={busy}
+              onBlur={() => onSaveTitle(open.documentId, title.trim() || null)}
+              onChange={(event) => setTitle(event.target.value)}
+              type="text"
+              value={title}
+            />
+            <p className="zen-hint">
+              CommonMark + GFM task lists · plain text only · writes past{" "}
+              {formatBytes(MAX_BODY_BYTES)} fail with an explicit error
+            </p>
+            <textarea
+              aria-label="Document body"
+              className="zen-body-input"
+              onBlur={() => {
+                if (!overBound && draft !== open.view.body) {
+                  onSaveBody(open.documentId, draft);
+                }
+              }}
+              onChange={(event) => setDraft(event.target.value)}
+              spellCheck={false}
+              value={draft}
+            />
+            {overBound && (
+              <p className="zen-error" role="alert">
+                This document is over the {formatBytes(MAX_BODY_BYTES)} bound and will not
+                save until it is shorter.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+
+      <footer className="zen-footer">
+        <span>
+          <b>esc</b> close
+        </span>
+        <span>autosaves locally · durable before sync reports it</span>
+      </footer>
+    </section>
+  );
+}
+
+/**
+ * Renders a zen body with the same Markdown stack the Reader uses.
+ *
+ * Only two behaviours are zen-specific, so only those are overridden: GFM task
+ * checkboxes stay live (a toggle is a character splice, not an edit mode), and
+ * `research:item/<uuid>` links resolve against the local library at view time.
+ */
+function ZenBody({
+  body,
+  onToggleTodo,
+  resolveMention,
+}: {
+  body: string;
+  onToggleTodo(sourceLine: number): void;
+  resolveMention(itemId: string): ZenMentionTarget | null;
+}) {
+  return (
+    <div className="zen-prose">
+      <ReactMarkdown
+        components={{
+          // The synthetic checkbox carries no source position, so the list
+          // item — which does — owns the control and the default is dropped.
+          input: () => null,
+          li: ({ children, node }) => {
+            const line = node?.position?.start.line;
+            const source =
+              typeof line === "number" ? (body.split("\n")[line - 1] ?? "") : "";
+            const task = /^\s*(?:[-*+]|\d+[.)])\s+\[([ xX])\]/.exec(source);
+            if (!task || typeof line !== "number") return <li>{children}</li>;
+            return (
+              <li className="zen-todo">
+                <input
+                  checked={task[1]!.toLowerCase() === "x"}
+                  onChange={() => onToggleTodo(line - 1)}
+                  type="checkbox"
+                />
+                {children}
+              </li>
+            );
+          },
+          a: ({ children, href }) => {
+            if (!href?.startsWith(MENTION_PREFIX)) {
+              return (
+                <a href={href} rel="noreferrer" target="_blank">
+                  {children}
+                </a>
+              );
+            }
+            const itemId = href.slice(MENTION_PREFIX.length);
+            const item = resolveMention(itemId);
+            if (!item) {
+              return (
+                <span className="zen-mention-unresolved">{href} · unresolved</span>
+              );
+            }
+            if (item.deleted) {
+              return (
+                <span>
+                  <span className="zen-mention-deleted">{item.title ?? children}</span>
+                  <span className="zen-mention-badge">deleted save</span>
+                </span>
+              );
+            }
+            return (
+              <span>
+                <a href={item.url} rel="noreferrer" target="_blank">
+                  {item.title ?? children}
+                </a>
+                <span className="zen-mention-host"> · {hostname(item.url)}</span>
+              </span>
+            );
+          },
+        }}
+        remarkPlugins={[remarkGfm]}
+        skipHtml
+        // The default transform drops unknown schemes, which would erase every
+        // mention before it could be resolved.
+        urlTransform={(url) => (url.startsWith(MENTION_PREFIX) ? url : defaultUrlTransform(url))}
+      >
+        {body}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+const MENTION_PREFIX = "research:item/";
+
+function hostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return "saved link";
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  return `${(bytes / 1024).toFixed(1)} KiB`;
+}
+
+function formatEdited(iso: string): string {
+  const edited = new Date(iso);
+  if (Number.isNaN(edited.getTime())) return "recently";
+  const elapsed = Date.now() - edited.getTime();
+  if (elapsed < 60_000) return "just now";
+  if (elapsed < 86_400_000) {
+    return edited.toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+  if (elapsed < 172_800_000) return "yesterday";
+  return edited.toLocaleDateString(undefined, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}

--- a/web/src/data/db.ts
+++ b/web/src/data/db.ts
@@ -136,6 +136,56 @@ export interface PersistedSyncConfiguration {
   lastErrorAt: string | null;
 }
 
+/**
+ * One aggregate-scoped operation awaiting upload.
+ *
+ * Kept out of the protocol-v1 `batches`/`outbox` stores so the v1 uploader
+ * cannot mistake a v2 envelope for one of its own.
+ */
+export interface PersistedAggregateBatch {
+  path: string;
+  aggregateKind: string;
+  aggregateId: string;
+  deviceId: string;
+  sequence: string;
+  payloadSha256: string;
+  envelopeJson: string;
+  origin: "local" | "remote";
+  appliedAt: string;
+}
+
+export interface PersistedAggregateOutbox {
+  path: string;
+  enqueuedAt: string;
+  attempts: number;
+  lastErrorKind: string | null;
+}
+
+/** One zen document's CRDT replica. Read only when a document is opened. */
+export interface PersistedZenReplica {
+  documentId: string;
+  snapshot: string;
+  updatedAt: string;
+}
+
+/**
+ * List-shaped zen metadata.
+ *
+ * Deliberately carries no body: the workspace index must stay proportional to
+ * the number of documents rather than their size.
+ */
+export interface PersistedZenDocument {
+  documentId: string;
+  title: string | null;
+  byteLength: number;
+  todoTotal: number;
+  todoDone: number;
+  createdAt: number;
+  editedAt: string;
+  tags: string[];
+  deleted: boolean;
+}
+
 interface ResearchPocketBrowserDb extends DBSchema {
   meta: {
     key: "library";
@@ -187,12 +237,31 @@ interface ResearchPocketBrowserDb extends DBSchema {
     key: "github";
     value: PersistedSyncConfiguration;
   };
+  zenDocuments: {
+    key: string;
+    value: PersistedZenDocument;
+    indexes: {
+      "by-edited-at": [string, string];
+    };
+  };
+  zenReplicas: {
+    key: string;
+    value: PersistedZenReplica;
+  };
+  aggregateBatches: {
+    key: string;
+    value: PersistedAggregateBatch;
+  };
+  aggregateOutbox: {
+    key: string;
+    value: PersistedAggregateOutbox;
+  };
 }
 
 export function openBrowserDatabase(
   name: string,
 ): Promise<IDBPDatabase<ResearchPocketBrowserDb>> {
-  return openDB<ResearchPocketBrowserDb>(name, 4, {
+  return openDB<ResearchPocketBrowserDb>(name, 5, {
     upgrade(database, oldVersion) {
       if (oldVersion < 1) {
         database.createObjectStore("meta", { keyPath: "key" });
@@ -218,6 +287,15 @@ export function openBrowserDatabase(
       }
       if (oldVersion < 4) {
         database.createObjectStore("capturedDocuments", { keyPath: "sha256" });
+      }
+      if (oldVersion < 5) {
+        const zen = database.createObjectStore("zenDocuments", {
+          keyPath: "documentId",
+        });
+        zen.createIndex("by-edited-at", ["editedAt", "documentId"]);
+        database.createObjectStore("zenReplicas", { keyPath: "documentId" });
+        database.createObjectStore("aggregateBatches", { keyPath: "path" });
+        database.createObjectStore("aggregateOutbox", { keyPath: "path" });
       }
     },
     blocked() {

--- a/web/src/data/library.ts
+++ b/web/src/data/library.ts
@@ -14,6 +14,7 @@ import {
   type PersistedOutbox,
   type PersistedSnapshot,
   type PersistedSyncConfiguration,
+  type PersistedZenDocument,
   type RemoteObservation,
 } from "./db";
 import { domainCore } from "./domain.ts";
@@ -1042,6 +1043,160 @@ class LibraryRepository {
     }
   }
 
+  /** Workspace index. Reads metadata only — never a document body. */
+  async listZenDocuments(): Promise<PersistedZenDocument[]> {
+    const database = await this.database();
+    const documents = await database.getAll("zenDocuments");
+    return documents
+      .filter((document) => !document.deleted)
+      .sort(
+        (left, right) =>
+          right.editedAt.localeCompare(left.editedAt) ||
+          left.documentId.localeCompare(right.documentId),
+      );
+  }
+
+  /** Reads one document body. The only call that loads body bytes. */
+  async zenDocument(documentId: string): Promise<ZenDocumentView> {
+    const database = await this.database();
+    const replica = await database.get("zenReplicas", documentId);
+    if (!replica) throw new Error("That document is no longer in this library.");
+    const meta = await database.get("meta", "library");
+    if (!meta) throw new Error("This library is still opening.");
+    return JSON.parse(
+      await domainCore.call(
+        "zenDocumentView",
+        replica.snapshot,
+        meta.peerId,
+        documentId,
+      ),
+    ) as ZenDocumentView;
+  }
+
+  async createZenDocument(input: {
+    title: string | null;
+    body: string;
+    tags: string[];
+  }): Promise<string> {
+    const documentId = uuidV7();
+    await this.commitZenMutation(documentId, {
+      type: "create",
+      document_id: documentId,
+      title: input.title,
+      body: input.body,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: input.tags,
+    });
+    return documentId;
+  }
+
+  async setZenTitle(documentId: string, title: string | null): Promise<void> {
+    await this.commitZenMutation(documentId, { type: "set_title", title });
+  }
+
+  async setZenBody(documentId: string, body: string): Promise<void> {
+    await this.commitZenMutation(documentId, { type: "set_body", body });
+  }
+
+  async addZenTag(documentId: string, tag: string): Promise<void> {
+    await this.commitZenMutation(documentId, { type: "add_tag", tag });
+  }
+
+  async removeZenTag(documentId: string, tag: string): Promise<void> {
+    await this.commitZenMutation(documentId, { type: "remove_tag", tag });
+  }
+
+  async deleteZenDocument(documentId: string): Promise<void> {
+    await this.commitZenMutation(documentId, { type: "delete" });
+  }
+
+  async restoreZenDocument(documentId: string): Promise<void> {
+    await this.commitZenMutation(documentId, { type: "restore" });
+  }
+
+  /**
+   * Applies one zen mutation and commits replica, index, and queue together.
+   *
+   * Only the edited document's replica is loaded, so a keystroke never costs
+   * anything proportional to the rest of the workspace.
+   */
+  private async commitZenMutation(
+    documentId: string,
+    mutation: Record<string, unknown>,
+  ): Promise<void> {
+    await this.write(async (database) => {
+      const meta = await database.get("meta", "library");
+      if (!meta) throw new Error("This library is still opening.");
+      const replica = await database.get("zenReplicas", documentId);
+      if (!replica && mutation.type !== "create") {
+        throw new Error("That document is no longer in this library.");
+      }
+      const now = new Date().toISOString();
+      const result = JSON.parse(
+        await domainCore.call(
+          "applyZenMutation",
+          replica?.snapshot ?? "",
+          meta.peerId,
+          meta.libraryId,
+          meta.deviceId,
+          meta.nextSequence,
+          now,
+          documentId,
+          JSON.stringify(mutation),
+        ),
+      ) as ZenMutationResult;
+
+      const path = `sync/v2/ops/zen/${documentId}/${meta.deviceId}/${meta.nextSequence}.json`;
+      const summary = result.summary;
+      const transaction = database.transaction(
+        ["meta", "zenReplicas", "zenDocuments", "aggregateBatches", "aggregateOutbox"],
+        "readwrite",
+      );
+      try {
+        await transaction.objectStore("meta").put({
+          ...meta,
+          nextSequence: incrementSequence(meta.nextSequence),
+        });
+        await transaction
+          .objectStore("zenReplicas")
+          .put({ documentId, snapshot: result.snapshot, updatedAt: now });
+        await transaction.objectStore("zenDocuments").put({
+          documentId,
+          title: summary.title,
+          byteLength: summary.byte_length,
+          todoTotal: summary.todo_total,
+          todoDone: summary.todo_done,
+          createdAt: summary.created_at,
+          editedAt: now,
+          tags: summary.tags,
+          deleted: summary.lifecycle_state === "deleted",
+        });
+        await transaction.objectStore("aggregateBatches").add({
+          path,
+          aggregateKind: "zen_document",
+          aggregateId: documentId,
+          deviceId: meta.deviceId,
+          sequence: meta.nextSequence,
+          payloadSha256: JSON.parse(result.envelope).payload_sha256 as string,
+          envelopeJson: result.envelope,
+          origin: "local" as const,
+          appliedAt: now,
+        });
+        await transaction.objectStore("aggregateOutbox").add({
+          path,
+          enqueuedAt: now,
+          attempts: 0,
+          lastErrorKind: null,
+        });
+        await transaction.done;
+      } catch (error) {
+        abortTransaction(transaction);
+        throw error;
+      }
+    });
+    this.channel.postMessage({ type: "changed" });
+  }
+
   private async afterCommit(status: string): Promise<void> {
     this.channel.postMessage({ type: "changed" });
     await this.load();
@@ -1781,6 +1936,32 @@ export interface SyncBridge {
   quiesce(): Promise<void>;
 }
 
+export interface ZenSummary {
+  document_id: string;
+  title: string | null;
+  created_at: number;
+  byte_length: number;
+  todo_total: number;
+  todo_done: number;
+  tags: string[];
+  lifecycle_state: "active" | "deleted";
+}
+
+export interface ZenDocumentView {
+  document_id: string;
+  title: { value: string | null };
+  created_at: { value: number };
+  body: string;
+  tags: string[];
+  lifecycle: { state: "active" | "deleted" };
+}
+
+interface ZenMutationResult {
+  snapshot: string;
+  summary: ZenSummary;
+  envelope: string;
+}
+
 const OPENING_STATE: LibraryState = {
   initialized: false,
   loading: true,
@@ -2024,6 +2205,46 @@ class LibraryWorkspace {
     packs: RemoteOperationPackInput[] = [],
   ): Promise<number> {
     return (await this.instance()).applyRemote(inputs, packs);
+  }
+
+  async listZenDocuments(): Promise<PersistedZenDocument[]> {
+    return (await this.instance()).listZenDocuments();
+  }
+
+  async zenDocument(documentId: string): Promise<ZenDocumentView> {
+    return (await this.instance()).zenDocument(documentId);
+  }
+
+  async createZenDocument(input: {
+    title: string | null;
+    body: string;
+    tags: string[];
+  }): Promise<string> {
+    return (await this.instance()).createZenDocument(input);
+  }
+
+  async setZenTitle(documentId: string, title: string | null): Promise<void> {
+    return (await this.instance()).setZenTitle(documentId, title);
+  }
+
+  async setZenBody(documentId: string, body: string): Promise<void> {
+    return (await this.instance()).setZenBody(documentId, body);
+  }
+
+  async addZenTag(documentId: string, tag: string): Promise<void> {
+    return (await this.instance()).addZenTag(documentId, tag);
+  }
+
+  async removeZenTag(documentId: string, tag: string): Promise<void> {
+    return (await this.instance()).removeZenTag(documentId, tag);
+  }
+
+  async deleteZenDocument(documentId: string): Promise<void> {
+    return (await this.instance()).deleteZenDocument(documentId);
+  }
+
+  async restoreZenDocument(documentId: string): Promise<void> {
+    return (await this.instance()).restoreZenDocument(documentId);
   }
 }
 

--- a/web/src/landing.ts
+++ b/web/src/landing.ts
@@ -1,0 +1,39 @@
+/**
+ * Sends a returning owner straight to their library.
+ *
+ * The chooser exists to decide how to *create* a library. Someone who already
+ * has one on this device has nothing to choose, so asking again is a step
+ * between them and their saves.
+ *
+ * Two things keep this from being annoying in the other direction: it only
+ * fires when a real library is present, and `?choose` opts out so the chooser
+ * stays reachable for adding another library or restoring onto this device.
+ */
+const LIBRARY_DATABASE_PREFIX = "researchpocket";
+
+async function openedLibraryExists(): Promise<boolean> {
+  // Not universally available; without it the chooser is the safe answer.
+  if (typeof indexedDB.databases !== "function") return false;
+  try {
+    const databases = await indexedDB.databases();
+    return databases.some(
+      (database) =>
+        typeof database.name === "string" &&
+        database.name.startsWith(LIBRARY_DATABASE_PREFIX) &&
+        database.name !== `${LIBRARY_DATABASE_PREFIX}-profiles`,
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function main(): Promise<void> {
+  const parameters = new URLSearchParams(window.location.search);
+  if (parameters.has("choose")) return;
+  if (!(await openedLibraryExists())) return;
+  // Replace rather than push so Back returns to wherever they came from
+  // instead of bouncing through a chooser they never chose to see.
+  window.location.replace("./app/");
+}
+
+void main();

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -4902,3 +4902,358 @@ kbd {
     text-align: left;
   }
 }
+
+/* ---- Zen workspace ------------------------------------------------------ */
+
+.zen-glyph {
+  color: var(--color-text-muted);
+  font-size: 14px;
+  text-align: center;
+  width: 18px;
+}
+
+.zen-open {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.zen-open:hover {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 0.2em;
+}
+
+.zen-todo-count {
+  color: var(--color-text-muted);
+}
+
+.zen-editor {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
+.zen-toolbar {
+  align-items: center;
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  gap: 12px;
+  min-height: 44px;
+  padding: 0 20px;
+}
+
+.zen-breadcrumb {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  font-size: 13px;
+  min-width: 0;
+}
+
+.zen-breadcrumb button {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font: inherit;
+  min-height: 32px;
+  padding: 0;
+}
+
+.zen-breadcrumb button:hover {
+  color: var(--color-text);
+}
+
+.zen-breadcrumb-current {
+  font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.zen-budget {
+  color: var(--color-text-muted);
+  font-size: 12px;
+  margin-left: auto;
+}
+
+.zen-mode {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  display: flex;
+}
+
+.zen-mode button {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 700;
+  min-height: 30px;
+  padding: 0 10px;
+}
+
+.zen-mode button + button {
+  border-left: 1px solid var(--color-border);
+}
+
+.zen-mode button[aria-pressed="true"] {
+  background: var(--color-surface-raised);
+  color: var(--color-accent);
+}
+
+.zen-canvas {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
+
+.zen-reader,
+.zen-edit {
+  margin: 0 auto;
+  max-width: 760px;
+  padding: 36px 24px 64px;
+}
+
+.zen-reader h1 {
+  font-size: 26px;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.zen-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 10px 0 0;
+}
+
+.zen-tags span {
+  color: var(--color-accent);
+  font-size: 12px;
+}
+
+.zen-prose {
+  line-height: 1.75;
+  margin-top: 20px;
+  overflow-wrap: anywhere;
+}
+
+.zen-prose blockquote {
+  border-left: 3px solid var(--color-border-strong);
+  color: var(--color-text-muted);
+  margin: 0 0 14px;
+  padding-left: 16px;
+}
+
+.zen-mention-host {
+  color: var(--color-text-muted);
+}
+
+.zen-mention-deleted {
+  color: var(--color-text-muted);
+  text-decoration: line-through;
+}
+
+.zen-mention-badge,
+.zen-mention-unresolved {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  color: var(--color-text-muted);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  margin-left: 6px;
+  padding: 0 4px;
+  text-transform: uppercase;
+}
+
+.zen-mention-unresolved {
+  border-style: dashed;
+  text-transform: none;
+}
+
+.zen-title-input {
+  background: transparent;
+  border: 0;
+  color: var(--color-text);
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  outline: 0;
+  padding: 0;
+  width: 100%;
+}
+
+.zen-hint {
+  color: var(--color-text-muted);
+  font-size: 12px;
+  margin: 8px 0 0;
+}
+
+.zen-body-input {
+  background: transparent;
+  border: 0;
+  caret-color: var(--color-accent);
+  color: var(--color-text-reader);
+  line-height: 1.75;
+  margin-top: 16px;
+  min-height: 480px;
+  outline: 0;
+  padding: 0;
+  resize: none;
+  width: 100%;
+}
+
+.zen-error {
+  color: var(--color-danger);
+  font-size: 12px;
+}
+
+.zen-footer {
+  align-items: center;
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  display: flex;
+  font-size: 12px;
+  gap: 16px;
+  min-height: 36px;
+  padding: 0 20px;
+}
+
+.zen-heading-row {
+  align-items: end;
+  display: flex;
+  gap: var(--space-4);
+  justify-content: space-between;
+}
+
+.zen-title {
+  align-items: baseline;
+  display: flex;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.zen-title h2 {
+  font-size: var(--font-size-xl);
+  font-weight: 750;
+  letter-spacing: -0.025em;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.zen-count {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  margin: 0;
+}
+
+.zen-heading-row select {
+  inline-size: auto;
+}
+
+.zen-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.zen-row {
+  align-items: center;
+  border-bottom: var(--rule) solid var(--color-border);
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: 1.125rem minmax(0, 1fr) auto;
+  min-block-size: 3.75rem;
+  padding: var(--space-2) 0;
+}
+
+.zen-row-copy {
+  display: grid;
+  gap: 0.1875rem;
+  min-width: 0;
+}
+
+.zen-row-copy h3 {
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.zen-row-meta {
+  align-items: center;
+  color: var(--color-text-muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: var(--font-size-xs);
+  gap: 0.375rem;
+  margin: 0;
+  min-width: 0;
+}
+
+.zen-row-tags {
+  color: var(--color-accent);
+  display: inline-flex;
+  gap: 0.1875rem;
+}
+
+.zen-row-actions {
+  display: flex;
+  gap: 0.1875rem;
+}
+
+.zen-row-actions button {
+  background: transparent;
+  border: var(--rule) solid transparent;
+  border-radius: var(--radius);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  block-size: 2rem;
+  inline-size: 2rem;
+  padding: 0;
+}
+
+.zen-row-actions button:hover:not(:disabled) {
+  border-color: var(--color-border);
+  color: var(--color-text);
+}
+
+/* Task lists render as rows, not bulleted list items with a stray marker. */
+.zen-prose ul.contains-task-list {
+  list-style: none;
+  padding-inline-start: 0;
+}
+
+.zen-prose li.zen-todo {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.5rem;
+  list-style: none;
+  min-block-size: 1.75rem;
+}
+
+.zen-prose li.zen-todo > input[type="checkbox"] {
+  accent-color: var(--color-accent);
+  block-size: 1rem;
+  cursor: pointer;
+  flex: 0 0 auto;
+  inline-size: 1rem;
+  margin: 0.3125rem 0 0;
+}
+
+.zen-prose li.zen-todo p {
+  margin: 0;
+}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -5257,3 +5257,16 @@ kbd {
 .zen-prose li.zen-todo p {
   margin: 0;
 }
+
+/* The local indicator is the way into sync, so it reads as pressable. */
+button.local-status {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+}
+
+button.local-status:hover .status-copy,
+button.local-status:focus-visible .status-copy {
+  color: var(--color-text);
+}


### PR DESCRIPTION
## Summary

The Research Zen web workspace (#140) — screens 1b, 1c, and the rail from the design.

- **1b document list**: new ZEN rail group; rows carry edited time, size, todo counts, and tags, with no URL and no favorite. Header states "titles and metadata only — bodies load on open", which is structurally true rather than aspirational.
- **1c editor**: `Zen / <title>` breadcrumb with *Zen* clickable, `edit ⇄ view` segmented control, and the `X of 256.0 KiB` budget readout. An over-bound body is refused with an explicit message and leaves the document untouched.
- **Live task lists in view mode.** A toggle is a character splice, not an edit, so checkboxes stay interactive while reading. The list item owns the checkbox because the synthetic one react-markdown emits carries no source position — the list item's position is what maps a click back to its line.
- **Mentions resolve at view time**: a live item renders title + hostname, a deleted item degrades to a struck-through marker with a `deleted save` badge, and an unknown UUID shows an explicit unresolved badge. The body only ever stores `research:item/<uuid>`.

## Reuse over reinvention

The first draft hand-rolled a Markdown block parser. `react-markdown` + `remark-gfm` were already dependencies powering the Reader, so the body now renders on that stack with only the two zen-specific behaviours overridden. Zen rows get their own grid rather than bending `item-card`, whose anatomy (favorite, URL) zen documents do not have.

## Also in this change

Library filters and the tag list now render only in the library view — they are noise in Zen, Sync, and Settings. The masthead is pure brand everywhere; clicking it returns to the library.

## Verification

Driven in a real browser against the production build, not just typechecked:

- Created a document, typed a body, and confirmed it persisted (295 B) and re-rendered.
- Toggled a todo in view mode: `[true,false,false]` → `[true,true,false]`, persisted through the CRDT splice, with the list then showing `Edited just now · 82 B · 2/3 todos`.
- Confirmed mention rendering both ways: `Local-first software · inkandswitch.com` for a real save, and the unresolved badge for a missing UUID.
- Verified the rail shows library filters in the library view and only Documents/Sync/Settings in Zen.
- Two layout defects found and fixed this way: a vertically-wrapping heading, and oversized checkboxes with stray list markers.

`npm run build` (wasm, typecheck, design-system, vite, dist privacy checks), `npm test` (16 pass), and the full Rust workspace suite all pass.

Refs #140
