### PR TITLE
Give the library one omnibar and the phone one shell

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import {
   MarkdownDocument,
   type MarkdownImage,
@@ -356,6 +357,28 @@ export function App() {
     window.addEventListener("keydown", handleShortcut);
     return () => window.removeEventListener("keydown", handleShortcut);
   }, [busyAction, undoNotice]);
+
+  // Pasting a URL with nothing focused stages it in the omnibar and puts the
+  // caret there. It stops short of saving: writing an item straight from the
+  // clipboard is not a thing to do without the owner seeing what it was.
+  useEffect(() => {
+    function handlePaste(event: ClipboardEvent) {
+      if (view !== "library") return;
+      if (readerItem || capturing || editingItem || commandOpen) return;
+      const target = event.target as HTMLElement | null;
+      if (target?.matches("input, textarea, select") || target?.isContentEditable) {
+        return;
+      }
+      const pasted = event.clipboardData?.getData("text")?.trim() ?? "";
+      if (!readOmnibarUrl(pasted)) return;
+      event.preventDefault();
+      setQuery(pasted);
+      document.querySelector<HTMLInputElement>("#library-search")?.focus();
+    }
+
+    window.addEventListener("paste", handlePaste);
+    return () => window.removeEventListener("paste", handlePaste);
+  }, [capturing, commandOpen, editingItem, readerItem, view]);
 
   const items = libraryState.items as unknown as LibraryItemView[];
   const activeCount = items.filter((item) => !item.deleted).length;
@@ -832,6 +855,21 @@ export function App() {
   const repositoryError = readStateError(libraryState.error);
   const displayedError = localError ?? repositoryError;
 
+  /**
+   * The two pushed screens — an open document and an open save — share one
+   * shell: the way back sits in the brand slot, the sync chip stays put, and
+   * the content column below is the only thing that differs. On a phone that
+   * back button is the only one there is.
+   */
+  const pushedScreen = readerItem
+    ? { label: "Library", onBack: closeReader }
+    : openZen
+      ? { label: "Zen", onBack: closeZenDocument }
+      : null;
+  // The rail is a library-and-Zen control strip. Elsewhere, and under a pushed
+  // screen, it has nothing to say and an empty strip reads as a fault.
+  const railApplies = (view === "library" || view === "zen") && !pushedScreen;
+
   if (libraryState.loading) {
     return <BootScreen />;
   }
@@ -855,18 +893,33 @@ export function App() {
       </a>
 
       <div className="workspace-chrome">
-        <header className="masthead">
-          <button
-            aria-label={view === "library" ? "ResearchPocket library" : "Back to library"}
-            className="brand-lockup"
-            onClick={() => navigateToView("library")}
-            type="button"
-          >
-            <span aria-hidden="true" className="brand-mark">
-              rp
-            </span>
-            <p className="brand-name">ResearchPocket</p>
-          </button>
+        <header className={`masthead${pushedScreen ? " masthead-pushed" : ""}`}>
+          <div className="masthead-lead">
+            {pushedScreen ? (
+              <button
+                className="masthead-back"
+                onClick={pushedScreen.onBack}
+                type="button"
+              >
+                <span aria-hidden="true">←</span>
+                <span>{pushedScreen.label}</span>
+              </button>
+            ) : null}
+            <button
+              aria-label={view === "library" ? "ResearchPocket library" : "Back to library"}
+              className="brand-lockup"
+              onClick={() => navigateToView("library")}
+              type="button"
+            >
+              <span aria-hidden="true" className="brand-mark">
+                rp
+              </span>
+              <p className="brand-name">ResearchPocket</p>
+              {/* A phone has no room for the product name and every reason to
+                  say which screen it is on, so the two swap places there. */}
+              <p className="brand-view">{formatViewLabel(view)}</p>
+            </button>
+          </div>
 
           <div className="masthead-actions">
             {profiles.length > 1 ? (
@@ -892,24 +945,26 @@ export function App() {
                 </select>
               </div>
             ) : null}
+            {/* The one route to Sync that is on screen from every view, so it
+                carries a chip's outline and says what pressing it does. */}
             <button
-              aria-label={`Sync — ${formatHeaderStatus(libraryState.status, libraryState.pendingCount)}`}
+              aria-label={`Open sync — ${formatHeaderStatus(libraryState.status, libraryState.pendingCount)}`}
               className="local-status"
+              data-pending={libraryState.pendingCount > 0 ? "true" : undefined}
               onClick={() => navigateToView("sync")}
+              title="Open sync"
               type="button"
             >
               <span aria-hidden="true" className="status-dot" />
               <span className="status-label">local</span>
               <span aria-live="polite" className="status-copy" role="status">
-                {formatHeaderStatus(libraryState.status, libraryState.pendingCount)}
+                {formatSyncCopy(libraryState.status, libraryState.pendingCount)}
               </span>
-              {/* The full status sentence does not fit on a phone, so the
-                  pending count stands in for it there. */}
-              {libraryState.pendingCount > 0 ? (
-                <span aria-hidden="true" className="status-pending">
-                  {libraryState.pendingCount}
-                </span>
-              ) : null}
+              {/* The full status sentence does not fit on a phone, so a shorter
+                  reading of the same state stands in for it there. */}
+              <span aria-hidden="true" className="status-chip">
+                {formatSyncChip(libraryState.status, libraryState.pendingCount)}
+              </span>
             </button>
             <button
               className="command-trigger"
@@ -923,7 +978,7 @@ export function App() {
       </div>
 
       <div className="workspace-layout">
-        <aside className={`tag-rail${view === "library" ? "" : " tag-rail-empty"}`}>
+        <aside className={`tag-rail${railApplies ? "" : " tag-rail-empty"}`}>
           <nav aria-label="Library views" className="rail-nav">
             <button
               aria-current={view === "library" && filter === "active" && !favoriteOnly ? "page" : undefined}
@@ -979,19 +1034,34 @@ export function App() {
                 }}
                 type="button"
               >
-                <span>Documents</span>
+                {/* The rail heading says ZEN above it; the chip strip drops
+                    headings, so the chip has to name itself. */}
+                <span className="rail-label-wide">Documents</span>
+                <span className="rail-label-narrow">Zen</span>
                 <small>{zenDocuments.length}</small>
               </button>
             </nav>
           </div>
 
-          {view === "library" && (
-          <>
+          {/* Tags belong to the library, but they stay reachable from Zen: on a
+              phone this strip is the whole navigation, and a filter that
+              disappears when a document opens is a filter nobody trusts. */}
           <div className="rail-tags">
             <div className="rail-heading">
               <p>Tags</p>
-              <button onClick={() => setFiltersOpen(true)} type="button">
-                {hiddenTagCount > 0 ? `+${hiddenTagCount} more` : "manage"}
+              {/* With the omnibar carrying search and saving, this is the way
+                  into the filters the strip has no room for. */}
+              <button
+                aria-controls="library-filters"
+                aria-expanded={filtersOpen}
+                onClick={() => setFiltersOpen((open) => !open)}
+                type="button"
+              >
+                {appliedFilterCount > 0
+                  ? `filters · ${appliedFilterCount}`
+                  : hiddenTagCount > 0
+                    ? `+${hiddenTagCount} more`
+                    : "manage"}
               </button>
             </div>
             <div className="rail-tag-list">
@@ -1015,10 +1085,8 @@ export function App() {
             onClick={() => setFiltersOpen(true)}
             type="button"
           >
-            Tags{selectedTags.length > 0 ? ` · ${selectedTags.length}` : ""}
+            Filters{appliedFilterCount > 0 ? ` · ${appliedFilterCount}` : ""}
           </button>
-          </>
-          )}
 
           <nav aria-label="Workspace utilities" className="rail-utilities">
             <button onClick={() => navigateToView("sync")} type="button">
@@ -1092,10 +1160,9 @@ export function App() {
               </h2>
               <p className="library-count">{pluralize(visibleItems.length, "item")}</p>
             </div>
-            <div className="density-controls" aria-label="List density">
-              <button aria-pressed={density === "compact"} onClick={() => setDensity("compact")} type="button">compact</button>
-              <button aria-pressed={density === "comfortable"} onClick={() => setDensity("comfortable")} type="button">comfortable</button>
-            </div>
+            {/* Density is a preference, not a toolbar decision, so it lives in
+                Settings and this row keeps only the one control that changes
+                what the list is showing. */}
             <label className="sort-control">
               <span className="sr-only">Sort order</span>
               <select onChange={(event) => setSortMode(event.target.value as SortMode)} value={sortMode}>
@@ -1106,51 +1173,15 @@ export function App() {
             </label>
           </div>
 
-          <QuickAdd busy={busyAction !== null} onAdd={addItem} />
-
-          <div className="library-tools">
-            <div className="search-control" role="search">
-              <label className="sr-only" htmlFor="library-search">
-                Search your library
-              </label>
-              <svg aria-hidden="true" className="search-glyph" viewBox="0 0 24 24">
-                <circle cx="10.5" cy="10.5" r="6.5" />
-                <path d="m15.5 15.5 4 4" />
-              </svg>
-              <input
-                autoComplete="off"
-                id="library-search"
-                name="query"
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="Title, URL, note, or tag"
-                type="search"
-                value={query}
-              />
-              {query ? (
-                <button
-                  aria-label="Clear search"
-                  className="search-clear"
-                  onClick={() => setQuery("")}
-                  title="Clear search"
-                  type="button"
-                >
-                  <span aria-hidden="true">×</span>
-                </button>
-              ) : null}
-            </div>
-            <button
-              aria-controls="library-filters"
-              aria-expanded={filtersOpen}
-              className="filter-toggle"
-              onClick={() => setFiltersOpen((open) => !open)}
-              type="button"
-            >
-              Filter{appliedFilterCount > 0 ? ` · ${appliedFilterCount}` : ""}
-            </button>
-          </div>
+          <Omnibar
+            busy={busyAction !== null}
+            onAdd={addItem}
+            onQueryChange={setQuery}
+            query={query}
+          />
 
           <div className="library-filters" hidden={!filtersOpen} id="library-filters">
-            <div className="mobile-filter-heading">
+            <div className="filter-heading">
               <strong>Filter library</strong>
               <button onClick={() => setFiltersOpen(false)} type="button">Done</button>
             </div>
@@ -1329,18 +1360,21 @@ export function App() {
               : `Showing ${renderedItems.length.toLocaleString()} of ${pluralize(visibleItems.length, "result")}`}
           </div>
           <footer className="keyboard-footer">
-            <span><b>Ctrl Shift P</b> command</span>
             <span><b>/</b> search</span>
+            <span><b>⌘V</b> save a URL</span>
             <span><b>⏎</b> reader</span>
-            <span><b>↗</b> open</span>
           </footer>
           </section>
         </main>
-        <nav aria-label="Mobile actions" className="mobile-actions">
-          <button className="primary-button" onClick={(event) => openCapture(event.currentTarget)} type="button">＋ Save a link</button>
-          <button className="secondary-button" onClick={() => { setOpenZen(null); navigateToView("zen"); }} type="button">Zen</button>
-          <button className="secondary-button" onClick={() => navigateToView("settings")} type="button">Settings</button>
-        </nav>
+        {/* Zen moved into the chip strip, so this keeps only what the strip and
+            the omnibar cannot carry: an authored capture, and Settings. It is
+            gone entirely under a pushed screen, which has its own footer. */}
+        {pushedScreen ? null : (
+          <nav aria-label="Mobile actions" className="mobile-actions">
+            <button className="primary-button" onClick={(event) => openCapture(event.currentTarget)} type="button">＋ Save a link</button>
+            <button className="secondary-button" onClick={() => navigateToView("settings")} type="button">Settings</button>
+          </nav>
+        )}
       </div>
 
       <div aria-atomic="true" aria-live="polite" className="sr-only">
@@ -2144,44 +2178,88 @@ function TokenFields() {
   );
 }
 
-function QuickAdd({
+/**
+ * One field for the two things a library is asked for: find something, or take
+ * something in. Typing filters as you go; a pasted URL turns the same field
+ * into a save, which is why it replaced a capture form, a search box and a
+ * filter button standing in a row.
+ *
+ * A save needs the scheme. Without it "inkandswitch.com" is indistinguishable
+ * from a search for that host, and guessing wrong writes an item.
+ */
+function Omnibar({
   busy,
   onAdd,
+  onQueryChange,
+  query,
 }: {
   busy: boolean;
   onAdd: (input: AddInput) => Promise<boolean>;
+  onQueryChange: (value: string) => void;
+  query: string;
 }) {
-  const [value, setValue] = useState("");
+  const parsed = readOmnibarUrl(query);
 
   async function submit(event: SubmitEvent<HTMLFormElement>) {
     event.preventDefault();
-    const parts = value.trim().split(/\s+/);
-    const url = parts.find((part) => !part.startsWith("#")) ?? "";
-    const tags = parts
-      .filter((part) => part.startsWith("#") && part.length > 1)
-      .map((part) => part.slice(1));
-    if (!url) return;
-    if (await onAdd({ favorite: false, tags, url } as AddInput)) setValue("");
+    if (!parsed) return;
+    if (await onAdd({ favorite: false, tags: parsed.tags, url: parsed.url } as AddInput)) {
+      onQueryChange("");
+    }
   }
 
   return (
-    <form className="quick-add" onSubmit={(event) => void submit(event)}>
-      <span aria-hidden="true">+</span>
-      <label className="sr-only" htmlFor="quick-add-url">Quickly save a URL</label>
+    <form className="omnibar" onSubmit={(event) => void submit(event)} role="search">
+      <label className="sr-only" htmlFor="library-search">
+        Search your library, or paste a URL to save it
+      </label>
+      <svg aria-hidden="true" className="search-glyph" viewBox="0 0 24 24">
+        <circle cx="10.5" cy="10.5" r="6.5" />
+        <path d="m15.5 15.5 4 4" />
+      </svg>
       <input
         autoCapitalize="none"
-        autoComplete="url"
+        autoComplete="off"
         disabled={busy}
-        id="quick-add-url"
-        inputMode="url"
-        onChange={(event) => setValue(event.target.value)}
-        placeholder="Paste or type a URL — ↵ saves it. Add #tags right here."
+        id="library-search"
+        name="query"
+        onChange={(event) => onQueryChange(event.target.value)}
+        placeholder="Search — or paste a URL to save it"
         type="text"
-        value={value}
+        value={query}
       />
-      <span className="quick-add-hint">or ⌘V anywhere</span>
+      {parsed ? (
+        <span className="omnibar-hint">
+          <kbd>↵</kbd> save{parsed.tags.length > 0 ? ` · ${parsed.tags.length} tag${parsed.tags.length === 1 ? "" : "s"}` : ""}
+        </span>
+      ) : query ? (
+        <button
+          aria-label="Clear search"
+          className="search-clear"
+          onClick={() => onQueryChange("")}
+          title="Clear search"
+          type="button"
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+      ) : (
+        <kbd className="omnibar-key">/</kbd>
+      )}
     </form>
   );
+}
+
+/** Reads an omnibar value as a save: one absolute URL plus any `#tags`. */
+function readOmnibarUrl(value: string): { tags: string[]; url: string } | null {
+  const parts = value.trim().split(/\s+/).filter(Boolean);
+  const urls = parts.filter((part) => /^https?:\/\/\S+$/i.test(part));
+  if (urls.length !== 1) return null;
+  const tags = parts
+    .filter((part) => part.startsWith("#") && part.length > 1)
+    .map((part) => part.slice(1));
+  // Anything that is neither the URL nor a tag means this is prose, not a save.
+  if (parts.length !== urls.length + tags.length) return null;
+  return { tags, url: urls[0]! };
 }
 
 interface CommandOption {
@@ -2539,9 +2617,30 @@ function ReaderView({
         <footer><span><b>j/k</b> next</span><span><b>esc</b> back</span></footer>
       </aside>
       <article className="reader-article">
+        {/* The pushed-screen title bar. Back sits in the masthead above it, so
+            this row carries the title and the two things a reader does to a
+            save without leaving it. */}
         <header className="reader-mobile-header">
-          <button aria-label="Back to all saves" onClick={onBack} type="button">←</button>
-          <span>{readHostname(item.url)}</span>
+          <span className="reader-mobile-title">{label}</span>
+          <button
+            aria-label={item.favorite ? "Remove favorite" : "Favorite"}
+            aria-pressed={item.favorite}
+            className="icon-button"
+            disabled={busy}
+            onClick={() => void onFavorite(item)}
+            type="button"
+          >
+            <span aria-hidden="true">★</span>
+          </button>
+          <a
+            aria-label="Open original"
+            className="icon-button"
+            href={item.url}
+            rel="noreferrer"
+            target="_blank"
+          >
+            <span aria-hidden="true">↗</span>
+          </a>
         </header>
         <div className="reader-content">
           <div className="reader-meta">
@@ -2579,6 +2678,25 @@ function ReaderView({
             <p className="reader-source">ResearchPocket keeps the URL and your authored context locally. The original page remains at <a href={item.url} rel="noreferrer" target="_blank">{readHostname(item.url)}</a>.</p>
           </div>
         </div>
+        <footer className="reader-mobile-footer">
+          <span>reader · saved copy</span>
+          <button
+            aria-haspopup="dialog"
+            disabled={busy}
+            onClick={(event) => onEdit(item, event.currentTarget)}
+            type="button"
+          >
+            <span aria-hidden="true">✎</span> edit details
+          </button>
+          <button
+            aria-label="Archive this save"
+            disabled={busy}
+            onClick={() => void onDelete(item).then(onBack)}
+            type="button"
+          >
+            <span aria-hidden="true">⌫</span>
+          </button>
+        </footer>
       </article>
       {expandedImage ? (
         <div
@@ -2907,7 +3025,6 @@ function LibraryItem({
   selectedTags: string[];
 }) {
   const label = item.title?.trim() || item.url;
-  const preview = item.note?.trim() || item.excerpt?.trim();
 
   return (
     <li>
@@ -2916,17 +3033,6 @@ function LibraryItem({
           item.deleted ? " item-card-deleted" : " item-card-editable"
         }${item.favorite ? " item-card-favorite" : ""}`}
       >
-        <button
-          aria-label={item.favorite ? `Remove ${label} from favorites` : `Add ${label} to favorites`}
-          aria-pressed={item.favorite}
-          className="item-favorite"
-          disabled={busy || item.deleted}
-          onClick={() => void onFavorite(item)}
-          title={item.favorite ? "Remove favorite" : "Favorite"}
-          type="button"
-        >
-          <span aria-hidden="true">{item.favorite ? "★" : "·"}</span>
-        </button>
         {!item.deleted ? (
           <button
             aria-label={`Read ${label}${item.favorite ? ", favorite" : ""}`}
@@ -2939,6 +3045,13 @@ function LibraryItem({
         ) : null}
         <div className="item-row-copy">
           <h3>
+            {/* The star reads as a mark on the title rather than a column of
+                its own, which is what let the row lose a whole grid track. */}
+            {item.favorite ? (
+              <span aria-hidden="true" className="item-star">
+                ★
+              </span>
+            ) : null}
             {item.deleted ? (
               <a href={item.url} rel="noreferrer" target="_blank">
                 {label}
@@ -2981,74 +3094,199 @@ function LibraryItem({
               </span>
             ) : null}
           </p>
-          {preview ? (
-            <p className="item-preview">
-              <span className="sr-only">Context: </span>
-              {preview}
-            </p>
-          ) : null}
         </div>
 
+        {/* Two controls carry the row: the one thing that leaves the app, and
+            everything else. Reader is the row itself, so it is not repeated
+            here — it stays in the menu for the keyboard. */}
         <div aria-label={`Actions for ${label}`} className="item-row-actions" role="group">
+          <a
+            aria-label={`Open ${label} in a new tab`}
+            className="icon-button"
+            href={item.url}
+            rel="noreferrer"
+            target="_blank"
+            title="Open in new tab"
+          >
+            <span aria-hidden="true">↗</span>
+          </a>
+          <ItemMenu
+            busy={busy}
+            item={item}
+            label={label}
+            onDelete={onDelete}
+            onEdit={onEdit}
+            onFavorite={onFavorite}
+            onRead={onRead}
+            onRestore={onRestore}
+          />
+        </div>
+      </article>
+    </li>
+  );
+}
+
+/**
+ * The row's second control. Everything that used to sit in a four-icon strip
+ * lives here, which is what let the resting row show two.
+ */
+function ItemMenu({
+  busy,
+  item,
+  label,
+  onDelete,
+  onEdit,
+  onFavorite,
+  onRead,
+  onRestore,
+}: {
+  busy: boolean;
+  item: LibraryItemView;
+  label: string;
+  onDelete: (item: LibraryItemView) => Promise<void>;
+  onEdit: (item: LibraryItemView, opener: HTMLButtonElement) => void;
+  onFavorite: (item: LibraryItemView) => Promise<void>;
+  onRead: (item: LibraryItemView) => void;
+  onRestore: (item: LibraryItemView) => Promise<void>;
+}) {
+  // Rows carry paint containment so a long list stays cheap to scroll, which
+  // no absolutely positioned child can escape. The menu is placed against the
+  // viewport instead, and closes on anything that would move it.
+  const [anchor, setAnchor] = useState<{ right: number; top: number } | null>(
+    null,
+  );
+  const open = anchor !== null;
+  const trigger = useRef<HTMLButtonElement>(null);
+  const wrapper = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function close() {
+      setAnchor(null);
+    }
+    function handlePointer(event: MouseEvent) {
+      const target = event.target as Node;
+      if (wrapper.current?.contains(target)) return;
+      if ((target as HTMLElement).closest?.(".item-menu-list")) return;
+      close();
+    }
+    function handleKey(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      // Stopped here so the same key does not also close the reader behind it.
+      event.stopPropagation();
+      close();
+      trigger.current?.focus();
+    }
+    window.addEventListener("pointerdown", handlePointer);
+    window.addEventListener("keydown", handleKey, true);
+    window.addEventListener("resize", close);
+    window.addEventListener("scroll", close, true);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointer);
+      window.removeEventListener("keydown", handleKey, true);
+      window.removeEventListener("resize", close);
+      window.removeEventListener("scroll", close, true);
+    };
+  }, [open]);
+
+  function run(action: () => void) {
+    setAnchor(null);
+    action();
+  }
+
+  function toggle() {
+    if (open) {
+      setAnchor(null);
+      return;
+    }
+    const rect = trigger.current?.getBoundingClientRect();
+    if (!rect) return;
+    // Rows near the foot of the window have no room beneath them.
+    const dropUp = rect.bottom > window.innerHeight - 12 * 16;
+    setAnchor({
+      right: Math.max(8, window.innerWidth - rect.right),
+      top: dropUp ? rect.top - 4 : rect.bottom + 4,
+    });
+  }
+
+  return (
+    <div className="item-menu" ref={wrapper}>
+      <button
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label={`More actions for ${label}`}
+        className="icon-button"
+        disabled={busy}
+        onClick={toggle}
+        ref={trigger}
+        title="More"
+        type="button"
+      >
+        <span aria-hidden="true">⋯</span>
+      </button>
+      {anchor ? createPortal(
+        <div
+          className="item-menu-list"
+          role="menu"
+          style={{
+            insetInlineEnd: `${anchor.right}px`,
+            top: `${anchor.top}px`,
+            transform:
+              anchor.top < window.innerHeight / 2 ? undefined : "translateY(-100%)",
+          }}
+        >
           {item.deleted ? (
             <button
-              aria-label={`Restore ${label}`}
-              className="icon-button restore-button"
-              disabled={busy}
-              onClick={() => void onRestore(item)}
-              title="Restore"
+              onClick={() => run(() => void onRestore(item))}
+              role="menuitem"
               type="button"
             >
-              <span aria-hidden="true">↶</span>
+              <span aria-hidden="true">↶</span> Restore
             </button>
           ) : (
             <>
               <button
-                aria-label={`Read ${label}`}
-                className="icon-button"
-                disabled={busy}
-                onClick={() => onRead(item)}
-                title="Reader"
+                onClick={() => run(() => onRead(item))}
+                role="menuitem"
                 type="button"
               >
-                <span aria-hidden="true">¶</span>
+                <span aria-hidden="true">¶</span> Reader
               </button>
               <button
-                aria-haspopup="dialog"
-                aria-label={`Edit ${label}`}
-                className="icon-button"
-                disabled={busy}
-                onClick={(event) => onEdit(item, event.currentTarget)}
-                title="Edit"
+                onClick={() => run(() => void onFavorite(item))}
+                role="menuitem"
                 type="button"
               >
-                <span aria-hidden="true">✎</span>
+                <span aria-hidden="true">★</span>{" "}
+                {item.favorite ? "Remove favorite" : "Favorite"}
               </button>
-              <a
-                aria-label={`Open ${label} in a new tab`}
-                className="icon-button"
-                href={item.url}
-                rel="noreferrer"
-                target="_blank"
-                title="Open in new tab"
-              >
-                <span aria-hidden="true">↗</span>
-              </a>
               <button
-                aria-label={`Delete ${label}`}
-                className="icon-button danger-button"
-                disabled={busy}
-                onClick={() => void onDelete(item)}
-                title="Delete"
+                onClick={(event) => {
+                  const opener = trigger.current ?? event.currentTarget;
+                  run(() => onEdit(item, opener));
+                }}
+                role="menuitem"
                 type="button"
               >
-                <span aria-hidden="true">⌫</span>
+                <span aria-hidden="true">✎</span> Edit details
+              </button>
+              <button
+                className="item-menu-danger"
+                onClick={() => run(() => void onDelete(item))}
+                role="menuitem"
+                type="button"
+              >
+                <span aria-hidden="true">⌫</span> Delete
               </button>
             </>
           )}
-        </div>
-      </article>
-    </li>
+        </div>,
+        // Inside the shell, not the body: every control in this app takes its
+        // press feel from `.app-shell`, and a menu that escapes containment
+        // must not escape that too.
+        document.querySelector(".app-shell") ?? document.body,
+      ) : null}
+    </div>
   );
 }
 
@@ -3548,6 +3786,34 @@ function readStateError(error: unknown) {
     return null;
   }
   return readError(error);
+}
+
+function formatViewLabel(view: WorkspaceView) {
+  if (view === "library") return "Library";
+  if (view === "zen") return "Zen";
+  if (view === "sync") return "Sync";
+  return "Settings";
+}
+
+/**
+ * What the chip shows. The arrow already says the count is waiting to leave
+ * this device, so the word "pending" beside it is saying it twice — it stays
+ * only in the accessible name, where there is no arrow to read.
+ */
+function formatSyncChip(status: unknown, pendingCount: number) {
+  if (pendingCount > 0) return `↑ ${pendingCount.toLocaleString()}`;
+  if (status === "error") return "! attention";
+  if (status === "saving") return "· saving";
+  if (status === "loading" || status === "opening" || status === "initializing") {
+    return "· opening";
+  }
+  return "✓ synced";
+}
+
+/** The wide-window reading, which has room for a word but not a repeated one. */
+function formatSyncCopy(status: unknown, pendingCount: number) {
+  if (pendingCount > 0) return `↑ ${pendingCount.toLocaleString()}`;
+  return formatHeaderStatus(status, pendingCount);
 }
 
 function formatHeaderStatus(status: unknown, pendingCount: number) {

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -326,6 +326,13 @@
   display: flex;
 }
 
+.masthead-lead {
+  align-items: center;
+  display: flex;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
 .brand-lockup {
   background: transparent;
   border: 0;
@@ -334,6 +341,25 @@
   min-height: 0;
   padding: 0;
   text-decoration: none;
+}
+
+/* The way out of a pushed screen. A wide window keeps the surrounding chrome,
+   so the brand slot only has to carry this on a phone. */
+.masthead-back,
+.brand-view {
+  display: none;
+}
+
+.masthead-back {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: var(--color-text-soft);
+  font-size: var(--font-size-sm);
+  font-weight: 750;
+  gap: var(--space-2);
+  min-height: 2.75rem;
+  padding: 0 var(--space-3);
 }
 
 .brand-mark,
@@ -364,10 +390,12 @@
   margin: 0;
 }
 
-.brand-name {
+.brand-name,
+.brand-view {
   font-size: var(--font-size-md);
   font-weight: 800;
   line-height: var(--line-height-tight);
+  margin: 0;
 }
 
 .brand-context {
@@ -390,7 +418,7 @@
 }
 
 .local-status {
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   font-size: var(--font-size-xs);
   gap: var(--space-2);
   justify-content: flex-end;
@@ -400,8 +428,47 @@
 
 .status-dot {
   background: var(--color-accent);
+  flex: 0 0 auto;
   height: 0.5rem;
   width: 0.5rem;
+}
+
+/* Queued work is the state worth interrupting for, so it takes the brighter
+   dot and the stronger edge. */
+.local-status[data-pending="true"] .status-dot {
+  background: var(--color-accent-strong);
+}
+
+/* The one route into Sync from any view. A bare dot and a word read as a
+   readout, so it takes a chip's outline to look like the control it is —
+   at every width, not only where the rail is gone. */
+button.local-status {
+  background: transparent;
+  border: var(--rule) solid var(--color-border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  min-block-size: 2rem;
+  padding-inline: 0.5rem;
+}
+
+button.local-status[data-pending="true"] {
+  border-color: var(--color-border-strong);
+}
+
+button.local-status:hover,
+button.local-status:focus-visible {
+  border-color: var(--color-accent-strong);
+}
+
+button.local-status:hover .status-copy,
+button.local-status:focus-visible .status-copy {
+  color: var(--color-text);
+}
+
+/* Desktop shows the whole status sentence, so the short reading would only
+   repeat it. */
+.status-chip {
+  display: none;
 }
 
 .workspace-nav {
@@ -796,15 +863,6 @@ footer,
   font-size: var(--font-size-xs);
 }
 
-.library-tools {
-  align-items: center;
-  display: grid;
-  gap: var(--space-2);
-  grid-template-columns: minmax(16rem, 1fr) auto;
-  margin: var(--space-5) 0 var(--space-3);
-}
-
-.filter-toggle,
 .filter-reset {
   background: transparent;
   border: var(--rule) solid var(--color-border-strong);
@@ -813,12 +871,6 @@ footer,
   font-size: var(--font-size-sm);
   font-weight: 750;
   padding: 0 var(--space-3);
-}
-
-.filter-toggle[aria-expanded="true"] {
-  background: var(--color-accent-soft);
-  border-color: var(--color-accent);
-  color: var(--color-accent-strong);
 }
 
 .library-filters {
@@ -938,23 +990,24 @@ footer,
   text-align: right;
 }
 
-.search-control {
+/* One field for search and for saving. It is the widest control in the view
+   because it is the only one most sessions touch. */
+.omnibar {
   align-items: center;
   background: var(--color-surface-raised);
   border: var(--rule) solid var(--color-border-strong);
   border-radius: var(--radius);
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
-  max-width: var(--measure);
   min-height: var(--control-height);
 }
 
-.search-control:focus-within {
+.omnibar:focus-within {
   outline: 0.1875rem solid var(--color-focus);
   outline-offset: 0.1875rem;
 }
 
-.search-control input {
+.omnibar input {
   background: transparent;
   border: 0;
   min-width: 0;
@@ -962,8 +1015,22 @@ footer,
   padding-inline: var(--space-2);
 }
 
-.search-control input::-webkit-search-cancel-button {
+.omnibar input::-webkit-search-cancel-button {
   display: none;
+}
+
+.omnibar-hint,
+.omnibar-key {
+  color: var(--color-text-muted);
+  flex: 0 0 auto;
+  font-size: var(--font-size-xs);
+  margin-right: var(--space-3);
+  white-space: nowrap;
+}
+
+/* The field changes what ⏎ does, so it says so before the key is pressed. */
+.omnibar-hint {
+  color: var(--color-accent-strong);
 }
 
 .search-glyph {
@@ -1088,18 +1155,27 @@ footer,
 }
 
 .item-card h3 {
+  align-items: baseline;
+  display: flex;
   font-size: var(--font-size-md);
   font-weight: 750;
+  gap: 0.4375rem;
   margin: 0;
   min-width: 0;
 }
 
 .item-card h3 a,
 .item-card h3 > span {
-  display: block;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.item-star {
+  color: var(--color-accent-strong);
+  flex: 0 0 auto;
+  font-size: var(--font-size-xs);
 }
 
 .item-card-edit-trigger {
@@ -1134,8 +1210,7 @@ footer,
   outline-offset: -0.1875rem;
 }
 
-.item-meta,
-.item-preview {
+.item-meta {
   color: var(--color-text-muted);
   font-size: var(--font-size-xs);
   line-height: var(--line-height-tight);
@@ -1206,6 +1281,55 @@ footer,
   gap: var(--space-1);
   position: relative;
   z-index: 2;
+}
+
+.item-menu {
+  position: relative;
+}
+
+/* Everything the resting row no longer shows. It is a short list, so it sits
+   against the trigger rather than borrowing a dialog. Placed against the
+   viewport because the rows themselves are paint-contained. */
+.item-menu-list {
+  background: var(--color-surface-raised);
+  border: var(--rule) solid var(--color-border-strong);
+  border-radius: var(--radius);
+  display: grid;
+  min-width: 11rem;
+  padding: var(--space-1) 0;
+  position: fixed;
+  z-index: 12;
+}
+
+.item-menu-list button {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-soft);
+  display: grid;
+  font-size: var(--font-size-sm);
+  gap: var(--space-3);
+  grid-template-columns: 1rem minmax(0, 1fr);
+  min-height: 2.25rem;
+  padding: 0 var(--space-4);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.item-menu-list button:focus-visible {
+  background: var(--color-accent-soft);
+  color: var(--color-text);
+  outline-offset: -0.1875rem;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .item-menu-list button:hover {
+    background: var(--color-accent-soft);
+    color: var(--color-text);
+  }
+}
+
+.item-menu-list .item-menu-danger {
+  color: var(--color-danger);
 }
 
 .icon-button {
@@ -1698,10 +1822,6 @@ footer {
     grid-template-columns: 1fr;
   }
 
-  .library-tools {
-    grid-template-columns: minmax(0, 1fr) auto;
-  }
-
   .sync-form .field,
   .capture-form .field {
     grid-template-columns: 1fr;
@@ -1921,6 +2041,7 @@ footer {
     .text-button,
     .close-button,
     .command-trigger,
+    .local-status,
     .search-clear,
     .tag-filter-options button,
     .tag-suggestions button,
@@ -1932,12 +2053,14 @@ footer {
     .rail-tag-list button,
     .rail-utilities button,
     .rail-heading button,
-    .density-controls button,
     .command-results button,
     .reader-list > header button,
     .reader-list li button,
     .reader-meta button,
     .reader-markdown-image-consent button,
+    .reader-mobile-footer button,
+    .item-menu-list button,
+    .masthead-back,
     .mobile-tag-filter-trigger
   ):active:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]) {
   background: var(--color-control-pressed);
@@ -1948,7 +2071,7 @@ footer {
 .app-shell
   :where(
     .primary-button,
-    .mobile-filter-heading button
+    .filter-heading button
   ):active:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]) {
   background: var(--color-control-primary-pressed);
   border-color: var(--color-control-primary-pressed);
@@ -1968,7 +2091,7 @@ footer {
   .secondary-button,
   .command-trigger,
   .mobile-tag-filter-trigger,
-  .mobile-filter-heading button,
+  .filter-heading button,
   .reader-markdown-image-consent button,
   .reader-image-viewer-close,
   .onboarding-choice
@@ -1983,7 +2106,7 @@ footer {
   .secondary-button,
   .command-trigger,
   .mobile-tag-filter-trigger,
-  .mobile-filter-heading button,
+  .filter-heading button,
   .reader-markdown-image-consent button,
   .reader-image-viewer-close,
   .onboarding-choice
@@ -2001,7 +2124,7 @@ footer {
   .secondary-button,
   .command-trigger,
   .mobile-tag-filter-trigger,
-  .mobile-filter-heading button,
+  .filter-heading button,
   .reader-markdown-image-consent button,
   .reader-image-viewer-close,
   .onboarding-choice
@@ -2012,7 +2135,7 @@ footer {
 }
 
 .primary-button,
-.mobile-filter-heading button {
+.filter-heading button {
   --control-edge-color: var(--color-inverse);
 }
 
@@ -2038,7 +2161,6 @@ footer {
 }
 
 .masthead-actions,
-.density-controls,
 .library-title,
 .reader-meta,
 .reader-meta > div,
@@ -2097,8 +2219,7 @@ kbd {
   display: none;
 }
 
-.mobile-tag-filter-trigger,
-.mobile-filter-heading {
+.mobile-tag-filter-trigger {
   display: none;
 }
 
@@ -2167,6 +2288,10 @@ kbd {
   font-weight: 400;
 }
 
+.rail-label-narrow {
+  display: none;
+}
+
 .rail-heading {
   align-items: baseline;
   display: flex;
@@ -2231,90 +2356,65 @@ kbd {
   margin: 0;
 }
 
-.density-controls {
-  border: var(--rule) solid var(--color-border);
-  border-radius: var(--radius);
+.sort-control {
   margin-left: auto;
 }
 
-.density-controls button {
-  background: transparent;
-  border: 0;
-  color: var(--color-text-muted);
-  font-size: var(--font-size-xs);
-  font-weight: 700;
-  min-height: 1.875rem;
-  padding: 0 0.625rem;
-}
-
-.density-controls button + button {
-  border-left: var(--rule) solid var(--color-border);
-}
-
-.density-controls button[aria-pressed="true"] {
-  background: var(--color-surface-raised);
-  color: var(--color-accent-strong);
-}
-
-.sort-control {
-  margin-left: 0.75rem;
-}
-
+/* No border: the row already has a heading and a count, and a third boxed
+   control makes a toolbar out of what should read as a caption. */
 .sort-control select {
   background: transparent;
-  border-color: var(--color-border);
-  color: var(--color-text-soft);
+  border-color: transparent;
+  color: var(--color-text-muted);
   font-size: var(--font-size-xs);
   height: 1.95rem;
   min-height: 1.95rem;
+  padding-inline: 0;
   width: auto;
 }
 
-.quick-add {
-  align-items: center;
-  border: var(--rule) dashed var(--color-border-strong);
-  border-radius: var(--radius);
-  display: grid;
-  gap: 0.625rem;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  margin-top: 0.75rem;
-  min-height: 2.75rem;
-  padding: 0 0.75rem;
+.sort-control select:hover,
+.sort-control select:focus-visible {
+  color: var(--color-text-soft);
 }
 
-.quick-add > span:first-child {
-  color: var(--color-accent-strong);
-  font-size: 1rem;
-  font-weight: 700;
+.omnibar {
+  margin: 0.625rem 0 0.75rem;
 }
 
-.quick-add input {
-  background: transparent;
-  border: 0;
+.omnibar input {
   height: 2.625rem;
   min-height: 2.625rem;
-  outline: 0;
-  padding: 0;
-}
-
-.quick-add-hint {
-  color: var(--color-text-muted);
-  font-size: var(--font-size-xs);
-}
-
-.library-tools {
-  grid-template-columns: minmax(12rem, 32rem) auto;
-  margin: 0.625rem 0;
-}
-
-.search-control {
-  background: transparent;
-  border-color: var(--color-border);
 }
 
 .library-filters {
   background: var(--color-surface);
   padding: 0.5rem;
+}
+
+.filter-heading {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  gap: var(--space-3);
+  min-height: 2rem;
+  padding-right: var(--space-2);
+}
+
+.filter-heading strong {
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.filter-heading button {
+  background: var(--color-inverse-surface);
+  border: var(--rule) solid var(--color-inverse-surface);
+  border-radius: var(--radius);
+  color: var(--color-inverse);
+  font-size: var(--font-size-xs);
+  min-height: 1.75rem;
+  padding: 0 0.625rem;
 }
 
 .result-count {
@@ -2326,59 +2426,33 @@ kbd {
 }
 
 .item-card {
-  gap: 0.75rem;
-  grid-template-columns: 1.125rem minmax(0, 1fr) auto;
-  min-block-size: 3.75rem;
-  padding: 0.625rem 0 0.625rem 0.125rem;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-block-size: 3.5rem;
+  padding: 0.5625rem 0.25rem;
 }
 
 .item-list-compact .item-card {
-  min-block-size: 2.875rem;
-  padding-block: 0.375rem;
-}
-
-.item-list-compact .item-preview {
-  display: none;
+  min-block-size: 2.75rem;
+  padding-block: 0.3125rem;
 }
 
 .item-card-favorite::before {
   display: none;
 }
 
-.item-favorite {
-  background: transparent;
-  border: 0;
-  color: var(--color-favorite-muted);
-  font-size: 0.875rem;
-  min-height: 2rem;
-  padding: 0;
-  position: relative;
-  width: 1.125rem;
-  z-index: 3;
-}
-
-.item-favorite[aria-pressed="true"] {
-  color: var(--color-accent-strong);
-}
-
 .item-card h3 {
   font-size: 0.875rem;
 }
 
-.item-meta {
-  order: 2;
-}
-
-.item-preview {
-  color: var(--color-text-soft);
-  order: 1;
-}
-
+/* The row is quiet until it is pointed at. Focus counts as pointing, so the
+   keyboard reaches the same two controls the mouse does. */
 .item-row-actions {
-  opacity: 0.45;
+  opacity: 0;
 }
 
-.item-card:focus-within .item-row-actions {
+.item-card:focus-within .item-row-actions,
+.item-row-actions:has(.item-menu-list) {
   opacity: 1;
 }
 
@@ -2990,7 +3064,8 @@ kbd {
   color: var(--color-text-muted);
 }
 
-.reader-mobile-header {
+.reader-mobile-header,
+.reader-mobile-footer {
   display: none;
 }
 
@@ -3073,32 +3148,34 @@ kbd {
     padding: 0 1rem;
   }
 
-  .brand-name::after {
-    content: "Library";
-  }
-
-  .brand-name {
-    font-size: 0;
-  }
-
-  .brand-name::after {
-    font-size: var(--font-size-md);
-  }
-
+  /* The product name is the one thing a phone already knows; which screen it
+     is on is the thing it has to be told. */
+  .brand-name,
   .command-trigger,
   .brand-context,
-  .status-copy {
+  .status-copy,
+  .status-label {
     display: none;
   }
 
-  .status-label {
-    display: inline;
+  .brand-view {
+    display: block;
+    white-space: nowrap;
   }
 
   .masthead {
     flex-wrap: nowrap;
     gap: 0.5rem;
     padding-bottom: 0;
+  }
+
+  /* Under a pushed screen the brand slot carries the way back instead. */
+  .masthead-pushed .brand-lockup {
+    display: none;
+  }
+
+  .masthead-pushed .masthead-back {
+    display: inline-flex;
   }
 
   .brand-lockup {
@@ -3124,21 +3201,19 @@ kbd {
     width: 100%;
   }
 
-  /* The only route to Sync on a phone: the rail's utilities are hidden and the
-     actions bar carries saving, not syncing. A bare dot and a word read as a
-     readout, so it takes a chip's outline to look like the control it is. */
   .local-status {
-    border: var(--rule) solid var(--color-border);
-    border-radius: var(--radius);
     flex: 0 0 auto;
     gap: 0.375rem;
-    min-block-size: 2rem;
-    padding-inline: 0.5rem;
   }
 
-  .status-pending {
+  /* The sentence is gone at this width, so the chip carries the state. */
+  .status-chip {
     color: var(--color-text-muted);
     display: inline;
+  }
+
+  .local-status[data-pending="true"] .status-chip {
+    color: var(--color-accent-strong);
   }
 
   .workspace-layout {
@@ -3178,21 +3253,45 @@ kbd {
     overflow: visible;
   }
 
+  /* The groups collapse so their buttons join the one strip. This is what puts
+     Zen and the tags one tap from anywhere instead of behind a bottom bar. */
   .rail-tags {
+    display: contents;
+  }
+
+  .rail-label-wide {
     display: none;
+  }
+
+  .rail-label-narrow {
+    display: inline;
   }
 
   .rail-nav button,
   .rail-tag-list button {
+    background: transparent;
     border: var(--rule) solid var(--color-border);
     border-radius: var(--radius);
+    color: var(--color-text-soft);
     flex: 0 0 auto;
+    font-weight: 400;
     gap: 0.4rem;
     min-height: 2rem;
     padding: 0 0.625rem;
     width: auto;
   }
 
+  /* The chip's whole edge marks the current view; the rail's left bar has no
+     meaning once the buttons are laid out in a row. */
+  .rail-nav button[aria-current="page"],
+  .rail-tag-list button[aria-current="page"] {
+    background: var(--color-surface-raised);
+    border-color: var(--color-border-strong);
+    color: var(--color-accent-strong);
+    font-weight: 700;
+  }
+
+  /* Archive is a destination, not a filter anyone reaches for mid-scroll. */
   .rail-nav button:nth-child(3) {
     display: none;
   }
@@ -3209,9 +3308,19 @@ kbd {
     padding: 0 0.625rem;
   }
 
+  /* A column so the view inside can reach the bottom of the screen. An open
+     document ends in a status footer, and a footer that floats halfway up a
+     tall blank page reads as the end of the content, not the end of the view. */
   #workspace {
+    display: flex;
     flex: 1 1 auto;
+    flex-direction: column;
     overflow: visible;
+  }
+
+  .library-section,
+  .zen-index {
+    flex: 1 1 auto;
   }
 
   .library-section {
@@ -3219,9 +3328,7 @@ kbd {
   }
 
   .library-heading-row,
-  .quick-add,
   .library-filters,
-  .filter-toggle,
   .keyboard-footer {
     display: none;
   }
@@ -3240,16 +3347,15 @@ kbd {
     z-index: 20;
   }
 
-  .mobile-filter-heading {
-    align-items: center;
+  .filter-heading {
     border-bottom: var(--rule) solid var(--color-border-strong);
-    display: flex;
     justify-content: space-between;
     margin-bottom: 0.25rem;
     min-height: 2.75rem;
+    padding-right: 0;
   }
 
-  .mobile-filter-heading button {
+  .filter-heading button {
     background: var(--color-inverse-surface);
     border: var(--rule) solid var(--color-inverse-surface);
     border-radius: var(--radius);
@@ -3290,12 +3396,8 @@ kbd {
     width: 100%;
   }
 
-  .library-tools {
-    display: block;
+  .omnibar {
     margin: 0;
-  }
-
-  .search-control {
     min-height: 2.75rem;
   }
 
@@ -3307,19 +3409,15 @@ kbd {
   .item-card {
     align-items: start;
     gap: 0.5rem;
-    grid-template-columns: 0.875rem minmax(0, 1fr);
-    min-block-size: 4rem;
-    padding: 0.5rem 0;
+    grid-template-columns: minmax(0, 1fr);
+    min-block-size: 2.75rem;
+    padding: 0.625rem 0;
   }
 
+  /* A hover strip has no meaning on a touch screen; opening the save is how
+     everything here is reached. */
   .item-row-actions {
     display: none;
-  }
-
-  .item-favorite {
-    font-size: var(--font-size-xs);
-    min-height: 1.75rem;
-    width: 0.875rem;
   }
 
   .item-card h3 {
@@ -3331,16 +3429,7 @@ kbd {
     flex-wrap: nowrap;
     gap: 0.25rem;
     line-height: 1.2;
-    margin: 0;
-  }
-
-  .item-meta > span:nth-child(2),
-  .item-meta > span:nth-child(3) {
-    display: none;
-  }
-
-  .item-preview {
-    display: block;
+    margin: 0.1875rem 0 0;
   }
 
   .item-row-copy {
@@ -3365,7 +3454,7 @@ kbd {
     display: grid;
     flex: 0 0 auto;
     gap: 0.375rem;
-    grid-template-columns: 1fr auto auto;
+    grid-template-columns: 1fr auto;
     left: 0;
     padding: 0.375rem 0.75rem max(0.5rem, env(safe-area-inset-bottom));
     position: sticky;
@@ -3387,15 +3476,18 @@ kbd {
     max-height: calc(100dvh - 5rem);
   }
 
+  /* An opened save is a pushed screen, not an overlay: the masthead above it
+     stays, carrying the way back and the sync chip, and only the column
+     underneath is replaced. That is the same shell an opened document uses. */
   .reader-view {
-    display: block;
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
     inset: auto;
-    min-height: 100dvh;
+    min-height: 0;
     position: static;
   }
 
-  .app-shell:has(> .reader-view) > .skip-link,
-  .app-shell:has(> .reader-view) > .workspace-chrome,
   .app-shell:has(> .reader-view) > .workspace-layout {
     display: none;
   }
@@ -3405,60 +3497,82 @@ kbd {
   }
 
   .reader-article {
-    min-height: 100dvh;
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    min-height: 0;
     overflow: visible;
   }
 
   .reader-mobile-header {
     align-items: center;
-    border-bottom: var(--rule) solid var(--color-border);
+    border-bottom: var(--rule) solid var(--color-border-subtle);
     display: flex;
     gap: 0.5rem;
-    min-height: 3.25rem;
-    padding: 0 0.5rem;
+    min-height: 2.75rem;
+    padding: 0 0.5rem 0 1rem;
   }
 
-  .reader-mobile-header button {
+  .reader-mobile-title {
+    flex: 1 1 auto;
+    font-size: var(--font-size-sm);
+    font-weight: 750;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .reader-mobile-header .icon-button {
+    flex: 0 0 auto;
+    height: 2.75rem;
+    min-height: 2.75rem;
+    width: 2.75rem;
+  }
+
+  .reader-mobile-header .icon-button[aria-pressed="true"] {
+    background: transparent;
+    border-color: transparent;
+  }
+
+  .reader-mobile-footer {
+    align-items: center;
+    border-top: var(--rule) solid var(--color-border-subtle);
+    bottom: 0;
+    background: var(--color-canvas);
+    color: var(--color-text-muted);
+    display: flex;
+    font-size: var(--font-size-xs);
+    gap: 0.75rem;
+    margin-top: auto;
+    min-height: 2.75rem;
+    padding: 0 0.75rem env(safe-area-inset-bottom);
+    position: sticky;
+  }
+
+  .reader-mobile-footer > span {
+    margin-right: auto;
+    padding-left: 0.25rem;
+  }
+
+  .reader-mobile-footer button {
     background: transparent;
     border: 0;
-    color: var(--color-text-soft);
-    font-size: 1rem;
-    width: 2.25rem;
-  }
-
-  .reader-mobile-header span {
     color: var(--color-text-muted);
     font-size: var(--font-size-xs);
+    min-height: 2.75rem;
+    padding: 0 0.25rem;
   }
 
   .reader-content {
-    padding: 1.25rem 1.25rem 6rem;
+    flex: 1 1 auto;
+    padding: 1.25rem 1.25rem 2rem;
   }
 
-  .reader-meta > span {
-    display: none;
-  }
-
+  /* Favourite, open, edit and archive all moved into the bars above and below,
+     so the desktop action strip has nothing left to show here. */
   .reader-meta > div {
-    bottom: 0;
-    background: var(--color-canvas);
-    border-top: var(--rule) solid var(--color-border-strong);
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    left: 0;
-    padding: 0.5rem 0.75rem max(1rem, env(safe-area-inset-bottom));
-    position: fixed;
-    right: 0;
-    z-index: 2;
-  }
-
-  .reader-meta button,
-  .reader-meta a {
-    border: var(--rule) solid var(--color-border);
-    font-size: 1.125rem;
-    height: 2.5rem;
-    min-height: 2.5rem;
-    width: auto;
+    display: none;
   }
 
   .reader-content h1 {
@@ -5304,24 +5418,6 @@ kbd {
   margin: 0;
 }
 
-/* The local indicator is the way into sync, so it reads as pressable. */
-button.local-status {
-  background: transparent;
-  border: 0;
-  cursor: pointer;
-  padding: 0;
-}
-
-/* Desktop shows the whole status sentence, so a bare count would repeat it. */
-.status-pending {
-  display: none;
-}
-
-button.local-status:hover .status-copy,
-button.local-status:focus-visible .status-copy {
-  color: var(--color-text);
-}
-
 .zen-footer-mobile {
   display: none;
 }
@@ -5346,10 +5442,11 @@ button.local-status:focus-visible .status-copy {
   }
 
   .zen-footer {
-    /* The status belongs on screen while writing, not below a tall body. The
-       offset clears the actions bar, which is sticky in the same scroller. */
+    /* The status belongs on screen while writing, not below a tall body. An
+       open document is a pushed screen, so there is no actions bar under this
+       one to clear. */
     background: var(--color-canvas);
-    bottom: var(--mobile-actions-size);
+    bottom: 0;
     justify-content: space-between;
     position: sticky;
   }
@@ -5361,6 +5458,17 @@ button.local-status:focus-visible .status-copy {
   .zen-toolbar {
     gap: 0.5rem;
     padding: 0 1rem;
+  }
+
+  /* The masthead above already carries "← Zen"; a second way back in the same
+     corner reads as two different destinations. */
+  .zen-breadcrumb button,
+  .zen-breadcrumb > span[aria-hidden="true"] {
+    display: none;
+  }
+
+  .zen-breadcrumb-current {
+    font-size: var(--font-size-sm);
   }
 
   .zen-page {


### PR DESCRIPTION
Implements the Turn 2 and Turn 3 screens from the *Research Zen* design doc. Turn 1 documents what already ships; 1e and 1g were unchosen new-tab alternatives and are not built.

## Desktop library (2a)

- One omnibar replaces the capture form, the search box, and the Filter button. Typing filters live; a pasted absolute URL (plus any `#tags`) flips the trailing hint to `↵ save`.
- `⌘V` with nothing focused stages the URL in the omnibar and puts the caret there. It deliberately stops short of writing — saving straight from the clipboard should not happen unseen. The footer already advertised this key; now something listens for it.
- Density leaves the toolbar for Settings, where the preference already lived. The sort select loses its border and reads as a caption.
- Rows rest at a title (star inline), one meta line, and two actions revealed on hover or focus: `↗` and `⋯`. Reader, Favorite, Edit and Delete move into the `⋯` menu.
- Filters keep a door: the rail's Tags heading opens the panel and reads `filters · N` when any are applied.

## Mobile (3a–3d)

- The header carries the brand mark, the current view name, and the sync chip. The hard-coded `Library` label is gone.
- The chip strip now carries Zen and the tag chips — previously a bottom-bar button and a filter sheet — and appears in Zen as well as Library.
- An opened save is a pushed screen rather than a full-screen overlay: the masthead stays, the brand slot becomes `← Library`, and the title bar carries `★` and `↗` over a `reader · saved copy` footer. An opened document uses the same shell with `← Zen`.

## Deviations from the drawing

1. **A slimmed bottom bar survives** (`＋ Save a link` · `Settings`), hidden on pushed screens. Turn 3 draws no bar, but removing it strands authored capture and Settings on a phone — the command palette is desktop-only.
2. **`⌫` sits beside `✎ edit details`** in the reader footer. 3d shows only the edit control, and archive had no other mobile route.
3. **The sync chip keeps its outline on desktop**, where 2a draws a plain readout. It is the one route into Sync from every view and had to read as a control.
4. **The `⋯` menu is invented.** The design says "two actions" without saying where the other four went.

## Notes

The overflow menu portals into the `.app-shell` element rather than `document.body`: list rows carry `contain: paint` for scroll cost, which no absolutely positioned child escapes, and the app's press micro-interaction is two `:active` rules scoped to `.app-shell`. Both rules were confirmed to still select the portalled buttons.

The row preview line (note or excerpt) is dropped per 2a.

## Protocol impact

None. No domain, store, sync, or publication code is touched.

## Verification

- `npm run verify` — 16/16 tests, typecheck, design-system check, production build, dist checks.
- Driven in Chrome at 1280px and 390px through: save via omnibar, paste-to-stage, the overflow menu at the foot of the list, the filter panel, an opened save, the Zen index, and an opened document.