### PR TITLE
Make the local indicator reach Sync on a phone

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -852,6 +852,13 @@ export function App() {
               <span aria-live="polite" className="status-copy" role="status">
                 {formatHeaderStatus(libraryState.status, libraryState.pendingCount)}
               </span>
+              {/* The full status sentence does not fit on a phone, so the
+                  pending count stands in for it there. */}
+              {libraryState.pendingCount > 0 ? (
+                <span aria-hidden="true" className="status-pending">
+                  {libraryState.pendingCount}
+                </span>
+              ) : null}
             </button>
             <button
               className="command-trigger"

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -3124,8 +3124,21 @@ kbd {
     width: 100%;
   }
 
+  /* The only route to Sync on a phone: the rail's utilities are hidden and the
+     actions bar carries saving, not syncing. A bare dot and a word read as a
+     readout, so it takes a chip's outline to look like the control it is. */
   .local-status {
+    border: var(--rule) solid var(--color-border);
+    border-radius: var(--radius);
     flex: 0 0 auto;
+    gap: 0.375rem;
+    min-block-size: 2rem;
+    padding-inline: 0.5rem;
+  }
+
+  .status-pending {
+    color: var(--color-text-muted);
+    display: inline;
   }
 
   .workspace-layout {
@@ -5288,6 +5301,11 @@ button.local-status {
   border: 0;
   cursor: pointer;
   padding: 0;
+}
+
+/* Desktop shows the whole status sentence, so a bare count would repeat it. */
+.status-pending {
+  display: none;
 }
 
 button.local-status:hover .status-copy,


### PR DESCRIPTION
Sync became unreachable on mobile. The rail's utilities — which hold Sync and Settings — are `display: none` at that breakpoint, and the mobile actions bar carries Save / Zen / Settings. That left the masthead `local` indicator as the only route, which is what we intended when the actions-bar sync button came out.

But a bare dot and the word "local" read as a status readout, not a control, so nobody would think to tap it. It was reachable in the DOM and unreachable in practice.

- The indicator now wears a chip outline on mobile, so it looks like the control it is.
- It carries the pending count there. That is the part of the status sentence the phone has no room for, and it is the information the removed `Sync 0` button used to show — so nothing was actually lost by taking that button out, it just had nowhere to live.

Desktop is unchanged: the full status sentence still shows, and the count would only repeat it, so it stays hidden above the breakpoint.

Typecheck, build, and the 16 web tests pass. Not clicked through — please confirm the chip is tappable and lands on Sync.