### PR TITLE
Prepare the 2.2.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "research"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "research-domain"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "research-store"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research"
-version = "2.1.1"
+version = "2.2.0"
 edition = "2024"
 rust-version = "1.94"
 keywords = ["bookmarks", "reading-list", "local-first", "knowledge", "cli"]
@@ -22,8 +22,8 @@ crossterm = "0.29.0"
 directories = "6.0.0"
 ratatui = { version = "0.30.2", default-features = false, features = ["crossterm_0_29"] }
 reqwest = { version = "0.13.4", features = ["json"] }
-research-domain = { version = "=2.1.1", path = "crates/research-domain" }
-research-store = { version = "=2.1.1", path = "crates/research-store" }
+research-domain = { version = "=2.2.0", path = "crates/research-domain" }
+research-store = { version = "=2.2.0", path = "crates/research-store" }
 scraper = "0.27.0"
 serde = "1.0.228"
 serde_json = "1.0.150"

--- a/crates/research-domain/Cargo.toml
+++ b/crates/research-domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research-domain"
-version = "2.1.1"
+version = "2.2.0"
 edition = "2024"
 rust-version = "1.94"
 authors = ["KorigamiK <korigamik.is-a.dev>"]

--- a/crates/research-store/Cargo.toml
+++ b/crates/research-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research-store"
-version = "2.1.1"
+version = "2.2.0"
 edition = "2024"
 rust-version = "1.94"
 authors = ["KorigamiK <korigamik.is-a.dev>"]
@@ -11,7 +11,7 @@ description = "Local SQLite projection, import, enrichment, and outbox for Resea
 [dependencies]
 base64 = "0.22.1"
 chrono = { version = "0.4.45", default-features = false, features = ["clock", "serde"] }
-research-domain = { version = "=2.1.1", path = "../research-domain" }
+research-domain = { version = "=2.2.0", path = "../research-domain" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 sha2 = "0.11.0"

--- a/docs/releases/v2.2.0.md
+++ b/docs/releases/v2.2.0.md
@@ -1,0 +1,94 @@
+# ResearchPocket 2.2.0
+
+ResearchPocket 2.2.0 adds Research Zen: bounded authored documents — prose,
+lists, and todos — that live beside your saves, synchronize between devices, and
+can mention saved links inline. It also fixes a repository-growth bug that could
+accumulate redundant snapshots in a private data repository indefinitely.
+
+## Install
+
+With Rust installed:
+
+```sh
+cargo install --locked --force research
+```
+
+Or download the verified archive for Linux, macOS, or Windows from the GitHub
+release and check it against `SHA256SUMS`.
+
+## What changed
+
+- **Research Zen.** A zen document is Markdown bounded to 256 KiB, stored as its
+  own aggregate rather than inside the item library. Documents carry a title,
+  tags, prose, GFM task lists, and `research:item/<uuid>` mentions that resolve
+  against your local saves. Saved items remain URL-first and unchanged: a
+  document is not a save without a link, it is a different thing.
+- **Todo counts are derived from the body**, never stored. A checkbox toggled by
+  clicking and one edited by hand are indistinguishable, and there is no counter
+  that can fall out of step with the text.
+- **Concurrent edits merge at character level.** A checkbox toggle is a text
+  splice, so two devices flipping different boxes in the same list keep both
+  changes, as do a toggle and a prose edit in the same paragraph.
+- **Zen documents synchronize.** Both clients now carry the aggregate generation
+  after their protocol-v1 phase. An operation whose causal predecessor has not
+  arrived is deferred and retried rather than partially applied, and uploads are
+  confirmed by reading the remote object rather than assumed from the write.
+- **`research zen` in the CLI**: `list`, `add`, `show`, `edit`, `delete`, and
+  `restore`. Bodies come from a file or standard input, because a document is
+  prose and shells mangle prose. Listing reads projected metadata only; `show`
+  is the one command that loads a body.
+- **The web workspace opens as a new-tab surface**: the time, one input that
+  both filters and creates, and the documents. Opening it costs nothing
+  proportional to how much you have written, because no body is read to draw it.
+- **Checkpoint selection fix.** A device that edited between building a
+  checkpoint and confirming its upload never selected the checkpoint it had just
+  published. Because tail thresholds are measured from the selected checkpoint,
+  every later cycle minted and uploaded another full-library snapshot. Protocol
+  v1 never prunes, so those accumulated permanently. Selection now requires only
+  that this replica has already applied everything the checkpoint covers.
+- **A returning owner lands in their library.** Opening the site with a library
+  already on the device goes straight to the app instead of asking again how to
+  create one. `?choose` still reaches the chooser for adding or restoring a
+  library.
+- **The web app no longer emits module preloads its own Content-Security-Policy
+  forbids**, which broke first load in strict browsers.
+
+## Upgrade an existing private library
+
+Upgrade the native client, verify the version, and run one normal sync:
+
+```sh
+cargo install --locked --force research
+research --version
+research sync run
+```
+
+The expected version is `research 2.2.0`.
+
+Zen documents are a new aggregate namespace under `sync/v2/ops/zen/`. They do
+not touch protocol-v1 history, which remains immutable and is not pruned. A
+2.1.x client that has not been upgraded will not see documents written by a
+2.2.0 client; it continues to synchronize saves normally. Upgrade every device
+you want documents on.
+
+This release does not perform the item-aggregate migration. Saves continue to
+synchronize over protocol v1.
+
+## GitHub release archives
+
+| Platform | Release asset |
+| --- | --- |
+| Linux GNU/glibc x86-64 (glibc 2.35 or newer) | `research-v2.2.0-linux-amd64.tar.gz` |
+| Windows x86-64 | `research-v2.2.0-windows-amd64.zip` |
+| macOS Intel | `research-v2.2.0-macos-amd64.tar.gz` |
+| macOS Apple Silicon | `research-v2.2.0-macos-arm64.tar.gz` |
+
+The archives remain unsigned. Verify the selected file with `SHA256SUMS`, or
+build the exact tag with the pinned toolchain:
+
+```sh
+git clone --branch v2.2.0 --depth 1 \
+  https://github.com/ResearchPocket/researchpocket.github.io.git
+cd researchpocket.github.io
+cargo build --locked --release
+```

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "research-pocket-web",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "research-pocket-web",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "dependencies": {
         "highlight.js": "11.11.1",
         "idb": "8.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "research-pocket-web",
   "private": true,
-  "version": "2.1.1",
+  "version": "2.2.0",
   "type": "module",
   "scripts": {
     "dev": "npm run wasm && vite",


### PR DESCRIPTION
Version bump to 2.2.0 across the workspace and the web package, plus release notes.

`2.1.1` → `2.2.0` — a minor bump: Research Zen is additive, nothing in the item contract changed, and protocol-v1 history is untouched.

## Headline

- **Research Zen** — bounded Markdown documents as their own aggregate, with prose, GFM todos, tags, and `research:item/<uuid>` mentions. Browser workspace and `research zen` in the CLI.
- **Documents synchronize** through the aggregate generation, with deferral for out-of-order operations and upload confirmed by reading the remote object.
- **Checkpoint-selection fix (#145)** — this one is worth calling out to users. A device that edited between building a checkpoint and confirming its upload never selected the checkpoint it had just published, so every later cycle re-minted and re-uploaded a full-library snapshot. Protocol v1 never prunes, so those accumulated in the private repository indefinitely.
- Returning owners land in their library instead of the chooser; the strict-CSP first-load crash is fixed.

## Notes call out the compatibility boundary

A 2.1.x client will not see documents written by 2.2.0 — they are a new namespace under `sync/v2/ops/zen/`. Saves continue to synchronize normally, and the release notes say so plainly rather than implying a silent upgrade. This release does not perform the item-aggregate migration.

## After merge

Tagging `v2.2.0` builds the binaries and stages a **draft** GitHub release from `docs/releases/v2.2.0.md`. Publishing that draft and dispatching the crates.io workflow are both deliberate manual steps.