### PR TITLE
Add the zen command group to the CLI

### DIFF
--- a/docs/v2/CLI.md
+++ b/docs/v2/CLI.md
@@ -663,23 +663,39 @@ Do not parse human output in integrations. The JSON and NDJSON schemas are the
 machine interfaces and require an explicit compatibility plan before a breaking
 change.
 
-## Zen documents (planned, v2.2)
+## Zen documents
 
 [ADR 0011](./ADR_0011_ZEN_DOCUMENTS.md) adds a bounded authored-document
-workspace after the [ADR 0010](./ADR_0010_BOUNDED_ITEM_SCOPED_SYNC.md)
-aggregate migration ships. The target command group is:
+workspace: Markdown limited to 256 KiB, mentioning saved items through
+`research:item/<uuid>` links, and never entering publication artifacts. Item
+capture is unchanged — `research add` still requires an absolute HTTP(S) URL.
 
 ```text
 research zen list
-research zen add [--title <TITLE>]
+research zen add [--title <TITLE>] [--body <TEXT> | --body-file <PATH>] [--tag <TAG>]
 research zen show <DOC_ID>
-research zen edit <DOC_ID>
+research zen edit <DOC_ID> [--title <TITLE> | --clear-title]
+                           [--body <TEXT> | --body-file <PATH>]
+                           [--add-tag <TAG>] [--remove-tag <TAG>]
 research zen delete <DOC_ID>
 research zen restore <DOC_ID>
 ```
 
-Zen commands are a target contract, not part of the shipped surface above.
-Documents are Markdown bounded to 256 KiB, mention saved items through
-`research:item/<uuid>` links, and never enter publication artifacts. Item
-capture is unchanged: `research add` still requires an absolute HTTP(S) URL.
-Machine output will version document records separately from item records.
+A body is prose, and shells mangle prose, so `--body-file` is the primary input
+and `--body-file -` reads standard input:
+
+```console
+$ printf -- '- [x] Ship it\n- [ ] Review #132\n' | research zen add --title Today --body-file -
+```
+
+`--body` remains for one-liners and accepts leading hyphens, since a Markdown
+body usually starts with a list marker.
+
+`research zen list` reads projected metadata only — title, size, todo counts,
+tags, lifecycle — and never loads a body. `research zen show` is the only
+command that does. Todo counts are derived from the body at read time rather
+than stored, so a hand-edited checkbox and a clicked one are indistinguishable.
+
+Machine output versions document records separately from item records:
+`zen_list`, `zen_add`, `zen_show`, `zen_edit`, `zen_delete`, and `zen_restore`
+each carry their own `command` value beside the shared `schema_version`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,8 +85,92 @@ pub enum Commands {
         command: SyncCommands,
     },
 
+    /// Write and read zen documents — prose, lists, and todos
+    Zen {
+        #[command(subcommand)]
+        command: ZenCommands,
+    },
+
     /// Show local library, import, outbox, and sync state
     Status,
+}
+
+#[derive(Subcommand)]
+pub enum ZenCommands {
+    /// List documents with their metadata; bodies are never read
+    List,
+
+    /// Create a document, reading its body from a file or standard input
+    Add(ZenAddArgs),
+
+    /// Print one document, body included
+    Show(ZenDocumentIdArgs),
+
+    /// Change a document's title, body, or tags
+    Edit(ZenEditArgs),
+
+    /// Delete a document without erasing its history
+    Delete(ZenDocumentIdArgs),
+
+    /// Restore a deleted document
+    Restore(ZenDocumentIdArgs),
+}
+
+#[derive(Args)]
+pub struct ZenDocumentIdArgs {
+    /// UUID of the document
+    pub document_id: String,
+}
+
+#[derive(Args)]
+pub struct ZenAddArgs {
+    /// Title; omit for an untitled document
+    #[arg(long)]
+    pub title: Option<String>,
+
+    /// Read the body from this file, or from standard input with `-`
+    #[arg(long, value_name = "PATH")]
+    pub body_file: Option<PathBuf>,
+
+    /// Body text, for short documents
+    // Hyphens are allowed because a Markdown body very often starts with a
+    // list marker, which clap would otherwise read as a flag.
+    #[arg(long, conflicts_with = "body_file", allow_hyphen_values = true)]
+    pub body: Option<String>,
+
+    /// Add exact tag text; repeat or comma-separate
+    #[arg(long, value_delimiter = ',', num_args = 1..)]
+    pub tag: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct ZenEditArgs {
+    /// UUID of the document
+    pub document_id: String,
+
+    /// Set the title
+    #[arg(long, conflicts_with = "clear_title")]
+    pub title: Option<String>,
+
+    /// Set the title to absent
+    #[arg(long)]
+    pub clear_title: bool,
+
+    /// Replace the body from this file, or from standard input with `-`
+    #[arg(long, value_name = "PATH")]
+    pub body_file: Option<PathBuf>,
+
+    /// Replace the body with this text
+    #[arg(long, conflicts_with = "body_file", allow_hyphen_values = true)]
+    pub body: Option<String>,
+
+    /// Add exact tag text; repeat or comma-separate
+    #[arg(long, value_delimiter = ',', num_args = 1..)]
+    pub add_tag: Vec<String>,
+
+    /// Remove exact tag text; repeat or comma-separate
+    #[arg(long, value_delimiter = ',', num_args = 1..)]
+    pub remove_tag: Vec<String>,
 }
 
 #[derive(Args)]

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -5,16 +5,17 @@ use std::time::Duration;
 
 use directories::ProjectDirs;
 use research_store::{
-    CreateItemRequest, EditItemRequest, EnrichmentClaim, EnrichmentJob, EnrichmentProvider,
-    EnrichmentQueueCounts, EnrichmentStatus as StoreEnrichmentStatus, ListQuery,
-    OptionalTextUpdate, SearchQuery, StoreError, StoredItem, V2Store,
+    CreateItemRequest, CreateZenDocumentRequest, EditItemRequest, EditZenDocumentRequest,
+    EnrichmentClaim, EnrichmentJob, EnrichmentProvider, EnrichmentQueueCounts,
+    EnrichmentStatus as StoreEnrichmentStatus, ListQuery, OptionalTextUpdate, SearchQuery,
+    StoreError, StoredItem, V2Store,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
 
 use crate::cli::{
     CaptureCommands, CliArgs, Commands, EnrichCommands, EnrichmentProviderArg, ImportCommands,
-    OutputFormat, SyncCommands,
+    OutputFormat, SyncCommands, ZenCommands,
 };
 use crate::{capture, enrichment, sync, tui};
 
@@ -140,8 +141,172 @@ pub async fn handle(args: &CliArgs) -> CliResult<()> {
         }
         Commands::Capture { command } => handle_capture(&data_dir, args.format, command).await,
         Commands::Sync { command } => handle_sync(&data_dir, args.format, command).await,
+        Commands::Zen { command } => handle_zen(&data_dir, args.format, command).await,
         Commands::Status => handle_status(&data_dir, args.format).await,
     }
+}
+
+/// Zen documents from the terminal.
+///
+/// Bodies come from a file or standard input rather than an argument, because a
+/// document is prose and shells mangle prose. `--body` stays for one-liners.
+async fn handle_zen(
+    data_dir: &Path,
+    format: OutputFormat,
+    command: &ZenCommands,
+) -> CliResult<()> {
+    let store = V2Store::open(data_dir).await?;
+    match command {
+        ZenCommands::List => {
+            let documents = store.list_zen_documents().await?;
+            let output = command_output(
+                "zen_list",
+                json!({ "documents": documents, "total": documents.len() }),
+            )?;
+            write_single(format, &output, human_zen_list)
+        }
+        ZenCommands::Add(add) => {
+            let summary = store
+                .create_zen_document(CreateZenDocumentRequest {
+                    title: add.title.clone(),
+                    body: read_body(add.body.as_deref(), add.body_file.as_deref())?,
+                    tags: add.tag.clone(),
+                })
+                .await?;
+            let output = command_output("zen_add", summary)?;
+            write_single(format, &output, human_zen_document)
+        }
+        ZenCommands::Show(document) => {
+            let view = store.zen_document(&document.document_id).await?;
+            let output = command_output("zen_show", view)?;
+            write_single(format, &output, human_zen_show)
+        }
+        ZenCommands::Edit(edit) => {
+            let body = match (&edit.body, &edit.body_file) {
+                (None, None) => None,
+                (body, file) => Some(read_body(body.as_deref(), file.as_deref())?),
+            };
+            let summary = store
+                .edit_zen_document(EditZenDocumentRequest {
+                    document_id: edit.document_id.clone(),
+                    title: match (&edit.title, edit.clear_title) {
+                        (_, true) => Some(None),
+                        (Some(title), false) => Some(Some(title.clone())),
+                        (None, false) => None,
+                    },
+                    body,
+                    add_tags: edit.add_tag.clone(),
+                    remove_tags: edit.remove_tag.clone(),
+                })
+                .await?;
+            let output = command_output("zen_edit", summary)?;
+            write_single(format, &output, human_zen_document)
+        }
+        ZenCommands::Delete(document) => {
+            let summary = store.delete_zen_document(&document.document_id).await?;
+            let output = command_output("zen_delete", summary)?;
+            write_single(format, &output, human_zen_document)
+        }
+        ZenCommands::Restore(document) => {
+            let summary = store.restore_zen_document(&document.document_id).await?;
+            let output = command_output("zen_restore", summary)?;
+            write_single(format, &output, human_zen_document)
+        }
+    }
+}
+
+/// Reads a document body from text, a file, or standard input via `-`.
+fn read_body(body: Option<&str>, body_file: Option<&Path>) -> CliResult<String> {
+    match (body, body_file) {
+        (Some(body), _) => Ok(body.to_owned()),
+        (None, Some(path)) if path == Path::new("-") => {
+            let mut body = String::new();
+            io::stdin().read_to_string(&mut body)?;
+            Ok(body)
+        }
+        (None, Some(path)) => Ok(std::fs::read_to_string(path)?),
+        (None, None) => Ok(String::new()),
+    }
+}
+
+fn human_zen_list(value: &Value) {
+    let Some(documents) = value.get("documents").and_then(Value::as_array) else {
+        println!("No documents found");
+        return;
+    };
+    println!("{} document{}", documents.len(), plural(documents.len()));
+    for document in documents {
+        println!();
+        println!(
+            "{}",
+            document
+                .get("title")
+                .and_then(Value::as_str)
+                .unwrap_or("Untitled document")
+        );
+        print_indented_string(document, "document_id", "ID");
+        print_zen_counts(document);
+    }
+}
+
+fn human_zen_document(value: &Value) {
+    println!(
+        "{}",
+        value
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("Untitled document")
+    );
+    print_indented_string(value, "document_id", "ID");
+    print_zen_counts(value);
+}
+
+fn human_zen_show(value: &Value) {
+    println!(
+        "{}",
+        value
+            .pointer("/title/value")
+            .and_then(Value::as_str)
+            .unwrap_or("Untitled document")
+    );
+    print_indented_string(value, "document_id", "ID");
+    if let Some(tags) = value.get("tags").and_then(Value::as_array) {
+        let tags = tags.iter().filter_map(Value::as_str).collect::<Vec<_>>();
+        if !tags.is_empty() {
+            println!("  tags: {}", tags.join(", "));
+        }
+    }
+    if let Some(body) = value.get("body").and_then(Value::as_str) {
+        println!();
+        println!("{body}");
+    }
+}
+
+fn print_zen_counts(document: &Value) {
+    if let Some(bytes) = document.get("byte_length").and_then(Value::as_u64) {
+        println!("  size: {bytes} B");
+    }
+    let total = document.get("todo_total").and_then(Value::as_u64);
+    if let Some(total) = total.filter(|total| *total > 0) {
+        let done = document
+            .get("todo_done")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        println!("  todos: {done}/{total}");
+    }
+    if let Some(tags) = document.get("tags").and_then(Value::as_array) {
+        let tags = tags.iter().filter_map(Value::as_str).collect::<Vec<_>>();
+        if !tags.is_empty() {
+            println!("  tags: {}", tags.join(", "));
+        }
+    }
+    if document.get("lifecycle_state").and_then(Value::as_str) == Some("deleted") {
+        println!("  state: deleted");
+    }
+}
+
+fn plural(count: usize) -> &'static str {
+    if count == 1 { "" } else { "s" }
 }
 
 async fn handle_capture(


### PR DESCRIPTION
Zen documents were reachable only from the browser. This lands the command group ADR 0011 described:

```text
research zen list
research zen add [--title <TITLE>] [--body <TEXT> | --body-file <PATH>] [--tag <TAG>]
research zen show <DOC_ID>
research zen edit <DOC_ID> [--title <TITLE> | --clear-title]
                           [--body <TEXT> | --body-file <PATH>]
                           [--add-tag <TAG>] [--remove-tag <TAG>]
research zen delete <DOC_ID>
research zen restore <DOC_ID>
```

**Bodies come from a file or stdin**, not an argument — a document is prose and shells mangle prose:

```console
$ printf -- '- [x] Ship it\n- [ ] Review #132\n' | research zen add --title Today --body-file -
```

`--body` stays for one-liners and takes `allow_hyphen_values`, because a Markdown body usually opens with a list marker and clap would otherwise read it as a flag. I hit exactly that on the first run.

**`zen list` never loads a body** — it reads the projection, so listing stays proportional to the number of documents rather than their size. `zen show` is the only command that reads one.

Each subcommand carries its own machine-output `command` name (`zen_list`, `zen_add`, …), so document records version separately from item records.

Docs: `docs/v2/CLI.md` moves zen from "planned, v2.2" to the shipped surface.

## Verification

Exercised end to end against a scratch library: add with tags, list, show, edit through `--body-file -`, delete, restore. Todo counts track the body (1/2 → 2/2 after toggling a box in the piped text) and tags merge as expected. Clippy clean; the workspace test suites pass.