### PR TITLE
Fix the Zen list on mobile and drop developer-facing copy

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -865,7 +865,7 @@ export function App() {
       </div>
 
       <div className="workspace-layout">
-        <aside className="tag-rail">
+        <aside className={`tag-rail${view === "library" ? "" : " tag-rail-empty"}`}>
           {view === "library" && (
           <nav aria-label="Library views" className="rail-nav">
             <button

--- a/web/src/components/ZenWorkspace.tsx
+++ b/web/src/components/ZenWorkspace.tsx
@@ -70,8 +70,7 @@ function ZenList({
         <div className="zen-title">
           <h2 id="zen-heading">Zen</h2>
           <p className="zen-count">
-            {documents.length} {documents.length === 1 ? "document" : "documents"} · titles
-            and metadata only — bodies load on open
+            {documents.length} {documents.length === 1 ? "document" : "documents"}
           </p>
         </div>
         <select
@@ -86,7 +85,7 @@ function ZenList({
       </div>
 
       <form
-        className="quick-capture"
+        className="quick-add zen-add"
         onSubmit={(event) => {
           event.preventDefault();
           onCreate(draftTitle.trim());
@@ -98,15 +97,14 @@ function ZenList({
           aria-label="New document title"
           disabled={busy}
           onChange={(event) => setDraftTitle(event.target.value)}
-          placeholder="New document — title optional, ↵ creates and opens."
+          placeholder="New document"
           type="text"
           value={draftTitle}
         />
-        <span className="quick-capture-hint">or research zen add</span>
       </form>
 
       <div className="library-search-row">
-        <label className="library-search">
+        <label className="library-search zen-search">
           <input
             onChange={(event) => setSearch(event.target.value)}
             placeholder="Search document titles"
@@ -196,7 +194,9 @@ function ZenEditor({
   onSaveTitle,
   onSaveBody,
 }: ZenWorkspaceProps & { open: { documentId: string; view: ZenDocumentView } }) {
-  const [mode, setMode] = useState<"edit" | "view">("view");
+  const [mode, setMode] = useState<"edit" | "view">(() =>
+    window.matchMedia("(max-width: 48rem)").matches ? "edit" : "view",
+  );
   const [draft, setDraft] = useState(open.view.body);
   const [title, setTitle] = useState(open.view.title.value ?? "");
   const byteLength = new TextEncoder().encode(draft).length;
@@ -233,7 +233,7 @@ function ZenEditor({
             {open.view.title.value?.trim() || "Untitled document"}
           </span>
         </nav>
-        <span className="zen-budget">
+        <span className="zen-budget zen-budget-toolbar">
           {formatBytes(byteLength)} of {formatBytes(MAX_BODY_BYTES)}
         </span>
         <div className="zen-mode" role="group" aria-label="Document mode">
@@ -287,10 +287,6 @@ function ZenEditor({
               type="text"
               value={title}
             />
-            <p className="zen-hint">
-              CommonMark + GFM task lists · plain text only · writes past{" "}
-              {formatBytes(MAX_BODY_BYTES)} fail with an explicit error
-            </p>
             <textarea
               aria-label="Document body"
               className="zen-body-input"
@@ -314,10 +310,16 @@ function ZenEditor({
       </div>
 
       <footer className="zen-footer">
-        <span>
+        <span className="zen-budget zen-budget-footer">
+          {formatBytes(byteLength)} of {formatBytes(MAX_BODY_BYTES)}
+        </span>
+        <span className="zen-footer-desktop">
           <b>esc</b> close
         </span>
-        <span>autosaves locally · durable before sync reports it</span>
+        <span className="zen-footer-desktop">
+          autosaves locally · durable before sync reports it
+        </span>
+        <span className="zen-footer-mobile">saved locally</span>
       </footer>
     </section>
   );

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -3346,6 +3346,7 @@ kbd {
 
   .mobile-actions {
     background: var(--color-canvas);
+    block-size: var(--mobile-actions-size);
     border-top: var(--rule) solid var(--color-border-strong);
     bottom: 0;
     display: grid;
@@ -5155,6 +5156,7 @@ kbd {
   color: var(--color-text-muted);
   font-size: var(--font-size-xs);
   margin: 0;
+  min-inline-size: 0;
 }
 
 .zen-heading-row select {
@@ -5269,4 +5271,83 @@ button.local-status {
 button.local-status:hover .status-copy,
 button.local-status:focus-visible .status-copy {
   color: var(--color-text);
+}
+
+.zen-budget-footer,
+.zen-footer-mobile {
+  display: none;
+}
+
+@media (max-width: 48rem) {
+  :root {
+    --mobile-actions-size: 3.25rem;
+  }
+
+  /* Outside the library the rail has nothing to show, and an empty strip
+     reads as a rendering fault. */
+  .tag-rail-empty {
+    display: none;
+  }
+
+  .zen-budget-toolbar,
+  .zen-footer-desktop {
+    display: none;
+  }
+
+  .zen-budget-footer,
+  .zen-footer-mobile {
+    display: inline;
+  }
+
+  .zen-footer {
+    /* The status belongs on screen while writing, not below a tall body. The
+       offset clears the actions bar, which is sticky in the same scroller. */
+    background: var(--color-canvas);
+    bottom: var(--mobile-actions-size);
+    justify-content: space-between;
+    position: sticky;
+  }
+
+  .zen-body-input {
+    min-block-size: 60vh;
+  }
+
+  .zen-toolbar {
+    gap: 0.5rem;
+    padding: 0 1rem;
+  }
+
+  .zen-reader,
+  .zen-edit {
+    padding: 1.25rem 1rem 2rem;
+  }
+
+  .zen-heading-row {
+    align-items: start;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .zen-title {
+    flex-wrap: wrap;
+    inline-size: 100%;
+  }
+
+  .zen-list {
+    min-inline-size: 0;
+  }
+
+  /* The library hides quick-add on mobile because the actions bar can save a
+     link. Nothing there creates a document, so this form has to stay. */
+  .zen-add {
+    display: grid;
+  }
+
+  .zen-row {
+    column-gap: 0.5rem;
+  }
+
+  .zen-row-meta {
+    row-gap: 0.125rem;
+  }
 }


### PR DESCRIPTION
## Summary

Fixes the Zen document list on mobile and removes copy that explains the implementation rather than helping anyone.

**The list was genuinely broken.** The create form used `quick-capture`, a class that does not exist in the stylesheet, so it rendered unstyled — the `+` sat on its own line and the placeholder overflowed the viewport. It now uses the real `quick-add` styling.

That surfaced a second problem: `.quick-add` is deliberately hidden on mobile because the actions bar can save a link. Nothing in that bar creates a *document*, so the zen form stays visible — without it there is no way to create a document on a phone at all.

**The empty rail strip.** Outside the library the rail has nothing to show, but still reserved a 21px band under the masthead, which reads as a rendering fault. Hidden when empty.

**Editor status stays on screen.** The budget moves to the footer on mobile where there is no room beside the breadcrumb, and the footer clears the actions bar via a shared `--mobile-actions-size` rather than a magic offset that would drift. Mobile opens in edit, per design 1d — there is no pointer to place a caret with.

## Copy removed

- `CommonMark + GFM task lists · plain text only · writes past 256.0 KiB fail with an explicit error`
- `or research zen add`
- `titles and metadata only — bodies load on open`

All three describe how the feature works. The format is discoverable by typing, the bound is already reported in the footer, and the loading strategy is not something someone reading their own notes needs. The count now reads simply `1 document`.

## Verification

Checked at 390×780 and 1280×900 against the production build: no horizontal overflow at either size, the create form renders and works on mobile, the rail strip is gone, the editor footer clears the actions bar exactly, and the desktop layout is unchanged.

`npm run build` (wasm, typecheck, design-system, vite, dist privacy checks) and `npm test` (16 pass) both pass.

Refs #140
