### PR TITLE
Carry zen documents over sync

### DIFF
--- a/crates/research-domain/src/lib.rs
+++ b/crates/research-domain/src/lib.rs
@@ -32,7 +32,8 @@ pub use projection::{
 };
 #[cfg(target_arch = "wasm32")]
 pub use wasm::{
-    apply_mutation, apply_remote_envelopes, initialize_library, materialize_library,
+    apply_mutation, apply_remote_envelopes, apply_zen_envelope, apply_zen_mutation,
+    initialize_library, materialize_library, zen_document_view,
 };
 pub use zen::{
     MAX_ZEN_BODY_BYTES, ZenAggregate, ZenDocumentSeed, ZenDocumentSummary, ZenDocumentView,

--- a/crates/research-domain/src/wasm.rs
+++ b/crates/research-domain/src/wasm.rs
@@ -775,6 +775,63 @@ pub fn apply_zen_mutation(
     .map_err(js_error)
 }
 
+/// Apply one remote zen operation to the replica it addresses.
+///
+/// `snapshot_base64` is empty when this device has never seen the document.
+/// A result with `deferred: true` carries no snapshot: the operation depends on
+/// one that has not arrived, and persisting anything now would drop it.
+#[wasm_bindgen(js_name = applyZenEnvelope)]
+pub fn apply_zen_envelope(
+    snapshot_base64: &str,
+    peer_id: &str,
+    library_id: &str,
+    path: &str,
+    envelope_json: &str,
+) -> Result<String, JsValue> {
+    zen_receive(snapshot_base64, peer_id, library_id, path, envelope_json).map_err(js_error)
+}
+
+#[derive(Serialize)]
+struct ZenEnvelopeResult {
+    deferred: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    snapshot: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    summary: Option<crate::ZenDocumentSummary>,
+}
+
+fn zen_receive(
+    snapshot_base64: &str,
+    peer_id: &str,
+    library_id: &str,
+    path: &str,
+    envelope_json: &str,
+) -> DomainResult<String> {
+    let peer_id = parse_peer_id(peer_id)?;
+    let envelope: crate::AggregateEnvelope = serde_json::from_str(envelope_json)?;
+    let aggregate = if snapshot_base64.is_empty() {
+        crate::ZenAggregate::from_envelope(path, &envelope, library_id, peer_id)?
+    } else {
+        let snapshot = STANDARD.decode(snapshot_base64)?;
+        let aggregate =
+            crate::ZenAggregate::from_snapshot(&envelope.aggregate_id, &snapshot, peer_id)?;
+        let deferred = aggregate.import_envelope(path, &envelope, library_id)?;
+        (!deferred).then_some(aggregate)
+    };
+    let Some(aggregate) = aggregate else {
+        return Ok(serde_json::to_string(&ZenEnvelopeResult {
+            deferred: true,
+            snapshot: None,
+            summary: None,
+        })?);
+    };
+    Ok(serde_json::to_string(&ZenEnvelopeResult {
+        deferred: false,
+        snapshot: Some(STANDARD.encode(aggregate.export_snapshot()?)),
+        summary: Some(aggregate.view()?.summary()),
+    })?)
+}
+
 /// Read one document, body included. Only called when a document is opened.
 #[wasm_bindgen(js_name = zenDocumentView)]
 pub fn zen_document_view(

--- a/crates/research-domain/src/zen.rs
+++ b/crates/research-domain/src/zen.rs
@@ -242,8 +242,16 @@ impl ZenAggregate {
             .map_err(loro_error)
     }
 
-    pub fn import_update(&self, update: &[u8]) -> DomainResult<()> {
-        self.doc.import(update).map_err(loro_error).map(|_| ())
+    /// Applies an update, reporting whether any of it was deferred.
+    ///
+    /// `true` means part of the update is waiting on an operation this replica
+    /// has not seen. Loro keeps it in memory, but a snapshot written now would
+    /// not carry it, so a caller that persists snapshots must retry the
+    /// operation after its dependency lands instead of recording it as applied.
+    pub fn import_update(&self, update: &[u8]) -> DomainResult<bool> {
+        LoroDoc::decode_import_blob_meta(update, true).map_err(loro_error)?;
+        let status = self.doc.import(update).map_err(loro_error)?;
+        Ok(status.pending.is_some())
     }
 
     pub fn export_envelope(
@@ -271,14 +279,33 @@ impl ZenAggregate {
         path: &str,
         envelope: &AggregateEnvelope,
         expected_library_id: &str,
-    ) -> DomainResult<()> {
-        if envelope.aggregate_kind != AggregateKind::Zen {
-            return Err(DomainError::UnsupportedAggregateKind(
-                envelope.aggregate_kind.as_str().to_owned(),
-            ));
-        }
-        let payload = envelope.validate(path, expected_library_id, &self.document_id)?;
+    ) -> DomainResult<bool> {
+        let payload =
+            verified_zen_payload(path, envelope, expected_library_id, &self.document_id)?;
         self.import_update(&payload)
+    }
+
+    /// Materializes a replica for a document this device has never seen.
+    ///
+    /// `None` means the update did not establish the document: the operation
+    /// depends on one that has not arrived, so the caller retries it once that
+    /// lands rather than persisting a replica with nothing in it.
+    pub fn from_envelope(
+        path: &str,
+        envelope: &AggregateEnvelope,
+        expected_library_id: &str,
+        peer_id: u64,
+    ) -> DomainResult<Option<Self>> {
+        let document_id = envelope.aggregate_id.clone();
+        let payload = verified_zen_payload(path, envelope, expected_library_id, &document_id)?;
+        let doc = LoroDoc::new();
+        doc.set_peer_id(peer_id).map_err(loro_error)?;
+        LoroDoc::decode_import_blob_meta(&payload, true).map_err(loro_error)?;
+        doc.import(&payload).map_err(loro_error)?;
+        if map_keys(&doc.get_map(ZEN)) != [document_id.clone()] {
+            return Ok(None);
+        }
+        Ok(Some(Self { document_id, doc }))
     }
 
     pub fn write_title(&self, revision_id: &str, title: Option<&str>) -> DomainResult<()> {
@@ -354,6 +381,26 @@ impl ZenAggregate {
     fn entity(&self) -> DomainResult<loro::LoroMap> {
         entity_mut(&self.doc, ZEN, &self.document_id)
     }
+}
+
+/// Checks that an envelope is a zen operation for the expected document and
+/// returns its verified payload.
+///
+/// A kind this build does not implement is reported as unsupported rather than
+/// skipped, so an aggregate written by a newer client stops the caller instead
+/// of quietly leaving a hole in the library.
+fn verified_zen_payload(
+    path: &str,
+    envelope: &AggregateEnvelope,
+    expected_library_id: &str,
+    expected_document_id: &str,
+) -> DomainResult<Vec<u8>> {
+    if envelope.aggregate_kind != AggregateKind::Zen {
+        return Err(DomainError::UnsupportedAggregateKind(
+            envelope.aggregate_kind.as_str().to_owned(),
+        ));
+    }
+    envelope.validate(path, expected_library_id, expected_document_id)
 }
 
 fn validate_body(body: &str) -> DomainResult<()> {

--- a/crates/research-domain/tests/wasm_convergence.rs
+++ b/crates/research-domain/tests/wasm_convergence.rs
@@ -1,8 +1,9 @@
 #![cfg(target_arch = "wasm32")]
 
 use research_domain::{
-    GOLDEN_CANONICAL_JSON, apply_mutation, apply_remote_envelopes, initialize_library,
-    materialize_library, run_convergence_scenario,
+    GOLDEN_CANONICAL_JSON, apply_mutation, apply_remote_envelopes, apply_zen_envelope,
+    apply_zen_mutation, initialize_library, materialize_library, run_convergence_scenario,
+    zen_document_view,
 };
 use serde_json::{Value, json};
 use wasm_bindgen_test::*;
@@ -218,4 +219,123 @@ fn mutation(snapshot: &str, sequence: &str, mutation: Value) -> Value {
         .expect("local browser mutation"),
     )
     .expect("local mutation result JSON")
+}
+
+/// The browser must reach the same document a native peer holds, and must
+/// decline an operation whose predecessor has not arrived rather than half-apply
+/// it. A snapshot written from a partially imported update would drop the
+/// pending part, so declining is what makes the browser queue durable.
+#[wasm_bindgen_test]
+fn browser_zen_operations_converge_and_defer_until_their_dependency_lands() {
+    const LIBRARY_ID: &str = "00000000-0000-7000-8000-000000000001";
+    const DOCUMENT_ID: &str = "00000000-0000-7000-8000-000000000004";
+    const DEVICE_ID: &str = "00000000-0000-7000-8000-000000000002";
+    const AUTHOR_PEER: &str = "18446744073709551614";
+    const READER_PEER: &str = "42";
+
+    let created = zen_mutation(
+        "",
+        "00000000000000000001",
+        json!({
+            "type": "create",
+            "document_id": DOCUMENT_ID,
+            "title": "CRDT reading log",
+            "body": "- [ ] Read the paper",
+            "created_at": 1_700_000_000_i64,
+            "tags": ["crdt"],
+        }),
+    );
+    let edited = zen_mutation(
+        created["snapshot"].as_str().expect("created snapshot"),
+        "00000000000000000002",
+        json!({
+            "type": "set_body",
+            "body": "- [x] Read the paper\n- [ ] Write it up",
+        }),
+    );
+
+    let path =
+        |sequence: &str| format!("sync/v2/ops/zen/{DOCUMENT_ID}/{DEVICE_ID}/{sequence}.json");
+    let create_path = path("00000000000000000001");
+    let edit_path = path("00000000000000000002");
+
+    // Backwards on purpose: the edit depends on the create.
+    let deferred: Value = serde_json::from_str(
+        &apply_zen_envelope(
+            "",
+            READER_PEER,
+            LIBRARY_ID,
+            &edit_path,
+            edited["envelope"].as_str().expect("edit envelope"),
+        )
+        .expect("receive the edit first"),
+    )
+    .expect("deferred result JSON");
+    assert_eq!(deferred["deferred"], json!(true));
+    assert!(
+        deferred.get("snapshot").is_none(),
+        "a deferred operation must not produce a replica"
+    );
+
+    let mut replica = String::new();
+    for (operation_path, envelope) in [
+        (&create_path, &created["envelope"]),
+        (&edit_path, &edited["envelope"]),
+    ] {
+        let applied: Value = serde_json::from_str(
+            &apply_zen_envelope(
+                &replica,
+                READER_PEER,
+                LIBRARY_ID,
+                operation_path,
+                envelope.as_str().expect("envelope"),
+            )
+            .expect("receive in order"),
+        )
+        .expect("applied result JSON");
+        assert_eq!(applied["deferred"], json!(false));
+        replica = applied["snapshot"]
+            .as_str()
+            .expect("applied snapshot")
+            .to_owned();
+    }
+
+    let reader: Value = serde_json::from_str(
+        &zen_document_view(&replica, READER_PEER, DOCUMENT_ID).expect("reader view"),
+    )
+    .expect("reader view JSON");
+    let author: Value = serde_json::from_str(
+        &zen_document_view(
+            edited["snapshot"].as_str().expect("author snapshot"),
+            AUTHOR_PEER,
+            DOCUMENT_ID,
+        )
+        .expect("author view"),
+    )
+    .expect("author view JSON");
+    assert_eq!(reader["body"], author["body"]);
+    assert_eq!(reader["title"]["value"], json!("CRDT reading log"));
+    assert!(
+        reader["body"]
+            .as_str()
+            .expect("body text")
+            .contains("Write it up")
+    );
+}
+
+fn zen_mutation(snapshot: &str, sequence: &str, mutation: Value) -> Value {
+    serde_json::from_str(
+        &apply_zen_mutation(
+            snapshot,
+            "18446744073709551614",
+            "00000000-0000-7000-8000-000000000001",
+            "00000000-0000-7000-8000-000000000002",
+            sequence,
+            "2026-07-11T00:00:00Z",
+            "00000000-0000-7000-8000-000000000004",
+            &mutation.to_string(),
+        )
+        .expect("local browser zen mutation"),
+    )
+    .expect("zen mutation result JSON")
 }

--- a/crates/research-store/migrations/0011_adopted_aggregate_generation.sql
+++ b/crates/research-store/migrations/0011_adopted_aggregate_generation.sql
@@ -1,0 +1,33 @@
+-- Let a device record a v2 generation it adopted rather than performed.
+--
+-- Only the device that migrates writes the v1 barrier operation. Every other
+-- device receives that barrier through ordinary v1 synchronization and then
+-- adopts the published genesis, so its migration record has no barrier of its
+-- own to point at. The original table required one, which made adoption
+-- impossible to express.
+--
+-- SQLite cannot drop a foreign key in place, so the table is rebuilt. Nothing
+-- else about the record changes: the exact protocol bytes remain the only
+-- stored truth, and every identity is still derived by validating them.
+CREATE TABLE aggregate_migration_rebuilt (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    library_id TEXT NOT NULL,
+    catalogue_json TEXT NOT NULL,
+    genesis_json TEXT NOT NULL,
+    barrier_device_id TEXT,
+    barrier_sequence TEXT CHECK (
+        barrier_sequence IS NULL OR length(barrier_sequence) = 20
+    ),
+    migrated_at TEXT NOT NULL,
+    -- A barrier is either fully identified or absent; never half of one.
+    CHECK ((barrier_device_id IS NULL) = (barrier_sequence IS NULL))
+);
+
+INSERT INTO aggregate_migration_rebuilt
+SELECT singleton, library_id, catalogue_json, genesis_json, barrier_device_id,
+       barrier_sequence, migrated_at
+FROM aggregate_migration;
+
+DROP TABLE aggregate_migration;
+
+ALTER TABLE aggregate_migration_rebuilt RENAME TO aggregate_migration;

--- a/crates/research-store/src/aggregate.rs
+++ b/crates/research-store/src/aggregate.rs
@@ -24,16 +24,160 @@ pub struct AggregateMigrationReceipt {
     pub v1_checkpoint_id: String,
     pub catalogue_path: String,
     pub catalogue_sha256: String,
-    pub barrier_path: String,
+    /// Absent when this device adopted a generation another device published:
+    /// only the migrating device writes the v1 barrier.
+    pub barrier_path: Option<String>,
     pub aggregate_count: usize,
     /// True when this call found an existing record and changed nothing.
     pub already_migrated: bool,
+}
+
+/// The exact protocol bytes of a v2 generation, ready to publish or compare.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AggregateGeneration {
+    pub genesis_json: String,
+    pub catalogue_json: String,
+    pub catalogue_path: String,
 }
 
 impl V2Store {
     pub async fn aggregate_migration(&self) -> StoreResult<Option<AggregateMigrationReceipt>> {
         let mut connection = self.pool.acquire().await?;
         read_migration(&mut connection).await
+    }
+
+    /// The exact generation bytes this device would publish, if it has one.
+    pub async fn aggregate_generation(&self) -> StoreResult<Option<AggregateGeneration>> {
+        let Some(row) = sqlx::query(
+            "SELECT library_id, catalogue_json, genesis_json FROM aggregate_migration \
+             WHERE singleton = 1",
+        )
+        .fetch_optional(&self.pool)
+        .await?
+        else {
+            return Ok(None);
+        };
+        let library_id: String = row.try_get("library_id")?;
+        let catalogue_json: String = row.try_get("catalogue_json")?;
+        let genesis_json: String = row.try_get("genesis_json")?;
+        let genesis: AggregateGenesis = serde_json::from_str(&genesis_json)?;
+        genesis.validate(&library_id, &catalogue_json)?;
+        Ok(Some(AggregateGeneration {
+            catalogue_path: aggregate_catalogue_path(&genesis.catalogue_sha256),
+            genesis_json,
+            catalogue_json,
+        }))
+    }
+
+    /// Records a generation another device published.
+    ///
+    /// Genesis is immutable, so adopting the same bytes twice is a no-op and
+    /// adopting different bytes is refused: two genesis artifacts for one
+    /// library means the remote is not the history this device belongs to.
+    /// Every identity is re-derived from the bytes, never from the caller.
+    pub async fn adopt_aggregate_generation(
+        &self,
+        genesis_json: &str,
+        catalogue_json: &str,
+    ) -> StoreResult<AggregateMigrationReceipt> {
+        let library_id = self.meta("library_id").await?;
+        let genesis: AggregateGenesis = serde_json::from_str(genesis_json)?;
+        genesis.validate(&library_id, catalogue_json)?;
+
+        let mut connection = self.pool.acquire().await?;
+        if let Some(existing) = read_migration(&mut connection).await? {
+            if existing.catalogue_sha256 != genesis.catalogue_sha256 {
+                return Err(StoreError::SyncIntegrity(
+                    "the remote aggregate generation does not match the one this device \
+                     already records"
+                        .into(),
+                ));
+            }
+            return Ok(existing);
+        }
+        sqlx::query(
+            "INSERT INTO aggregate_migration \
+             (singleton, library_id, catalogue_json, genesis_json, migrated_at) \
+             VALUES (1, ?, ?, ?, ?)",
+        )
+        .bind(&library_id)
+        .bind(catalogue_json)
+        .bind(genesis_json)
+        .bind(now_rfc3339())
+        .execute(&mut *connection)
+        .await?;
+        read_migration(&mut connection).await?.ok_or_else(|| {
+            StoreError::InvalidStore("adopted aggregate generation was not stored".into())
+        })
+    }
+
+    /// Stores one aggregate checkpoint an adopted catalogue names.
+    ///
+    /// The artifact is validated into a live replica before anything is written,
+    /// so a checkpoint that does not rebuild cannot seed local state.
+    pub async fn receive_aggregate_checkpoint(
+        &self,
+        path: &str,
+        checkpoint_json: &str,
+    ) -> StoreResult<()> {
+        let peer_id = peer_id_for_device(&self.meta("device_id").await?)?;
+        let artifact: ItemAggregateCheckpoint = serde_json::from_str(checkpoint_json)?;
+        artifact.validate(path, peer_id)?;
+        let snapshot = STANDARD.decode(&artifact.snapshot_base64).map_err(|_| {
+            StoreError::SyncIntegrity("aggregate checkpoint payload is not Base64".into())
+        })?;
+        let now = now_rfc3339();
+        let mut connection = self.pool.acquire().await?;
+        sqlx::query(
+            "INSERT INTO aggregate_state \
+             (aggregate_kind, aggregate_id, snapshot, snapshot_sha256, updated_at) \
+             VALUES (?, ?, ?, ?, ?) \
+             ON CONFLICT(aggregate_kind, aggregate_id) DO NOTHING",
+        )
+        .bind(AggregateKind::Item.as_str())
+        .bind(&artifact.aggregate_id)
+        .bind(&snapshot)
+        .bind(&artifact.snapshot_sha256)
+        .bind(&now)
+        .execute(&mut *connection)
+        .await?;
+        sqlx::query(
+            "INSERT INTO aggregate_checkpoints \
+             (path, aggregate_kind, aggregate_id, snapshot_sha256, checkpoint_json, created_at) \
+             VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(path) DO NOTHING",
+        )
+        .bind(path)
+        .bind(AggregateKind::Item.as_str())
+        .bind(&artifact.aggregate_id)
+        .bind(&artifact.snapshot_sha256)
+        .bind(checkpoint_json)
+        .bind(&now)
+        .execute(&mut *connection)
+        .await?;
+        Ok(())
+    }
+
+    /// Checkpoints this device holds, for publication.
+    pub async fn aggregate_checkpoints(&self) -> StoreResult<Vec<(String, String)>> {
+        let rows = sqlx::query(
+            "SELECT path, checkpoint_json FROM aggregate_checkpoints ORDER BY path ASC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|row| Ok((row.try_get("path")?, row.try_get("checkpoint_json")?)))
+            .collect()
+    }
+
+    /// Aggregate IDs already present locally, so adoption downloads only what
+    /// is missing rather than every checkpoint in the catalogue.
+    pub async fn known_aggregate_ids(&self, kind: &AggregateKind) -> StoreResult<Vec<String>> {
+        Ok(sqlx::query_scalar(
+            "SELECT aggregate_id FROM aggregate_state WHERE aggregate_kind = ?",
+        )
+        .bind(kind.as_str())
+        .fetch_all(&self.pool)
+        .await?)
     }
 
     /// Move this installation onto the item-aggregates-v2 generation.
@@ -75,8 +219,8 @@ async fn read_migration(
     let library_id: String = row.try_get("library_id")?;
     let catalogue_json: String = row.try_get("catalogue_json")?;
     let genesis_json: String = row.try_get("genesis_json")?;
-    let device_id: String = row.try_get("barrier_device_id")?;
-    let sequence: String = row.try_get("barrier_sequence")?;
+    let device_id: Option<String> = row.try_get("barrier_device_id")?;
+    let sequence: Option<String> = row.try_get("barrier_sequence")?;
     // Reading revalidates rather than trusting local bytes, so a corrupt row
     // cannot report a migration whose identities do not hold.
     let genesis: AggregateGenesis = serde_json::from_str(&genesis_json)?;
@@ -86,7 +230,9 @@ async fn read_migration(
         v1_checkpoint_id: genesis.migrated_from_v1_checkpoint,
         catalogue_path: aggregate_catalogue_path(&genesis.catalogue_sha256),
         catalogue_sha256: genesis.catalogue_sha256,
-        barrier_path: format!("sync/v1/ops/{device_id}/{sequence}.json"),
+        barrier_path: device_id
+            .zip(sequence)
+            .map(|(device, sequence)| format!("sync/v1/ops/{device}/{sequence}.json")),
         aggregate_count: catalogue.entries.len(),
         already_migrated: true,
     }))
@@ -239,7 +385,7 @@ async fn run_migration(
         v1_checkpoint_id: checkpoint.checkpoint_id,
         catalogue_path: aggregate_catalogue_path(&migration.catalogue_sha256),
         catalogue_sha256: migration.catalogue_sha256,
-        barrier_path,
+        barrier_path: Some(barrier_path),
         aggregate_count: migration.checkpoints.len(),
         already_migrated: false,
     })

--- a/crates/research-store/src/aggregate_sync.rs
+++ b/crates/research-store/src/aggregate_sync.rs
@@ -1,0 +1,341 @@
+//! Transport for aggregate-scoped operations.
+//!
+//! This is the v2 counterpart to the protocol-v1 batch queue. It is kept
+//! separate because the unit of work is different: a v1 operation addresses the
+//! whole library, while a v2 operation addresses one aggregate, and only that
+//! aggregate's replica is loaded to apply it.
+//!
+//! Applying is allowed to decline. An operation whose causal dependency has not
+//! arrived is reported as deferred and nothing is written — not the replica, not
+//! the batch record, not the remote observation — so the caller can retry it
+//! once its dependency lands. Recording it as applied would be a silent loss:
+//! Loro keeps the pending update in memory, but the snapshot this store
+//! persists would not carry it.
+
+use research_domain::{AggregateEnvelope, AggregateKind, ItemAggregate, ZenAggregate};
+use sqlx::{Row, SqliteConnection};
+
+use crate::store::{now_rfc3339, peer_id_for_device, sha256_hex};
+use crate::zen::persist_zen_projection;
+use crate::{StoreError, StoreResult, V2Store};
+
+/// One aggregate operation awaiting upload.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingAggregateOperation {
+    pub path: String,
+    pub envelope_json: String,
+}
+
+/// What receiving an aggregate operation did.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AggregateDisposition {
+    Applied,
+    AlreadyApplied,
+    /// Waiting on an operation this device has not applied yet.
+    Deferred,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RemoteAggregateResult {
+    pub disposition: AggregateDisposition,
+    /// True when this operation was one of ours coming back, which is the only
+    /// proof an upload is durable on the remote.
+    pub acknowledged_outbox: bool,
+}
+
+impl V2Store {
+    /// Operations queued for upload, oldest first within each aggregate.
+    ///
+    /// Ordered by device and sequence so a receiver never has to wait on an
+    /// operation that was uploaded later than the one depending on it.
+    pub async fn pending_aggregate_operations(
+        &self,
+    ) -> StoreResult<Vec<PendingAggregateOperation>> {
+        let rows = sqlx::query(
+            "SELECT b.path, b.envelope_json FROM aggregate_outbox o \
+             JOIN aggregate_batches b ON b.aggregate_kind = o.aggregate_kind \
+             AND b.aggregate_id = o.aggregate_id AND b.device_id = o.device_id \
+             AND b.sequence = o.sequence \
+             ORDER BY o.device_id ASC, o.sequence ASC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|row| {
+                Ok(PendingAggregateOperation {
+                    path: row.try_get("path")?,
+                    envelope_json: row.try_get("envelope_json")?,
+                })
+            })
+            .collect()
+    }
+
+    pub async fn pending_aggregate_operation_count(&self) -> StoreResult<u64> {
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM aggregate_outbox")
+            .fetch_one(&self.pool)
+            .await?;
+        u64::try_from(count).map_err(|_| StoreError::NumericRange("pending aggregate count"))
+    }
+
+    pub async fn record_aggregate_outbox_attempt(
+        &self,
+        path: &str,
+        error_kind: Option<&str>,
+    ) -> StoreResult<()> {
+        sqlx::query(
+            "UPDATE aggregate_outbox SET attempts = attempts + 1, last_error = ? \
+             WHERE EXISTS (SELECT 1 FROM aggregate_batches b \
+             WHERE b.aggregate_kind = aggregate_outbox.aggregate_kind \
+             AND b.aggregate_id = aggregate_outbox.aggregate_id \
+             AND b.device_id = aggregate_outbox.device_id \
+             AND b.sequence = aggregate_outbox.sequence AND b.path = ?)",
+        )
+        .bind(error_kind)
+        .bind(path)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Applies one remote aggregate operation, or declines it.
+    ///
+    /// The whole effect is one transaction: replica, projection, batch record,
+    /// outbox acknowledgement, and remote observation land together or not at
+    /// all.
+    pub async fn receive_remote_aggregate_operation(
+        &self,
+        path: &str,
+        blob_sha: &str,
+        bytes: &[u8],
+    ) -> StoreResult<RemoteAggregateResult> {
+        let envelope: AggregateEnvelope = serde_json::from_slice(bytes)
+            .map_err(|_| StoreError::SyncIntegrity(format!("{path} is not a v2 envelope")))?;
+        let library_id = self.meta("library_id").await?;
+        let local_device_id = self.meta("device_id").await?;
+        let peer_id = peer_id_for_device(&local_device_id)?;
+        // Fails closed on a kind this build does not implement: skipping the
+        // operation would materialize a library missing part of its history.
+        envelope.aggregate_kind.path_segment()?;
+        if envelope.path()? != path {
+            return Err(StoreError::SyncIntegrity(format!(
+                "{path} does not address the operation it contains"
+            )));
+        }
+
+        let mut connection = self.pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *connection)
+            .await?;
+        let result = async {
+            let known: Option<String> = sqlx::query_scalar(
+                "SELECT path FROM aggregate_batches WHERE aggregate_kind = ? \
+                 AND aggregate_id = ? AND device_id = ? AND sequence = ?",
+            )
+            .bind(envelope.aggregate_kind.as_str())
+            .bind(&envelope.aggregate_id)
+            .bind(&envelope.device_id)
+            .bind(&envelope.sequence)
+            .fetch_optional(&mut *connection)
+            .await?;
+
+            let disposition = if known.is_some() {
+                AggregateDisposition::AlreadyApplied
+            } else if apply_aggregate(&mut connection, path, &envelope, &library_id, peer_id)
+                .await?
+            {
+                record_aggregate_batch(&mut connection, path, &envelope, bytes).await?;
+                AggregateDisposition::Applied
+            } else {
+                AggregateDisposition::Deferred
+            };
+
+            if disposition == AggregateDisposition::Deferred {
+                return Ok(RemoteAggregateResult {
+                    disposition,
+                    acknowledged_outbox: false,
+                });
+            }
+
+            let acknowledged = sqlx::query(
+                "DELETE FROM aggregate_outbox WHERE aggregate_kind = ? AND aggregate_id = ? \
+                 AND device_id = ? AND sequence = ?",
+            )
+            .bind(envelope.aggregate_kind.as_str())
+            .bind(&envelope.aggregate_id)
+            .bind(&envelope.device_id)
+            .bind(&envelope.sequence)
+            .execute(&mut *connection)
+            .await?
+            .rows_affected()
+                > 0;
+            observe_aggregate_blob(&mut connection, path, blob_sha).await?;
+            Ok(RemoteAggregateResult {
+                disposition,
+                acknowledged_outbox: acknowledged,
+            })
+        }
+        .await;
+        match result {
+            Ok(result) => {
+                sqlx::query("COMMIT").execute(&mut *connection).await?;
+                Ok(result)
+            }
+            Err(error) => {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *connection).await;
+                Err(error)
+            }
+        }
+    }
+}
+
+/// Applies an operation to its aggregate's replica.
+///
+/// Returns `false` when the operation was deferred, leaving every table
+/// untouched.
+async fn apply_aggregate(
+    connection: &mut SqliteConnection,
+    path: &str,
+    envelope: &AggregateEnvelope,
+    library_id: &str,
+    peer_id: u64,
+) -> StoreResult<bool> {
+    let kind = envelope.aggregate_kind.as_str();
+    let existing: Option<Vec<u8>> = sqlx::query_scalar(
+        "SELECT snapshot FROM aggregate_state WHERE aggregate_kind = ? AND aggregate_id = ?",
+    )
+    .bind(kind)
+    .bind(&envelope.aggregate_id)
+    .fetch_optional(&mut *connection)
+    .await?;
+    let now = now_rfc3339();
+
+    match envelope.aggregate_kind {
+        AggregateKind::Zen => {
+            let aggregate = match existing {
+                Some(snapshot) => {
+                    let aggregate = ZenAggregate::from_snapshot(
+                        &envelope.aggregate_id,
+                        &snapshot,
+                        peer_id,
+                    )?;
+                    if aggregate.import_envelope(path, envelope, library_id)? {
+                        return Ok(false);
+                    }
+                    aggregate
+                }
+                None => {
+                    match ZenAggregate::from_envelope(path, envelope, library_id, peer_id)? {
+                        Some(aggregate) => aggregate,
+                        None => return Ok(false),
+                    }
+                }
+            };
+            write_replica(
+                connection,
+                kind,
+                &envelope.aggregate_id,
+                &aggregate.export_snapshot()?,
+                &now,
+            )
+            .await?;
+            persist_zen_projection(connection, &aggregate.view()?.summary(), &now).await?;
+        }
+        AggregateKind::Item => {
+            // Item replicas are seeded by migration, so an operation for one
+            // this device has never seen is waiting on the catalogue rather
+            // than on another operation.
+            let Some(snapshot) = existing else {
+                return Ok(false);
+            };
+            let aggregate =
+                ItemAggregate::from_snapshot(&envelope.aggregate_id, &snapshot, peer_id)?;
+            if aggregate.import_envelope(path, envelope, library_id)? {
+                return Ok(false);
+            }
+            write_replica(
+                connection,
+                kind,
+                &envelope.aggregate_id,
+                &aggregate.export_snapshot()?,
+                &now,
+            )
+            .await?;
+        }
+        AggregateKind::Unsupported(ref value) => {
+            return Err(
+                research_domain::DomainError::UnsupportedAggregateKind(value.clone()).into(),
+            );
+        }
+    }
+    Ok(true)
+}
+
+async fn write_replica(
+    connection: &mut SqliteConnection,
+    kind: &str,
+    aggregate_id: &str,
+    snapshot: &[u8],
+    now: &str,
+) -> StoreResult<()> {
+    sqlx::query(
+        "INSERT INTO aggregate_state \
+         (aggregate_kind, aggregate_id, snapshot, snapshot_sha256, updated_at) \
+         VALUES (?, ?, ?, ?, ?) \
+         ON CONFLICT(aggregate_kind, aggregate_id) DO UPDATE SET \
+         snapshot = excluded.snapshot, snapshot_sha256 = excluded.snapshot_sha256, \
+         updated_at = excluded.updated_at",
+    )
+    .bind(kind)
+    .bind(aggregate_id)
+    .bind(snapshot)
+    .bind(sha256_hex(snapshot))
+    .bind(now)
+    .execute(&mut *connection)
+    .await?;
+    Ok(())
+}
+
+async fn record_aggregate_batch(
+    connection: &mut SqliteConnection,
+    path: &str,
+    envelope: &AggregateEnvelope,
+    bytes: &[u8],
+) -> StoreResult<()> {
+    let envelope_json = std::str::from_utf8(bytes)
+        .map_err(|_| StoreError::SyncIntegrity(format!("{path} is not UTF-8 JSON")))?;
+    sqlx::query(
+        "INSERT INTO aggregate_batches \
+         (aggregate_kind, aggregate_id, device_id, sequence, path, payload_sha256, \
+          envelope_json, origin, applied_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'remote', ?)",
+    )
+    .bind(envelope.aggregate_kind.as_str())
+    .bind(&envelope.aggregate_id)
+    .bind(&envelope.device_id)
+    .bind(&envelope.sequence)
+    .bind(path)
+    .bind(&envelope.payload_sha256)
+    .bind(envelope_json)
+    .bind(now_rfc3339())
+    .execute(&mut *connection)
+    .await?;
+    Ok(())
+}
+
+/// Records that an immutable v2 path was seen carrying exactly these bytes.
+async fn observe_aggregate_blob(
+    connection: &mut SqliteConnection,
+    path: &str,
+    blob_sha: &str,
+) -> StoreResult<()> {
+    sqlx::query(
+        "INSERT OR IGNORE INTO remote_observations (path, blob_sha, observed_at) \
+         VALUES (?, ?, ?)",
+    )
+    .bind(path)
+    .bind(blob_sha)
+    .bind(now_rfc3339())
+    .execute(&mut *connection)
+    .await?;
+    Ok(())
+}

--- a/crates/research-store/src/lib.rs
+++ b/crates/research-store/src/lib.rs
@@ -1,6 +1,7 @@
 //! Durable, local-only persistence for a V2 ResearchPocket library.
 
 mod aggregate;
+mod aggregate_sync;
 mod captured;
 mod enrichment;
 mod error;
@@ -11,7 +12,10 @@ mod store;
 mod sync;
 mod zen;
 
-pub use aggregate::AggregateMigrationReceipt;
+pub use aggregate::{AggregateGeneration, AggregateMigrationReceipt};
+pub use aggregate_sync::{
+    AggregateDisposition, PendingAggregateOperation, RemoteAggregateResult,
+};
 pub use enrichment::ENRICHMENT_MAX_ATTEMPTS;
 pub use error::{StoreError, StoreResult};
 pub use model::{

--- a/crates/research-store/src/zen.rs
+++ b/crates/research-store/src/zen.rs
@@ -334,7 +334,7 @@ async fn load_aggregate(
     ZenAggregate::from_snapshot(document_id, &snapshot, peer_id).map_err(StoreError::from)
 }
 
-async fn persist_zen_projection(
+pub(crate) async fn persist_zen_projection(
     connection: &mut SqliteConnection,
     summary: &ZenDocumentSummary,
     now: &str,

--- a/crates/research-store/tests/sync_contract.rs
+++ b/crates/research-store/tests/sync_contract.rs
@@ -168,7 +168,7 @@ async fn migrating_to_item_aggregates_is_idempotent_and_queues_the_barrier() {
     // existing outbox and older clients meet it on their next pull.
     let queued = store.pending_batches().await.expect("barrier queued");
     assert_eq!(queued.len(), 1);
-    assert_eq!(queued[0].path, receipt.barrier_path);
+    assert_eq!(Some(queued[0].path.clone()), receipt.barrier_path);
 
     let repeated = store
         .migrate_to_item_aggregates()

--- a/crates/research-store/tests/zen_contract.rs
+++ b/crates/research-store/tests/zen_contract.rs
@@ -1,4 +1,6 @@
-use research_store::{CreateZenDocumentRequest, EditZenDocumentRequest, V2Store};
+use research_store::{
+    AggregateDisposition, CreateZenDocumentRequest, EditZenDocumentRequest, V2Store,
+};
 
 /// The workspace list must stay metadata-only and every edit must queue exactly
 /// one aggregate-scoped operation.
@@ -64,6 +66,120 @@ async fn zen_documents_project_metadata_and_queue_one_operation_per_edit() {
     assert_eq!(queued, 4);
     let items: i64 = sqlx_scalar(&store, "SELECT COUNT(*) FROM outbox").await;
     assert_eq!(items, 0, "zen work never lands in the protocol-v1 outbox");
+}
+
+/// A second device must reach the same document from the operations alone, and
+/// must not lose an operation that arrives before the one it depends on.
+#[tokio::test]
+async fn zen_operations_converge_and_defer_until_their_dependency_lands() {
+    let root = tempfile::tempdir().expect("temporary test root");
+    let sender = V2Store::init(root.path().join("sender"))
+        .await
+        .expect("sender store");
+    let receiver = V2Store::init(root.path().join("receiver"))
+        .await
+        .expect("receiver store");
+    let identity = sender.sync_identity().await.expect("sender identity");
+    receiver
+        .adopt_library_id_if_pristine(&identity.library_id)
+        .await
+        .expect("adopt sender library");
+
+    let created = sender
+        .create_zen_document(CreateZenDocumentRequest {
+            title: Some("CRDT reading log".into()),
+            body: "- [ ] Read the paper".into(),
+            tags: vec!["crdt".into()],
+        })
+        .await
+        .expect("create document");
+    sender
+        .edit_zen_document(EditZenDocumentRequest {
+            document_id: created.document_id.clone(),
+            body: Some("- [x] Read the paper\n- [ ] Write it up".into()),
+            ..EditZenDocumentRequest::default()
+        })
+        .await
+        .expect("edit document");
+
+    let queued = sender
+        .pending_aggregate_operations()
+        .await
+        .expect("queued operations");
+    assert_eq!(queued.len(), 2);
+
+    // Deliberately backwards: the edit depends on the create, so it must be
+    // declined rather than half-applied and recorded.
+    let deferred = receiver
+        .receive_remote_aggregate_operation(
+            &queued[1].path,
+            &"a".repeat(40),
+            queued[1].envelope_json.as_bytes(),
+        )
+        .await
+        .expect("receive the edit first");
+    assert_eq!(deferred.disposition, AggregateDisposition::Deferred);
+    assert!(
+        receiver
+            .list_zen_documents()
+            .await
+            .expect("list")
+            .is_empty(),
+        "a deferred operation must not create a document"
+    );
+
+    for operation in [&queued[0], &queued[1]] {
+        let result = receiver
+            .receive_remote_aggregate_operation(
+                &operation.path,
+                &"b".repeat(40),
+                operation.envelope_json.as_bytes(),
+            )
+            .await
+            .expect("receive in order");
+        assert_eq!(result.disposition, AggregateDisposition::Applied);
+    }
+
+    assert_eq!(
+        receiver.list_zen_documents().await.expect("receiver list"),
+        sender.list_zen_documents().await.expect("sender list"),
+    );
+    let body = receiver
+        .zen_document(&created.document_id)
+        .await
+        .expect("receiver body")
+        .body;
+    assert_eq!(
+        body,
+        sender
+            .zen_document(&created.document_id)
+            .await
+            .expect("sender body")
+            .body
+    );
+    assert!(body.contains("Write it up"));
+
+    // The sender seeing its own operation come back is what clears the queue.
+    let acknowledged = sender
+        .receive_remote_aggregate_operation(
+            &queued[0].path,
+            &"c".repeat(40),
+            queued[0].envelope_json.as_bytes(),
+        )
+        .await
+        .expect("acknowledge own upload");
+    assert_eq!(
+        acknowledged.disposition,
+        AggregateDisposition::AlreadyApplied
+    );
+    assert!(acknowledged.acknowledged_outbox);
+    assert_eq!(
+        sender
+            .pending_aggregate_operation_count()
+            .await
+            .expect("remaining"),
+        1
+    );
 }
 
 async fn sqlx_scalar(store: &V2Store, query: &'static str) -> i64 {

--- a/docs/v2/SYNC_PROTOCOL.md
+++ b/docs/v2/SYNC_PROTOCOL.md
@@ -472,6 +472,32 @@ clients accept the barrier, validate v2 genesis/catalogue/checkpoints, and apply
 only aggregate-scoped updates. Repeating migration with the same v1 checkpoint
 and identities produces the same aggregate identities and visible state.
 
+### Aggregate operation transport
+
+Aggregate operations are carried after the protocol-v1 phase of a cycle, so the
+migration barrier is on the remote before any v2 object a barrier-blind client
+could reach. Discovery covers all of `sync/`: a client that enumerated only the
+paths it writes could upload into a namespace it never read.
+
+Application may decline. An operation whose causal predecessor has not been
+applied is *deferred*: no replica, batch record, or remote observation is
+written, and the client retries it after other operations land. This is required
+rather than cosmetic — a replica persists as a snapshot, and a snapshot does not
+carry the part of an update Loro is still holding pending, so recording a
+partially imported operation as applied would lose it silently. A round that
+applies nothing while operations remain deferred means a dependency is absent
+from the remote, which is reported as an integrity failure.
+
+Upload is confirmed from the remote, never assumed. A created object is applied
+back from the write that created it, and a losing race is resolved by reading
+whatever object is actually at that path. Only that confirmation clears the
+queue, so an interrupted cycle re-uploads rather than dropping work.
+
+Zen documents use the `zen_document` kind and the `zen` path segment, so their
+operations live at `sync/v2/ops/zen/…`. They are aggregates from the start and
+have no v1 history, so they need no catalogue entry: a create operation
+establishes the whole document.
+
 ## Version negotiation
 
 A client advertises an internal supported tuple:

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -7,12 +7,14 @@ use chrono::{DateTime, FixedOffset};
 use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
 use reqwest::{Client, Response, StatusCode, Url};
 use research_domain::{
-    DomainError, LibraryGenesis, MAX_OPERATION_PACK_BYTES, MAX_OPERATION_PACK_MEMBERS,
-    OperationPackArtifact, create_operation_pack, validate_checkpoint,
+    AGGREGATE_GENESIS_PATH, AGGREGATE_OPS_ROOT, AggregateCatalogue, AggregateGenesis,
+    AggregateKind, DomainError, LibraryGenesis, MAX_OPERATION_PACK_BYTES,
+    MAX_OPERATION_PACK_MEMBERS, OperationPackArtifact, aggregate_catalogue_path,
+    create_operation_pack, validate_checkpoint,
 };
 use research_store::{
-    PendingBatch, PendingCapturedDocument, RemoteBatchDisposition, StoreError,
-    SyncConfiguration, V2Store,
+    AggregateDisposition, AggregateGeneration, PendingAggregateOperation, PendingBatch,
+    PendingCapturedDocument, RemoteBatchDisposition, StoreError, SyncConfiguration, V2Store,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -24,7 +26,6 @@ const GENESIS_PATH: &str = "sync/v1/library.json";
 const OPS_PREFIX: &str = "sync/v1/ops/";
 const PACKS_PREFIX: &str = "sync/v1/ops/packs/";
 const CHECKPOINTS_PREFIX: &str = "sync/v1/checkpoints/";
-const CONTENT_PREFIX: &str = "sync/v2/content/sha256/";
 const MAX_UPLOAD_ATTEMPTS: usize = 4;
 const PACK_JSON_OVERHEAD_ALLOWANCE: usize = 1_024;
 
@@ -121,6 +122,18 @@ pub struct SyncCycleResult {
     pub acknowledged: u64,
     pub uploaded: u64,
     pub pending: u64,
+    /// Aggregate-scoped work — zen documents today, items once they move.
+    /// Counted apart from v1 because the two generations queue separately and
+    /// a number that mixed them could not be reconciled with either queue.
+    pub aggregates_uploaded: u64,
+    pub aggregates_applied: u64,
+    pub aggregates_pending: u64,
+}
+
+#[derive(Default)]
+struct AggregateStats {
+    uploaded: u64,
+    applied: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -462,6 +475,7 @@ async fn run_configured(
     }
     pull.add(pull_remote(store, client, remote).await?);
     ensure_checkpoint_uploaded(store, client, remote).await?;
+    let aggregates = run_aggregates(store, client, remote).await?;
     let pending = u64::try_from(store.pending_batches().await?.len())
         .map_err(|_| StoreError::NumericRange("pending sync batch count"))?;
     Ok(SyncCycleResult {
@@ -473,7 +487,309 @@ async fn run_configured(
         acknowledged: pull.acknowledged,
         uploaded,
         pending,
+        aggregates_uploaded: aggregates.uploaded,
+        aggregates_applied: aggregates.applied,
+        aggregates_pending: store.pending_aggregate_operation_count().await?,
     })
+}
+
+/// Carries the aggregate generation: publish or adopt it, upload what is
+/// queued, then apply what is there.
+///
+/// Runs after the v1 phase so the migration barrier is already on the remote by
+/// the time any v2 object is: an older client meets the barrier and stops
+/// before it can encounter a namespace it does not implement.
+async fn run_aggregates(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+) -> Result<AggregateStats, SyncError> {
+    reconcile_generation(store, client, remote).await?;
+    let mut stats = AggregateStats::default();
+    for operation in store.pending_aggregate_operations().await? {
+        if ensure_aggregate_uploaded(store, client, remote, &operation).await? {
+            stats.uploaded += 1;
+        }
+    }
+    stats.applied = apply_remote_aggregates(store, client, remote).await?;
+    Ok(stats)
+}
+
+/// Agrees with the remote on which v2 generation this library is in.
+///
+/// Genesis is immutable, so there is exactly one right answer per library: the
+/// first device to publish defines it and everyone else adopts. A device that
+/// finds a genesis it cannot reconcile with its own stops rather than writing
+/// into a history it does not share.
+async fn reconcile_generation(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+) -> Result<(), SyncError> {
+    let tree = client.discover(remote).await?;
+    let Some(sha) = tree.blobs.get(AGGREGATE_GENESIS_PATH) else {
+        if let Some(generation) = store.aggregate_generation().await? {
+            publish_generation(store, client, remote, &generation).await?;
+        }
+        return Ok(());
+    };
+
+    let genesis_json = remote_text(client, remote, sha, AGGREGATE_GENESIS_PATH).await?;
+    let genesis: AggregateGenesis = serde_json::from_str(&genesis_json)
+        .map_err(|_| SyncError::RemoteData("aggregate genesis JSON is invalid".into()))?;
+    let catalogue_path = aggregate_catalogue_path(&genesis.catalogue_sha256);
+    let catalogue_sha = tree.blobs.get(&catalogue_path).ok_or_else(|| {
+        SyncError::Integrity(
+            "aggregate genesis names a catalogue the repository does not contain".into(),
+        )
+    })?;
+    let catalogue_json = remote_text(client, remote, catalogue_sha, &catalogue_path).await?;
+    // Adoption revalidates both artifacts against this library and fails closed
+    // on an aggregate kind this build does not implement.
+    store
+        .adopt_aggregate_generation(&genesis_json, &catalogue_json)
+        .await?;
+    store
+        .record_immutable_remote_blob(AGGREGATE_GENESIS_PATH, sha)
+        .await?;
+
+    let catalogue: AggregateCatalogue = serde_json::from_str(&catalogue_json)
+        .map_err(|_| SyncError::RemoteData("aggregate catalogue JSON is invalid".into()))?;
+    seed_missing_replicas(store, client, remote, &tree, &catalogue).await?;
+    publish_missing_checkpoints(store, client, remote, &tree).await
+}
+
+/// Downloads the checkpoints for catalogue entries this device has no replica
+/// of, which is how a device that did not migrate joins the generation.
+async fn seed_missing_replicas(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+    tree: &ProtocolTree,
+    catalogue: &AggregateCatalogue,
+) -> Result<(), SyncError> {
+    let kinds = catalogue
+        .entries
+        .iter()
+        .map(|entry| entry.aggregate_kind.as_str().to_owned())
+        .collect::<BTreeSet<_>>();
+    let mut present = BTreeSet::new();
+    for kind in kinds {
+        for id in store
+            .known_aggregate_ids(&AggregateKind::from(kind.clone()))
+            .await?
+        {
+            present.insert((kind.clone(), id));
+        }
+    }
+    for entry in &catalogue.entries {
+        let key = (
+            entry.aggregate_kind.as_str().to_owned(),
+            entry.aggregate_id.clone(),
+        );
+        if present.contains(&key) {
+            continue;
+        }
+        let sha = tree.blobs.get(&entry.checkpoint_path).ok_or_else(|| {
+            SyncError::Integrity(
+                "the aggregate catalogue names a checkpoint the repository does not contain"
+                    .into(),
+            )
+        })?;
+        let json = remote_text(client, remote, sha, &entry.checkpoint_path).await?;
+        store
+            .receive_aggregate_checkpoint(&entry.checkpoint_path, &json)
+            .await?;
+        store
+            .record_immutable_remote_blob(&entry.checkpoint_path, sha)
+            .await?;
+    }
+    Ok(())
+}
+
+/// Publishes this device's generation. The catalogue goes up before genesis, so
+/// genesis never names an artifact a reader cannot fetch.
+async fn publish_generation(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+    generation: &AggregateGeneration,
+) -> Result<(), SyncError> {
+    put_immutable(
+        client,
+        remote,
+        &generation.catalogue_path,
+        generation.catalogue_json.as_bytes(),
+    )
+    .await?;
+    put_immutable(
+        client,
+        remote,
+        AGGREGATE_GENESIS_PATH,
+        generation.genesis_json.as_bytes(),
+    )
+    .await?;
+    let tree = client.discover(remote).await?;
+    publish_missing_checkpoints(store, client, remote, &tree).await
+}
+
+async fn publish_missing_checkpoints(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+    tree: &ProtocolTree,
+) -> Result<(), SyncError> {
+    for (path, checkpoint_json) in store.aggregate_checkpoints().await? {
+        if tree.blobs.contains_key(&path) {
+            continue;
+        }
+        put_immutable(client, remote, &path, checkpoint_json.as_bytes()).await?;
+    }
+    Ok(())
+}
+
+/// Writes a content-addressed object, treating "already there" as success.
+///
+/// Every v2 artifact is named by the hash of its own bytes, so a losing race is
+/// a race with an identical object.
+async fn put_immutable(
+    client: &GitHubClient,
+    remote: &Remote,
+    path: &str,
+    bytes: &[u8],
+) -> Result<(), SyncError> {
+    for attempt in 0..MAX_UPLOAD_ATTEMPTS {
+        match client
+            .put_new(remote, path, bytes, Some(&remote.branch))
+            .await?
+        {
+            PutResult::Created(_) | PutResult::Race => return Ok(()),
+            PutResult::Ambiguous(_) => retry_delay(path, attempt).await,
+        }
+    }
+    Err(SyncError::Contention)
+}
+
+async fn ensure_aggregate_uploaded(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+    operation: &PendingAggregateOperation,
+) -> Result<bool, SyncError> {
+    let bytes = operation.envelope_json.as_bytes();
+    for attempt in 0..MAX_UPLOAD_ATTEMPTS {
+        match client
+            .put_new(remote, &operation.path, bytes, Some(&remote.branch))
+            .await
+        {
+            Ok(PutResult::Created(sha)) => {
+                // Confirming from the write is what clears the outbox, so a
+                // crash before the next pull cannot leave the operation queued
+                // forever.
+                store
+                    .receive_remote_aggregate_operation(&operation.path, &sha, bytes)
+                    .await?;
+                return Ok(true);
+            }
+            Ok(PutResult::Race) => {
+                // The path already exists. Confirm from whatever is actually
+                // there rather than assuming our bytes are what a reader sees.
+                let tree = client.discover(remote).await?;
+                if let Some(sha) = tree.blobs.get(&operation.path) {
+                    let existing = client.download_blob(remote, sha).await?;
+                    store
+                        .receive_remote_aggregate_operation(&operation.path, sha, &existing)
+                        .await?;
+                    return Ok(false);
+                }
+                store
+                    .record_aggregate_outbox_attempt(&operation.path, Some("contention"))
+                    .await?;
+                retry_delay(&operation.path, attempt).await;
+            }
+            Ok(PutResult::Ambiguous(kind)) => {
+                store
+                    .record_aggregate_outbox_attempt(&operation.path, Some(kind))
+                    .await?;
+                retry_delay(&operation.path, attempt).await;
+            }
+            Err(error) => {
+                let _ = store
+                    .record_aggregate_outbox_attempt(&operation.path, Some(error.kind()))
+                    .await;
+                return Err(error);
+            }
+        }
+    }
+    Err(SyncError::Contention)
+}
+
+/// Applies every remote aggregate operation this device has not seen.
+///
+/// Operations are retried in rounds rather than applied once each: one can
+/// depend on another that sorts after it by path. A round that applies nothing
+/// while work remains means a dependency is genuinely absent from the remote,
+/// which is a broken history rather than a slow one.
+async fn apply_remote_aggregates(
+    store: &V2Store,
+    client: &GitHubClient,
+    remote: &Remote,
+) -> Result<u64, SyncError> {
+    let tree = client.discover(remote).await?;
+    let mut queue = Vec::new();
+    for (path, sha) in tree
+        .blobs
+        .iter()
+        .filter(|(path, _)| path.starts_with(AGGREGATE_OPS_ROOT))
+    {
+        if let Some(observed) = store.observed_remote_blob(path).await? {
+            if observed == *sha {
+                continue;
+            }
+            return Err(SyncError::Integrity(
+                "an immutable aggregate operation changed after it was observed".into(),
+            ));
+        }
+        let bytes = client.download_blob(remote, sha).await?;
+        queue.push((path.clone(), sha.clone(), bytes));
+    }
+
+    let mut applied = 0_u64;
+    while !queue.is_empty() {
+        let mut deferred = Vec::new();
+        let mut progressed = false;
+        for (path, sha, bytes) in queue {
+            let result = store
+                .receive_remote_aggregate_operation(&path, &sha, &bytes)
+                .await?;
+            match result.disposition {
+                AggregateDisposition::Deferred => deferred.push((path, sha, bytes)),
+                AggregateDisposition::Applied => {
+                    applied += 1;
+                    progressed = true;
+                }
+                AggregateDisposition::AlreadyApplied => progressed = true,
+            }
+        }
+        if !deferred.is_empty() && !progressed {
+            return Err(SyncError::Integrity(
+                "remote aggregate operations have missing causal dependencies".into(),
+            ));
+        }
+        queue = deferred;
+    }
+    Ok(applied)
+}
+
+async fn remote_text(
+    client: &GitHubClient,
+    remote: &Remote,
+    sha: &str,
+    path: &str,
+) -> Result<String, SyncError> {
+    let bytes = client.download_blob(remote, sha).await?;
+    String::from_utf8(bytes)
+        .map_err(|_| SyncError::RemoteData(format!("{path} is not UTF-8 JSON")))
 }
 
 async fn pull_remote(
@@ -857,7 +1173,7 @@ impl GitHubClient {
                 validate_reserved_directory(&path, &entry)?;
                 if entry.kind == "tree" && protocol_tree_relevant(&path) {
                     stack.push((entry.sha, path));
-                } else if path.starts_with("sync/v1/") || path.starts_with(CONTENT_PREFIX) {
+                } else if is_protocol_path(&path) {
                     insert_protocol_blob(&mut protocol, &path, &entry)?;
                 }
             }
@@ -1026,9 +1342,7 @@ fn collect_protocol_entries(
     for entry in entries {
         let path = join_path(prefix, &entry.path);
         validate_reserved_directory(&path, &entry)?;
-        if (path.starts_with("sync/v1/") || path.starts_with(CONTENT_PREFIX))
-            && entry.kind != "tree"
-        {
+        if is_protocol_path(&path) && entry.kind != "tree" {
             insert_protocol_blob(&mut protocol, &path, &entry)?;
         }
     }
@@ -1071,12 +1385,15 @@ fn validate_reserved_directory(path: &str, entry: &TreeEntry) -> Result<(), Sync
     Ok(())
 }
 
+/// Both generations live under `sync/`, and a client must see all of it:
+/// discovering only what it writes would let it upload into a namespace it has
+/// not read.
+fn is_protocol_path(path: &str) -> bool {
+    path.starts_with("sync/v1/") || path.starts_with("sync/v2/")
+}
+
 fn protocol_tree_relevant(path: &str) -> bool {
-    matches!(
-        path,
-        "sync" | "sync/v1" | "sync/v2" | "sync/v2/content" | "sync/v2/content/sha256"
-    ) || path.starts_with("sync/v1/")
-        || path.starts_with(CONTENT_PREFIX)
+    path == "sync" || path == "sync/v1" || path == "sync/v2" || is_protocol_path(path)
 }
 
 fn join_path(prefix: &str, path: &str) -> String {

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -1163,6 +1163,9 @@ fn print_sync_counts(value: &Value) {
     print_number(value, "acknowledged", "Acknowledged");
     print_number(value, "uploaded", "Uploaded");
     print_number(value, "pending", "Pending");
+    print_number(value, "aggregates_applied", "Documents applied");
+    print_number(value, "aggregates_uploaded", "Documents uploaded");
+    print_number(value, "aggregates_pending", "Documents pending");
 }
 
 fn human_status(value: &Value) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1889,7 +1889,8 @@ function SyncPanel({
             <div>
               <dt>Last cycle</dt>
               <dd>
-                {state.lastCycle.downloaded} down · {state.lastCycle.uploaded} up
+                {state.lastCycle.downloaded + state.lastCycle.aggregatesApplied} down ·{" "}
+                {state.lastCycle.uploaded + state.lastCycle.aggregatesUploaded} up
               </dd>
             </div>
           ) : null}

--- a/web/src/data/domain.ts
+++ b/web/src/data/domain.ts
@@ -1,5 +1,6 @@
 type DomainMethod =
   | "applyMutation"
+  | "applyZenEnvelope"
   | "applyZenMutation"
   | "applyRemoteEnvelopes"
   | "createCheckpoint"

--- a/web/src/data/domain.worker.ts
+++ b/web/src/data/domain.worker.ts
@@ -1,5 +1,6 @@
 import initWasm, {
   applyMutation,
+  applyZenEnvelope,
   applyZenMutation,
   applyRemoteEnvelopes,
   createCheckpoint,
@@ -17,6 +18,7 @@ import initWasm, {
 
 type DomainMethod =
   | "applyMutation"
+  | "applyZenEnvelope"
   | "applyZenMutation"
   | "applyRemoteEnvelopes"
   | "createCheckpoint"
@@ -45,6 +47,7 @@ interface DomainResponse {
 
 const methods: Record<DomainMethod, (...args: string[]) => string> = {
   applyMutation,
+  applyZenEnvelope,
   applyZenMutation,
   applyRemoteEnvelopes,
   createCheckpoint,

--- a/web/src/data/github.ts
+++ b/web/src/data/github.ts
@@ -9,6 +9,7 @@ export const GENESIS_PATH = "sync/v1/library.json";
 export const OPS_PREFIX = "sync/v1/ops/";
 export const PACKS_PREFIX = `${OPS_PREFIX}packs/`;
 export const CONTENT_PREFIX = "sync/v2/content/sha256/";
+export const AGGREGATE_OPS_ROOT = "sync/v2/ops/";
 
 export interface GitHubRemote {
   owner: string;
@@ -161,10 +162,7 @@ export class GitHubClient {
         validateReservedDirectory(path, entry);
         if (entry.type === "tree" && protocolTreeRelevant(path)) {
           stack.push([entry.sha, path]);
-        } else if (
-          path.startsWith("sync/v1/") ||
-          path.startsWith(CONTENT_PREFIX)
-        ) {
+        } else if (isProtocolPath(path)) {
           insertProtocolBlob(protocol, path, entry);
         }
       }
@@ -338,10 +336,7 @@ function collectProtocolEntries(entries: TreeEntry[], prefix: string): ProtocolT
   for (const entry of entries) {
     const path = joinPath(prefix, entry.path);
     validateReservedDirectory(path, entry);
-    if (
-      (path.startsWith("sync/v1/") || path.startsWith(CONTENT_PREFIX)) &&
-      entry.type !== "tree"
-    ) {
+    if (isProtocolPath(path) && entry.type !== "tree") {
       insertProtocolBlob(protocol, path, entry);
     }
   }
@@ -387,17 +382,18 @@ function validateReservedDirectory(path: string, entry: TreeEntry): void {
   }
 }
 
+/**
+ * Both protocol generations live under `sync/`, and a client has to see all of
+ * it: discovering only the paths it writes would let it upload into a namespace
+ * it never read.
+ */
+function isProtocolPath(path: string): boolean {
+  return path.startsWith("sync/v1/") || path.startsWith("sync/v2/");
+}
+
 function protocolTreeRelevant(path: string): boolean {
   return (
-    [
-      "sync",
-      "sync/v1",
-      "sync/v2",
-      "sync/v2/content",
-      "sync/v2/content/sha256",
-    ].includes(path) ||
-    path.startsWith("sync/v1/") ||
-    path.startsWith(CONTENT_PREFIX)
+    ["sync", "sync/v1", "sync/v2"].includes(path) || isProtocolPath(path)
   );
 }
 

--- a/web/src/data/library.ts
+++ b/web/src/data/library.ts
@@ -591,6 +591,181 @@ class LibraryRepository {
     return (await this.database()).count("deferred");
   }
 
+  /**
+   * Aggregate operations awaiting upload, oldest first.
+   *
+   * Ordered by device and sequence so a receiver is never handed an operation
+   * before the one it depends on.
+   */
+  async pendingAggregateOperations(): Promise<PendingAggregateOperation[]> {
+    const database = await this.database();
+    const outbox = await database.getAll("aggregateOutbox");
+    const pending = await Promise.all(
+      outbox.map(async (entry) => {
+        const batch = await database.get("aggregateBatches", entry.path);
+        if (!batch) {
+          throw new Error("A queued aggregate operation is missing its immutable batch.");
+        }
+        return {
+          path: entry.path,
+          envelopeJson: batch.envelopeJson,
+          deviceId: batch.deviceId,
+          sequence: batch.sequence,
+        };
+      }),
+    );
+    return pending.sort(
+      (left, right) =>
+        left.deviceId.localeCompare(right.deviceId) ||
+        left.sequence.localeCompare(right.sequence),
+    );
+  }
+
+  async pendingAggregateCount(): Promise<number> {
+    return (await this.database()).count("aggregateOutbox");
+  }
+
+  async recordAggregateOutboxAttempt(
+    path: string,
+    errorKind: string | null,
+  ): Promise<void> {
+    await this.write(async (database) => {
+      const entry = await database.get("aggregateOutbox", path);
+      if (!entry) return;
+      await database.put("aggregateOutbox", {
+        ...entry,
+        attempts: entry.attempts + 1,
+        lastErrorKind: errorKind,
+      });
+    });
+  }
+
+  /**
+   * Applies one remote aggregate operation, or declines it.
+   *
+   * Declining is not a failure: an operation whose causal predecessor has not
+   * arrived is reported as `deferred` and nothing is written, so the caller can
+   * retry it once that predecessor lands. Recording it as applied would lose it,
+   * because the snapshot this store persists does not carry a pending update.
+   */
+  async receiveRemoteAggregateOperation(
+    path: string,
+    blobSha: string,
+    envelopeJson: string,
+  ): Promise<RemoteAggregateOutcome> {
+    validateBlobSha(blobSha);
+    const envelope = JSON.parse(envelopeJson) as {
+      aggregate_kind: string;
+      aggregate_id: string;
+      device_id: string;
+      sequence: string;
+      payload_sha256: string;
+    };
+    // Fails closed rather than skipping: a kind this build cannot apply would
+    // otherwise leave a hole in the library that looks like a complete one.
+    if (envelope.aggregate_kind !== "zen_document") {
+      throw new Error(
+        `This library contains ${envelope.aggregate_kind} aggregates, which this version cannot read. Update to continue.`,
+      );
+    }
+    const expected = `sync/v2/ops/zen/${envelope.aggregate_id}/${envelope.device_id}/${envelope.sequence}.json`;
+    if (path !== expected) {
+      throw new Error("An aggregate operation does not address its own contents.");
+    }
+
+    let outcome: RemoteAggregateOutcome = {
+      disposition: "deferred",
+      acknowledged: false,
+    };
+    await this.write(async (database) => {
+      const meta = await database.get("meta", "library");
+      if (!meta) throw new Error("This library is still opening.");
+      const known = await database.get("aggregateBatches", path);
+      const replica = await database.get("zenReplicas", envelope.aggregate_id);
+      const now = new Date().toISOString();
+
+      let applied: ZenEnvelopeResult | null = null;
+      if (!known) {
+        applied = JSON.parse(
+          await domainCore.call(
+            "applyZenEnvelope",
+            replica?.snapshot ?? "",
+            meta.peerId,
+            meta.libraryId,
+            path,
+            envelopeJson,
+          ),
+        ) as ZenEnvelopeResult;
+        if (applied.deferred) {
+          outcome = { disposition: "deferred", acknowledged: false };
+          return;
+        }
+      }
+
+      const transaction = database.transaction(
+        [
+          "zenReplicas",
+          "zenDocuments",
+          "aggregateBatches",
+          "aggregateOutbox",
+          "remoteObservations",
+        ],
+        "readwrite",
+      );
+      try {
+        if (applied?.snapshot && applied.summary) {
+          const summary = applied.summary;
+          await transaction.objectStore("zenReplicas").put({
+            documentId: envelope.aggregate_id,
+            snapshot: applied.snapshot,
+            updatedAt: now,
+          });
+          await transaction.objectStore("zenDocuments").put({
+            documentId: envelope.aggregate_id,
+            title: summary.title,
+            byteLength: summary.byte_length,
+            todoTotal: summary.todo_total,
+            todoDone: summary.todo_done,
+            createdAt: summary.created_at,
+            editedAt: now,
+            tags: summary.tags,
+            deleted: summary.lifecycle_state === "deleted",
+          });
+          await transaction.objectStore("aggregateBatches").add({
+            path,
+            aggregateKind: envelope.aggregate_kind,
+            aggregateId: envelope.aggregate_id,
+            deviceId: envelope.device_id,
+            sequence: envelope.sequence,
+            payloadSha256: envelope.payload_sha256,
+            envelopeJson,
+            origin: "remote" as const,
+            appliedAt: now,
+          });
+        }
+        const outbox = transaction.objectStore("aggregateOutbox");
+        const queued = await outbox.get(path);
+        if (queued) await outbox.delete(path);
+        await transaction
+          .objectStore("remoteObservations")
+          .put({ path, blobSha, observedAt: now });
+        await transaction.done;
+        outcome = {
+          disposition: known ? "already_applied" : "applied",
+          acknowledged: queued !== undefined,
+        };
+      } catch (error) {
+        abortTransaction(transaction);
+        throw error;
+      }
+    });
+    if (outcome.disposition !== "deferred") {
+      this.channel.postMessage({ type: "changed" });
+      await this.load();
+    }
+    return outcome;
+  }
+
   async checkpointCandidate(
     force = false,
   ): Promise<BrowserCheckpointCandidate | null> {
@@ -997,13 +1172,16 @@ class LibraryRepository {
         this.emit();
         return;
       }
-      const [items, outbox] = await Promise.all([
+      const [items, outbox, queuedDocuments] = await Promise.all([
         database.getAll("items"),
         database.getAll("outbox"),
+        database.count("aggregateOutbox"),
       ]);
       items.sort(compareItems);
       const pendingChanges = materializePendingChanges(outbox, items);
-      const pendingCount = pendingChanges.length;
+      // Document edits queue separately but are just as unsynchronized, and a
+      // count that ignored them would report "all synced" while they wait.
+      const pendingCount = pendingChanges.length + queuedDocuments;
       this.state = {
         initialized: true,
         loading: false,
@@ -1195,6 +1373,9 @@ class LibraryRepository {
       }
     });
     this.channel.postMessage({ type: "changed" });
+    // Reloads so the pending count includes this edit: a document waiting to
+    // sync must not read as synchronized.
+    await this.load();
   }
 
   private async afterCommit(status: string): Promise<void> {
@@ -1962,6 +2143,26 @@ interface ZenMutationResult {
   envelope: string;
 }
 
+/** Absent snapshot and summary mean the operation was deferred. */
+interface ZenEnvelopeResult {
+  deferred: boolean;
+  snapshot?: string;
+  summary?: ZenSummary;
+}
+
+export interface PendingAggregateOperation {
+  path: string;
+  envelopeJson: string;
+  deviceId: string;
+  sequence: string;
+}
+
+export interface RemoteAggregateOutcome {
+  disposition: "applied" | "already_applied" | "deferred";
+  /** True when this was one of ours coming back — the proof an upload stuck. */
+  acknowledged: boolean;
+}
+
 const OPENING_STATE: LibraryState = {
   initialized: false,
   loading: true,
@@ -2172,6 +2373,33 @@ class LibraryWorkspace {
 
   async deferredSyncCount(): Promise<number> {
     return (await this.instance()).deferredSyncCount();
+  }
+
+  async pendingAggregateOperations(): Promise<PendingAggregateOperation[]> {
+    return (await this.instance()).pendingAggregateOperations();
+  }
+
+  async pendingAggregateCount(): Promise<number> {
+    return (await this.instance()).pendingAggregateCount();
+  }
+
+  async recordAggregateOutboxAttempt(
+    path: string,
+    errorKind: string | null,
+  ): Promise<void> {
+    return (await this.instance()).recordAggregateOutboxAttempt(path, errorKind);
+  }
+
+  async receiveRemoteAggregateOperation(
+    path: string,
+    blobSha: string,
+    envelopeJson: string,
+  ): Promise<RemoteAggregateOutcome> {
+    return (await this.instance()).receiveRemoteAggregateOperation(
+      path,
+      blobSha,
+      envelopeJson,
+    );
   }
 
   async checkpointCandidate(

--- a/web/src/data/sync.ts
+++ b/web/src/data/sync.ts
@@ -1,4 +1,5 @@
 import {
+  AGGREGATE_OPS_ROOT,
   CONTENT_PREFIX,
   GENESIS_PATH,
   GitHubClient,
@@ -15,6 +16,7 @@ import {
   libraryRepository,
   type BrowserCheckpointCandidate,
   type CapturedDocumentReference,
+  type PendingAggregateOperation,
   type PendingSyncBatch,
   type RemoteEnvelopeInput,
   type RemoteOperationPackInput,
@@ -54,6 +56,11 @@ export interface SyncCycleResult {
   acknowledged: number;
   uploaded: number;
   pending: number;
+  /** Aggregate-scoped work — zen documents today. Counted apart from v1
+   *  because the two generations queue separately. */
+  aggregatesUploaded: number;
+  aggregatesApplied: number;
+  aggregatesPending: number;
 }
 
 interface PullStats {
@@ -481,11 +488,15 @@ class BrowserSyncService {
       this.patch({ status: "Publishing a fast-restore checkpoint…" });
       await this.ensureCheckpointUploaded(client, remote, checkpoint);
     }
+    const aggregates = await this.runAggregates(client, remote);
     const pending = (await libraryRepository.pendingSyncBatches()).length;
     const result: SyncCycleResult = {
       ...pull,
       uploaded,
       pending,
+      aggregatesUploaded: aggregates.uploaded,
+      aggregatesApplied: aggregates.applied,
+      aggregatesPending: await libraryRepository.pendingAggregateCount(),
     };
     await libraryRepository.recordSyncSuccess();
     this.retryNotBefore = 0;
@@ -743,6 +754,150 @@ class BrowserSyncService {
       "Checkpoint publication remained contended after safe retries.",
       "contention",
     );
+  }
+
+  /**
+   * Carries the aggregate generation: zen documents today.
+   *
+   * Runs after the v1 phase so the ordering on the remote matches the ordering
+   * a reader needs — v1 first, then the aggregates layered on top.
+   */
+  private async runAggregates(
+    client: GitHubClient,
+    remote: GitHubRemote,
+  ): Promise<{ uploaded: number; applied: number }> {
+    let uploaded = 0;
+    const queued = await libraryRepository.pendingAggregateOperations();
+    if (queued.length > 0) {
+      this.patch({
+        status: `Uploading ${queued.length} queued document change${queued.length === 1 ? "" : "s"}…`,
+      });
+    }
+    for (const operation of queued) {
+      if (await this.ensureAggregateUploaded(client, remote, operation)) {
+        uploaded += 1;
+      }
+    }
+    return { uploaded, applied: await this.applyRemoteAggregates(client, remote) };
+  }
+
+  private async ensureAggregateUploaded(
+    client: GitHubClient,
+    remote: GitHubRemote,
+    operation: PendingAggregateOperation,
+  ): Promise<boolean> {
+    for (let attempt = 0; attempt < MAX_UPLOAD_ATTEMPTS; attempt += 1) {
+      let put;
+      try {
+        put = await client.putNew(
+          remote,
+          operation.path,
+          operation.envelopeJson,
+          remote.branch,
+        );
+      } catch (error) {
+        await libraryRepository.recordAggregateOutboxAttempt(
+          operation.path,
+          error instanceof GitHubSyncError ? error.kind : "transport",
+        );
+        throw error;
+      }
+      if (put.type === "created") {
+        // Confirming from the write is what clears the queue, so a crash before
+        // the next pull cannot leave the operation queued forever.
+        await libraryRepository.receiveRemoteAggregateOperation(
+          operation.path,
+          put.blobSha,
+          operation.envelopeJson,
+        );
+        return true;
+      }
+      if (put.type === "race") {
+        // Already there. Confirm from whatever a reader would actually see
+        // rather than assuming our bytes won.
+        const tree = await client.discover(remote);
+        const existingSha = tree.blobs.get(operation.path);
+        if (existingSha) {
+          const existing = await client.downloadText(remote, existingSha);
+          await libraryRepository.receiveRemoteAggregateOperation(
+            operation.path,
+            existingSha,
+            existing,
+          );
+          return false;
+        }
+      }
+      await libraryRepository.recordAggregateOutboxAttempt(
+        operation.path,
+        put.type === "race" ? "contention" : put.kind,
+      );
+      await retryDelay(operation.path, attempt);
+    }
+    throw new GitHubSyncError(
+      "Document synchronization remained contended after safe retries.",
+      "contention",
+    );
+  }
+
+  /**
+   * Applies every remote aggregate operation this device has not seen.
+   *
+   * Operations are retried in rounds because one can depend on another that
+   * sorts after it by path. A round that applies nothing while work remains
+   * means a dependency is genuinely absent — a broken history, not a slow one.
+   */
+  private async applyRemoteAggregates(
+    client: GitHubClient,
+    remote: GitHubRemote,
+  ): Promise<number> {
+    const tree = await client.discover(remote);
+    let queue: Array<{ path: string; blobSha: string; json: string }> = [];
+    for (const [path, blobSha] of [...tree.blobs.entries()].sort(([left], [right]) =>
+      left.localeCompare(right),
+    )) {
+      if (!path.startsWith(AGGREGATE_OPS_ROOT)) continue;
+      const observation = await libraryRepository.remoteObservation(path);
+      if (observation) {
+        if (observation.blobSha === blobSha) continue;
+        throw new GitHubSyncError(
+          "An immutable document change was rewritten after it was observed.",
+          "integrity",
+        );
+      }
+      queue.push({ path, blobSha, json: await client.downloadText(remote, blobSha) });
+    }
+    if (queue.length > 0) {
+      this.patch({
+        status: `Applying ${queue.length} document change${queue.length === 1 ? "" : "s"}…`,
+      });
+    }
+
+    let applied = 0;
+    while (queue.length > 0) {
+      const deferred: typeof queue = [];
+      let progressed = false;
+      for (const operation of queue) {
+        const outcome = await libraryRepository.receiveRemoteAggregateOperation(
+          operation.path,
+          operation.blobSha,
+          operation.json,
+        );
+        if (outcome.disposition === "deferred") {
+          deferred.push(operation);
+          continue;
+        }
+        progressed = true;
+        if (outcome.disposition === "applied") applied += 1;
+      }
+      if (deferred.length > 0 && !progressed) {
+        throw new GitHubSyncError(
+          "Remote document changes are missing a causal predecessor.",
+          "integrity",
+        );
+      }
+      queue = deferred;
+    }
+    return applied;
   }
 
   private async ensureUploaded(


### PR DESCRIPTION
Zen edits have queued durably since the workspace shipped, but nothing uploaded them — the v2 aggregate queue had no driver on either side, so a document written on one device stayed there. This builds that driver, native and browser.

## What carries now

- **The aggregate phase runs after v1** in every cycle, so the migration barrier reaches the remote before any v2 object a barrier-blind client could stumble into.
- **Discovery widens to all of `sync/`.** Enumerating only the paths a client writes would let it upload into a namespace it never read.
- **Zen operations upload from `aggregate_outbox`** and remote ones are applied back into the replica, the list projection, and the batch record in one transaction.
- **Item aggregates** publish genesis + catalogue + checkpoints when a device has migrated, and adopt them when another device published first.

## Deferral is load-bearing

An operation whose causal predecessor has not been applied is *deferred*: no replica, no batch record, no observation, and it is retried in rounds.

This is not tidiness. A replica is persisted as a snapshot, and a snapshot does not carry the part of an update Loro is still holding pending. Recording a partially imported operation as applied would drop it with nothing left to show it ever arrived. A round that applies nothing while operations remain deferred means the dependency is genuinely absent from the remote — reported as an integrity failure, not retried forever.

## Confirming, not assuming

A created object is applied back from the write that created it; a lost race reads whatever object is actually at that path. Only that confirmation clears the queue, so an interrupted cycle re-uploads rather than silently dropping work. Observed immutable paths are re-checked, so a rewritten operation fails closed.

## Notes

- `0011` rebuilds `aggregate_migration` so the barrier columns can be null — only the migrating device writes a barrier, so adoption could not previously be expressed at all.
- An `aggregate_kind` this build cannot apply fails closed with an upgrade-shaped error on both clients rather than being skipped, which would materialize a library that looks complete but is not.
- Queued documents now count toward the pending indicator. They were invisible there, so a library with unsynchronized documents reported itself fully synchronized.

## Verification

- New store contract test: two devices converge on a document, and an edit delivered before its create is declined, creates nothing, and applies once the create lands.
- New browser convergence test covering the same path through the WASM bindings, including the deferral. It runs in headless Chrome in CI; I could not run it locally (no driver on this machine), so CI is the first execution.
- `cargo clippy --workspace --all-targets` clean, 14 native test suites pass, web typecheck + build + 16 tests pass.