### PR TITLE
Release 2.2.1 instead of 2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "research"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "base64",
  "chrono",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "research-domain"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "base64",
  "chrono",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "research-store"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 rust-version = "1.94"
 keywords = ["bookmarks", "reading-list", "local-first", "knowledge", "cli"]
@@ -22,8 +22,8 @@ crossterm = "0.29.0"
 directories = "6.0.0"
 ratatui = { version = "0.30.2", default-features = false, features = ["crossterm_0_29"] }
 reqwest = { version = "0.13.4", features = ["json"] }
-research-domain = { version = "=2.2.0", path = "crates/research-domain" }
-research-store = { version = "=2.2.0", path = "crates/research-store" }
+research-domain = { version = "=2.2.1", path = "crates/research-domain" }
+research-store = { version = "=2.2.1", path = "crates/research-store" }
 scraper = "0.27.0"
 serde = "1.0.228"
 serde_json = "1.0.150"

--- a/crates/research-domain/Cargo.toml
+++ b/crates/research-domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research-domain"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 rust-version = "1.94"
 authors = ["KorigamiK <korigamik.is-a.dev>"]

--- a/crates/research-store/Cargo.toml
+++ b/crates/research-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research-store"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 rust-version = "1.94"
 authors = ["KorigamiK <korigamik.is-a.dev>"]
@@ -11,7 +11,7 @@ description = "Local SQLite projection, import, enrichment, and outbox for Resea
 [dependencies]
 base64 = "0.22.1"
 chrono = { version = "0.4.45", default-features = false, features = ["clock", "serde"] }
-research-domain = { version = "=2.2.0", path = "../research-domain" }
+research-domain = { version = "=2.2.1", path = "../research-domain" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 sha2 = "0.11.0"

--- a/docs/releases/v2.2.1.md
+++ b/docs/releases/v2.2.1.md
@@ -1,9 +1,12 @@
-# ResearchPocket 2.2.0
+# ResearchPocket 2.2.1
 
-ResearchPocket 2.2.0 adds Research Zen: bounded authored documents — prose,
+ResearchPocket 2.2.1 adds Research Zen: bounded authored documents — prose,
 lists, and todos — that live beside your saves, synchronize between devices, and
 can mention saved links inline. It also fixes a repository-growth bug that could
 accumulate redundant snapshots in a private data repository indefinitely.
+
+2.2.1 is the first release of this line. A `v2.2.0` tag exists in the repository
+but was never built or published.
 
 ## Install
 
@@ -63,12 +66,12 @@ research --version
 research sync run
 ```
 
-The expected version is `research 2.2.0`.
+The expected version is `research 2.2.1`.
 
 Zen documents are a new aggregate namespace under `sync/v2/ops/zen/`. They do
 not touch protocol-v1 history, which remains immutable and is not pruned. A
 2.1.x client that has not been upgraded will not see documents written by a
-2.2.0 client; it continues to synchronize saves normally. Upgrade every device
+2.2.1 client; it continues to synchronize saves normally. Upgrade every device
 you want documents on.
 
 This release does not perform the item-aggregate migration. Saves continue to
@@ -78,16 +81,16 @@ synchronize over protocol v1.
 
 | Platform | Release asset |
 | --- | --- |
-| Linux GNU/glibc x86-64 (glibc 2.35 or newer) | `research-v2.2.0-linux-amd64.tar.gz` |
-| Windows x86-64 | `research-v2.2.0-windows-amd64.zip` |
-| macOS Intel | `research-v2.2.0-macos-amd64.tar.gz` |
-| macOS Apple Silicon | `research-v2.2.0-macos-arm64.tar.gz` |
+| Linux GNU/glibc x86-64 (glibc 2.35 or newer) | `research-v2.2.1-linux-amd64.tar.gz` |
+| Windows x86-64 | `research-v2.2.1-windows-amd64.zip` |
+| macOS Intel | `research-v2.2.1-macos-amd64.tar.gz` |
+| macOS Apple Silicon | `research-v2.2.1-macos-arm64.tar.gz` |
 
 The archives remain unsigned. Verify the selected file with `SHA256SUMS`, or
 build the exact tag with the pinned toolchain:
 
 ```sh
-git clone --branch v2.2.0 --depth 1 \
+git clone --branch v2.2.1 --depth 1 \
   https://github.com/ResearchPocket/researchpocket.github.io.git
 cd researchpocket.github.io
 cargo build --locked --release

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "research-pocket-web",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "research-pocket-web",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "dependencies": {
         "highlight.js": "11.11.1",
         "idb": "8.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "research-pocket-web",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "scripts": {
     "dev": "npm run wasm && vite",


### PR DESCRIPTION
The `v2.2.0` tag was pushed before the zen title and rail fixes (#158) landed, so the code under it shipped an editor whose title could not be edited.

Deleting or moving the tag is blocked by a repository ruleset — correctly. A release tag that moves is worse than a skipped version number, and I would rather burn `2.2.0` than weaken the rule to reclaim it.

So: versions bump to 2.2.1, the notes are renamed, and they state plainly that a `v2.2.0` tag exists but was never built or published. Nothing reached crates.io or a GitHub release under it; the draft was deleted.

No content changes beyond the version and that note.