### PR TITLE
Give an open document its own history entry

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -222,6 +222,10 @@ export function App() {
   } | null>(null);
   const [profiles, setProfiles] = useState<LibraryProfile[]>([]);
   const [activeProfileId, setActiveProfileId] = useState<string | null>(null);
+  // Read only by the history listener, which needs the current document
+  // without re-subscribing every time one is opened.
+  const openZenId = useRef<string | null>(null);
+  openZenId.current = openZen?.documentId ?? null;
   const captureOpenerRef = useRef<HTMLButtonElement | null>(null);
   const editOpenerRef = useRef<HTMLButtonElement | null>(null);
 
@@ -389,21 +393,32 @@ export function App() {
 
   useEffect(() => {
     function restoreNavigationFromHistory() {
-      const match = window.location.hash.match(/^#item=(.+)$/);
-      if (!match) {
-        setReaderItem(null);
-        setView(readWorkspaceView());
+      const item = window.location.hash.match(/^#item=(.+)$/);
+      if (item) {
+        const itemId = decodeURIComponent(item[1]!);
+        setReaderItem(items.find((entry) => entry.id === itemId) ?? null);
         return;
       }
-      const itemId = decodeURIComponent(match[1]!);
-      setReaderItem(items.find((item) => item.id === itemId) ?? null);
+      setReaderItem(null);
+      setView(readWorkspaceView());
+
+      const document = window.location.hash.match(/^#document=(.+)$/);
+      if (!document) {
+        setOpenZen(null);
+        return;
+      }
+      const documentId = decodeURIComponent(document[1]!);
+      // Already loaded when this runs for an entry we pushed ourselves; only a
+      // real back, forward, or deep link has to fetch the document.
+      if (documentId === openZenId.current) return;
+      if (libraryState.initialized) void loadZenDocument(documentId);
     }
 
     window.addEventListener("popstate", restoreNavigationFromHistory);
     restoreNavigationFromHistory();
     return () =>
       window.removeEventListener("popstate", restoreNavigationFromHistory);
-  }, [items]);
+  }, [items, libraryState.initialized]);
   const deferredQuery = useDeferredValue(query);
   const visibleItems = useMemo(
     () =>
@@ -495,15 +510,52 @@ export function App() {
     setZenDocuments(await libraryRepository.listZenDocuments());
   }
 
-  async function openZenDocument(documentId: string) {
+  /** Loads a document into the workspace without touching history. */
+  async function loadZenDocument(documentId: string) {
     try {
       setOpenZen({
         documentId,
         view: await libraryRepository.zenDocument(documentId),
       });
+      return true;
     } catch (error) {
       setLocalError(error instanceof Error ? error.message : "That document could not be opened.");
+      return false;
     }
+  }
+
+  /**
+   * Opening a document is a navigation, so it earns a history entry. Without
+   * one the browser's back gesture leaves the application entirely instead of
+   * returning to the index, which is the only back a phone has.
+   */
+  async function openZenDocument(documentId: string) {
+    if (!(await loadZenDocument(documentId))) return;
+    const nextUrl = `${window.location.pathname}${window.location.search}#document=${encodeURIComponent(documentId)}`;
+    if (nextUrl === `${window.location.pathname}${window.location.search}${window.location.hash}`) {
+      return;
+    }
+    window.history.pushState(
+      { ...window.history.state, researchPocketZen: true },
+      "",
+      nextUrl,
+    );
+  }
+
+  function closeZenDocument() {
+    setOpenZen(null);
+    if (!window.location.hash.startsWith("#document=")) return;
+    // Unwinding our own entry keeps forward working and stops the stack from
+    // growing every time a document is opened and closed.
+    if (window.history.state?.researchPocketZen) {
+      window.history.back();
+      return;
+    }
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${window.location.pathname}${window.location.search}${hashForView("zen")}`,
+    );
   }
 
   async function createZenDocument(title: string) {
@@ -522,7 +574,7 @@ export function App() {
     await runZen(async () => {
       await libraryRepository.setZenBody(documentId, body);
       await refreshZenDocuments();
-      await openZenDocument(documentId);
+      await loadZenDocument(documentId);
     });
   }
 
@@ -530,14 +582,14 @@ export function App() {
     await runZen(async () => {
       await libraryRepository.setZenTitle(documentId, title);
       await refreshZenDocuments();
-      await openZenDocument(documentId);
+      await loadZenDocument(documentId);
     });
   }
 
   async function removeZenDocument(documentId: string) {
     await runZen(async () => {
       await libraryRepository.deleteZenDocument(documentId);
-      setOpenZen(null);
+      closeZenDocument();
       await refreshZenDocuments();
     });
   }
@@ -1015,7 +1067,7 @@ export function App() {
           busy={busyAction !== null}
           documents={zenDocuments}
           hidden={view !== "zen"}
-          onClose={() => setOpenZen(null)}
+          onClose={closeZenDocument}
           onCreate={(title) => void createZenDocument(title)}
           onDelete={(documentId) => void removeZenDocument(documentId)}
           onLeave={() => navigateToView("library")}

--- a/web/src/components/ZenWorkspace.tsx
+++ b/web/src/components/ZenWorkspace.tsx
@@ -278,9 +278,6 @@ function ZenEditor({
             {open.view.title.value?.trim() || "Untitled document"}
           </span>
         </nav>
-        <span className="zen-budget zen-budget-toolbar">
-          {formatBytes(byteLength)} of {formatBytes(MAX_BODY_BYTES)}
-        </span>
         <div className="zen-mode" role="group" aria-label="Document mode">
           <button
             aria-pressed={mode === "edit"}
@@ -325,7 +322,14 @@ function ZenEditor({
             aria-label="Document title"
             className="zen-title-input"
             disabled={busy}
-            onBlur={() => onSaveTitle(open.documentId, title.trim() || null)}
+            onBlur={() => {
+              // Every save is an operation other devices have to fetch, so a
+              // blur that changed nothing must not write one.
+              const next = title.trim() || null;
+              if (next !== (open.view.title.value ?? null)) {
+                onSaveTitle(open.documentId, next);
+              }
+            }}
             onChange={(event) => setTitle(event.target.value)}
             placeholder="Untitled document"
             type="text"
@@ -369,15 +373,18 @@ function ZenEditor({
         </div>
       </div>
 
+      {/* The budget lives here rather than in the toolbar: it is a readout
+          about the body, and the toolbar is the one bar that has to stay
+          legible while scrolling. */}
       <footer className="zen-footer">
-        <span className="zen-budget zen-budget-footer">
-          {formatBytes(byteLength)} of {formatBytes(MAX_BODY_BYTES)}
-        </span>
         <span className="zen-footer-desktop">
           <b>esc</b> close
         </span>
         <span className="zen-footer-desktop">saves as you go</span>
         <span className="zen-footer-mobile">saved</span>
+        <span className="zen-budget">
+          {formatBytes(byteLength)} of {formatBytes(MAX_BODY_BYTES)}
+        </span>
       </footer>
     </section>
   );

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -5063,18 +5063,26 @@ kbd {
   flex: 1 1 auto;
 }
 
+/* The bar carries the way back out of a document, so it stays on screen for
+   the whole scroll. On a wide window the canvas is the scroller and this is
+   already out of it, which makes the stickiness a no-op there. */
 .zen-toolbar {
   align-items: center;
+  background: var(--color-canvas);
   border-bottom: 1px solid var(--color-border);
   display: flex;
   gap: 12px;
   min-height: 44px;
   padding: 0 20px;
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
 .zen-breadcrumb {
   align-items: center;
   display: flex;
+  flex: 1 1 auto;
   gap: 8px;
   font-size: 13px;
   min-width: 0;
@@ -5105,6 +5113,7 @@ kbd {
   color: var(--color-text-muted);
   font-size: 12px;
   margin-left: auto;
+  white-space: nowrap;
 }
 
 .zen-mode {
@@ -5313,7 +5322,6 @@ button.local-status:focus-visible .status-copy {
   color: var(--color-text);
 }
 
-.zen-budget-footer,
 .zen-footer-mobile {
   display: none;
 }
@@ -5329,12 +5337,10 @@ button.local-status:focus-visible .status-copy {
     display: none;
   }
 
-  .zen-budget-toolbar,
   .zen-footer-desktop {
     display: none;
   }
 
-  .zen-budget-footer,
   .zen-footer-mobile {
     display: inline;
   }


### PR DESCRIPTION
**Back returns to the index.** Opening a document only set React state, so the
browser's back gesture left the application rather than returning to the Zen
index — on a phone that is the only back there is. Opening now pushes
`#document=<id>`; the existing history listener restores the document on
back/forward and clears it when the hash no longer names one; closing unwinds
the entry we pushed so the stack does not grow with every open and close.
`loadZenDocument` is split out from `openZenDocument` because a save reloads
the projection and must not push a second entry.

**The toolbar is sticky.** It carries the breadcrumb out of the document and
was scrolling away on a long one. On a wide window the canvas is the scroller
and the toolbar sits outside it, so the stickiness only takes effect where the
page itself scrolls.

**The byte budget moves to the footer**, next to the other readouts, leaving
the sticky bar with controls only.

Also: blurring the title without changing it no longer writes an operation —
the title register was recording a revision on every blur.

Typecheck, web unit tests, and the design-system check pass locally.