### PR TITLE
Open on Zen and open documents for reading

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -483,8 +483,7 @@ export function App() {
   }
 
   function navigateToView(nextView: WorkspaceView) {
-    const hash = nextView === "library" ? "" : `#${nextView}`;
-    const nextUrl = `${window.location.pathname}${window.location.search}${hash}`;
+    const nextUrl = `${window.location.pathname}${window.location.search}${hashForView(nextView)}`;
     const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
     if (nextUrl !== currentUrl) {
       window.history.pushState(window.history.state, "", nextUrl);
@@ -732,7 +731,7 @@ export function App() {
     window.history.replaceState(
       window.history.state,
       "",
-      `${window.location.pathname}${window.location.search}`,
+      `${window.location.pathname}${window.location.search}${hashForView(view)}`,
     );
     setReaderItem(null);
   }
@@ -3386,14 +3385,20 @@ function pluralize(count: number, noun: string) {
 }
 
 function readWorkspaceView(): WorkspaceView {
-  if (
-    window.location.hash === "#sync" ||
-    window.location.hash === "#restore"
-  ) {
-    return "sync";
-  }
-  if (window.location.hash === "#zen") return "zen";
-  return window.location.hash === "#settings" ? "settings" : "library";
+  const hash = window.location.hash;
+  if (hash === "#sync" || hash === "#restore") return "sync";
+  if (hash === "#settings") return "settings";
+  // The reader is a library surface, so a deep-linked item closes back into the
+  // library rather than into the default workspace.
+  if (hash === "#library" || hash.startsWith("#item=")) return "library";
+  return "zen";
+}
+
+/**
+ * Zen is the default workspace, so it is the one view that owns the bare URL.
+ */
+function hashForView(target: WorkspaceView) {
+  return target === "zen" ? "" : `#${target}`;
 }
 
 function readDensityPreference(): Density {

--- a/web/src/components/ZenWorkspace.tsx
+++ b/web/src/components/ZenWorkspace.tsx
@@ -219,8 +219,11 @@ function ZenEditor({
   onSaveTitle,
   onSaveBody,
 }: ZenWorkspaceProps & { open: { documentId: string; view: ZenDocumentView } }) {
+  // Reading is the default everywhere, phones included: a document is opened to
+  // be read far more often than to be changed. An empty one is the exception —
+  // there is nothing to read yet, so it opens ready to type.
   const [mode, setMode] = useState<"edit" | "view">(() =>
-    window.matchMedia("(max-width: 48rem)").matches ? "edit" : "view",
+    open.view.body.trim() === "" ? "edit" : "view",
   );
   const [draft, setDraft] = useState(open.view.body);
   const [title, setTitle] = useState(open.view.title.value ?? "");


### PR DESCRIPTION
Two defaults change.

**Zen is the default workspace.** The bare URL resolves to Zen; the library
gets a `#library` hash of its own, and `navigateToView` routes through a
`hashForView` helper so only one place knows which view owns the bare URL. A
deep-linked `#item=…` still resolves to the library, so closing a reader that
was opened from a link lands where the item lives rather than in Zen.

**Documents open in view mode.** Previously phones opened straight into edit
mode. Opening a document is usually about reading it, so view is now the
default on every screen. The one exception is a document with an empty body:
there is nothing to read, so it opens ready to type — which keeps "create" on
the Zen index a single gesture.

Typecheck, the web unit tests, and the design-system check pass locally.