### PR TITLE
Make the zen title editable and the rail's Documents live

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -913,7 +913,12 @@ export function App() {
             <nav aria-label="Zen" className="rail-nav">
               <button
                 aria-current={view === "zen" ? "page" : undefined}
-                onClick={() => navigateToView("zen")}
+                onClick={() => {
+                  // Closes the open document too, or this reads as a dead
+                  // control for anyone already inside one.
+                  setOpenZen(null);
+                  navigateToView("zen");
+                }}
                 type="button"
               >
                 <span>Documents</span>

--- a/web/src/components/ZenWorkspace.tsx
+++ b/web/src/components/ZenWorkspace.tsx
@@ -33,8 +33,10 @@ interface ZenWorkspaceProps {
 
 export function ZenWorkspace(props: ZenWorkspaceProps) {
   if (props.hidden) return null;
+  // Keyed by document so switching documents starts a fresh editor rather than
+  // carrying the previous one's unsaved title and body across.
   return props.open ? (
-    <ZenEditor {...props} open={props.open} />
+    <ZenEditor {...props} key={props.open.documentId} open={props.open} />
   ) : (
     <ZenIndex {...props} />
   );
@@ -258,7 +260,7 @@ function ZenEditor({
 
   return (
     <section
-      aria-labelledby="zen-doc-heading"
+      aria-label="Zen document"
       className="zen-editor"
       id="zen-document"
       ref={section}
@@ -312,55 +314,56 @@ function ZenEditor({
       </div>
 
       <div className="zen-canvas">
-        {mode === "view" ? (
-          <article className="zen-reader">
-            <h1 id="zen-doc-heading">
-              {open.view.title.value?.trim() || "Untitled document"}
-            </h1>
-            {open.view.tags.length > 0 && (
-              <p className="zen-tags">
-                {open.view.tags.map((tag) => (
-                  <span key={tag}>#{tag}</span>
-                ))}
-              </p>
-            )}
+        <div className="zen-page">
+          {/* The title sits outside the mode switch. It is one line, it is never
+              Markdown, and hiding it behind edit mode was the only reason it
+              could not be changed while reading. */}
+          <input
+            aria-label="Document title"
+            className="zen-title-input"
+            disabled={busy}
+            onBlur={() => onSaveTitle(open.documentId, title.trim() || null)}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="Untitled document"
+            type="text"
+            value={title}
+          />
+          {open.view.tags.length > 0 && (
+            <p className="zen-tags">
+              {open.view.tags.map((tag) => (
+                <span key={tag}>#{tag}</span>
+              ))}
+            </p>
+          )}
+          {mode === "view" ? (
             <ZenBody
               body={open.view.body}
               onToggleTodo={toggleTodo}
               resolveMention={resolveMention}
             />
-          </article>
-        ) : (
-          <div className="zen-edit">
-            <input
-              aria-label="Document title"
-              className="zen-title-input"
-              disabled={busy}
-              onBlur={() => onSaveTitle(open.documentId, title.trim() || null)}
-              onChange={(event) => setTitle(event.target.value)}
-              type="text"
-              value={title}
-            />
-            <textarea
-              aria-label="Document body"
-              className="zen-body-input"
-              onBlur={() => {
-                if (!overBound && draft !== open.view.body) {
-                  onSaveBody(open.documentId, draft);
-                }
-              }}
-              onChange={(event) => setDraft(event.target.value)}
-              spellCheck={false}
-              value={draft}
-            />
-            {overBound && (
-              <p className="zen-error" role="alert">
-                This document is over the {formatBytes(MAX_BODY_BYTES)} bound and will not
-                save until it is shorter.
-              </p>
-            )}
-          </div>
-        )}
+          ) : (
+            <>
+              <textarea
+                aria-label="Document body"
+                className="zen-body-input"
+                onBlur={() => {
+                  if (!overBound && draft !== open.view.body) {
+                    onSaveBody(open.documentId, draft);
+                  }
+                }}
+                onChange={(event) => setDraft(event.target.value)}
+                spellCheck={false}
+                value={draft}
+              />
+              {overBound && (
+                <p className="zen-error" role="alert">
+                  This document is over the {formatBytes(MAX_BODY_BYTES)} bound and will
+                  not save until it is shorter.
+                </p>
+              )}
+            </>
+          )}
+        </div>
       </div>
 
       <footer className="zen-footer">

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -5126,18 +5126,10 @@ kbd {
   overflow: auto;
 }
 
-.zen-reader,
-.zen-edit {
+.zen-page {
   margin: 0 auto;
   max-width: 760px;
   padding: 36px 24px 64px;
-}
-
-.zen-reader h1 {
-  font-size: 26px;
-  letter-spacing: -0.02em;
-  line-height: 1.2;
-  margin: 0;
 }
 
 .zen-tags {
@@ -5194,13 +5186,22 @@ kbd {
 .zen-title-input {
   background: transparent;
   border: 0;
+  border-block-end: var(--rule) solid transparent;
   color: var(--color-text);
   font-size: 26px;
   font-weight: 700;
   letter-spacing: -0.02em;
+  line-height: 1.2;
   outline: 0;
   padding: 0;
   width: 100%;
+}
+
+/* The title is always editable, so it has to look reachable without shouting
+   about it while the document is being read. */
+.zen-title-input:hover,
+.zen-title-input:focus {
+  border-block-end-color: var(--color-border);
 }
 
 .zen-body-input {
@@ -5338,8 +5339,7 @@ button.local-status:focus-visible .status-copy {
     padding: 0 1rem;
   }
 
-  .zen-reader,
-  .zen-edit {
+  .zen-page {
     padding: 1.25rem 1rem 2rem;
   }
 


### PR DESCRIPTION
Three defects reported from use.

## The title could not be edited

It was an input only in edit mode; view mode rendered it as a heading. Since view is the default on desktop, the only path to renaming a document was to switch modes and notice that the borderless line at the top of the textarea was an input and not the heading it looked like.

A title is one line and is never Markdown, so it did not need a mode. It now sits above the body in both modes, with an underline that appears on hover and focus — reachable without shouting while the document is being read.

## Documents in the rail did nothing from inside a document

It called `navigateToView("zen")` without clearing the open document, so a reader already in the Zen view stayed on the editor and the control read as dead. It now closes the document too, making it the second way back to the index alongside the breadcrumb.

## The editor carried state between documents

`ZenEditor` stayed mounted across documents, so its title and body state survived a switch — open A, type a title, open B, and B's editor showed A's text. It is now keyed by document ID and starts fresh.

## Verification

Typecheck, build, and the 16 web tests pass. I have not clicked through this one — please confirm the title edits and save, and that Documents in the rail returns you to the index from inside a document.