### PR TITLE
Stop emitting module preloads the CSP cannot fetch

### DIFF
--- a/web/scripts/check-dist.mjs
+++ b/web/scripts/check-dist.mjs
@@ -86,6 +86,9 @@ for (const [name, pattern] of [
 for (const [name, pattern] of [
   ["unsafe-inline CSP source", /unsafe-inline/i],
   ["development CSP nonce", /nonce-[a-z0-9]+/i],
+  // Firefox fetches modulepreload under default-src, which is 'none' here, so
+  // a preload link takes the page down instead of speeding it up.
+  ["a modulepreload link this CSP cannot fetch", /rel="modulepreload"/i],
 ]) {
   const matchingFiles = htmlArtifacts
     .filter(({ bytes }) => pattern.test(bytes.toString("utf8")))

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -39,6 +39,13 @@ export default defineConfig(({ command }) => {
     base: "./",
     build: {
       manifest: "asset-manifest.json",
+      // Firefox fetches <link rel="modulepreload"> under default-src, which is
+      // 'none' here, so preloading breaks the page it is meant to speed up.
+      // The polyfill is worse: it is also a static import of every entry, so a
+      // blocked fetch takes the whole module graph down. Nothing this app
+      // needs — WASM, Web Locks, IndexedDB — exists in a browser that lacks
+      // modulepreload, so there is nothing to gain by keeping either.
+      modulePreload: false,
       rollupOptions: {
         input: {
           app: "app/index.html",


### PR DESCRIPTION
## The bug

The deployed app fails to start in Firefox:

```
Content-Security-Policy: The page's settings blocked the loading of a resource (default-src)
at https://researchpocket.github.io/assets/modulepreload-polyfill-Dezn_h7o.js
because it violates the following directive: "default-src 'none'"
```

Firefox fetches `<link rel="modulepreload">` under `default-src`, not `script-src`. Ours is `'none'`, so the preload is blocked.

That alone would be wasteful but harmless. The polyfill made it fatal: Vite emits it as a **static import of every entry chunk**, so the blocked fetch takes down the whole module graph and nothing runs.

**This is a regression from #150.** Adding a module script to the landing page — previously it had none — is what turned the polyfill on. Verified by rebuilding the pre-#150 `index.html`: no polyfill chunk emitted; with it, one appears and is preloaded from every page.

## The fix

`build.modulePreload: false`. Nothing this app requires — WASM, Web Locks, IndexedDB, `<dialog>` — exists in a browser that lacks modulepreload, so both the polyfill and the preload links are pure cost under this CSP. The `MarkdownDocument` preload link this also removes predates #150 and was being blocked the same way, just non-fatally.

Weakening `default-src` was the alternative and is not on the table: the strict CSP is a threat-model invariant, and modulepreload is only a latency optimization.

## Preventing recurrence

`check-dist` now fails on any `rel="modulepreload"` in production HTML. Artifact checks passing while the page cannot start is exactly the gap that let this reach the deployed site — verified the new check fires by injecting a preload link into a built page.

## Not from us

The other console entries in the report are a browser extension, not this app: `index.js` / `app.js` with `Medium parser loaded`, and `may not load or link to file:///`. Our built assets are content-hashed (`app-*.js`), and the app loads no inline scripts or styles.

## Verification

Loaded the production build with CSP enforced: app boots, library initializes, **zero console errors**. `npm run build` and `npm test` (16 pass) both pass.
