### PR TITLE
Give the library a graph mode

### DIFF
--- a/docs/v2/ADR_0011_ZEN_DOCUMENTS.md
+++ b/docs/v2/ADR_0011_ZEN_DOCUMENTS.md
@@ -76,9 +76,13 @@ resolves the UUID against the local projection at view time:
   title; and
 - an unknown UUID renders as an explicit unresolved reference.
 
-Mentions are one-way references. There is no backlink index, no graph query
-surface, and no automatic insertion of mentions. New `research:` reference
-kinds require an ADR; the namespace is append-only.
+Mentions are one-way references. No backlink index is persisted or
+synchronized, mentions are never inserted automatically, and no mention
+structure is part of the wire format, the projection, or any publication
+artifact. A read-only view may derive relationships from bodies already in
+memory, provided it stores nothing and the derivation is discarded with the
+view ([ADR 0012](./ADR_0012_DERIVED_LIBRARY_GRAPH.md)). New `research:`
+reference kinds require an ADR; the namespace is append-only.
 
 ### Todos and lists
 

--- a/docs/v2/ADR_0012_DERIVED_LIBRARY_GRAPH.md
+++ b/docs/v2/ADR_0012_DERIVED_LIBRARY_GRAPH.md
@@ -1,0 +1,127 @@
+# ADR 0012: A derived library graph, and what "no graph query surface" means
+
+- Status: accepted
+- Date: 2026-08-06
+- Amends: [ADR 0011](./ADR_0011_ZEN_DOCUMENTS.md) mention semantics, and the
+  wording of the corresponding non-goal in [PRODUCT.md](./PRODUCT.md) and the
+  repository `AGENTS.md`
+
+## Context
+
+The library is only ever seen as a filtered list. Everything it already knows
+about relatedness — which saves share a tag, which saves one zen document
+mentions together — is invisible. There is no way to see a cluster, no way to
+find an orphan (a save with no tag and no mention, which is effectively lost),
+and no way to move sideways from a save into its neighbourhood.
+
+A graph view answers those from data the library already stores. It needs no
+new field, no new mutation, and no new sync payload.
+
+ADR 0011 forbids something that sounds exactly like it:
+
+> Mentions are one-way references. There is no backlink index, no graph query
+> surface, and no automatic insertion of mentions.
+
+That clause was written to protect three things: that a mention costs one
+Markdown link and nothing else; that no second structure has to be kept
+consistent with the bodies it was derived from; and that ResearchPocket does
+not become the note-graph application PRODUCT.md declines to be. It was not
+written to decide whether the owner may look at their own library sideways.
+
+Reading the clause literally forbids the view. Reading it for its purpose
+forbids *persisting* or *synchronizing* a mention index — which is a different
+and much narrower thing.
+
+## Decision
+
+### The prohibition is on stored structure, not on looking
+
+ADR 0011's clause is narrowed to what it was protecting. The revised text
+reads verbatim:
+
+> Mentions are one-way references. No backlink index is persisted or
+> synchronized, mentions are never inserted automatically, and no mention
+> structure is part of the wire format, the projection, or any publication
+> artifact. A read-only view may derive relationships from bodies already in
+> memory, provided it stores nothing and the derivation is discarded with the
+> view. New `research:` reference kinds require an ADR; the namespace is
+> append-only.
+
+The PRODUCT.md and `AGENTS.md` non-goal keeps its wording. A derived view is
+not "a note graph" in the sense those documents decline: what they decline is
+an application whose organizing structure is the graph, where links are
+authored as structure and the graph is the thing being maintained. Mentions
+remain prose. Nothing in the library is authored *as* an edge.
+
+### What the graph is
+
+The library graph is a pure, synchronous projection over state already loaded:
+
+- **Nodes** are saved items and their tags. Nothing else — not zen documents,
+  not source domains.
+- **Item-to-tag edges** come from the item's own tags. Tags act as hubs
+  deliberately: the item-to-item "shares a tag" clique is O(n²) and a
+  300-item tag alone would be roughly 45,000 edges of mush.
+- **Item-to-item edges** are co-mentions: for each zen document, every pair of
+  distinct items its body mentions, weighted by how many documents the pair
+  co-occurs in, capped per document at `MAX_COMENTION_FANOUT` so a link-dump
+  document cannot dominate the layout.
+- **Orphans** are item nodes with degree zero.
+
+The node set is the list's result set. The same search, tag selection,
+favourite and lifecycle filters drive both projections, so switching between
+them never changes membership — only how it is drawn.
+
+### What it must not become
+
+- Nothing is written. No store, no index, no cache that outlives the session,
+  no field on an item or a document.
+- Nothing is synchronized. The graph contributes no mutation, no envelope, and
+  no checkpoint content.
+- Nothing is published. Edges are not a publication field, and the publisher's
+  negative scans are unaffected because there is no artifact to scan.
+- No mutation is offered from it. Dragging a node moves a pixel, not a record.
+  There is no explicit item-to-item link type; adding one would be a new
+  mutation kind and a new sync payload, and would need its own ADR.
+- It is read-only over zen bodies. The graph reads what the reader already
+  reads and resolves mentions the same way.
+
+### Cost of reading bodies
+
+The workspace index deliberately carries no body bytes (ADR 0011), so
+co-mention derivation is the second call that materializes them. It runs only
+while the graph is on screen, and each document's extracted mention list is
+memoized against its replica revision, so an unedited document is read once.
+This is an in-memory memo of derived data, not an index: it does not survive
+the page, and a document that changes is re-read rather than patched.
+
+## Consequences
+
+- The graph is renderer-agnostic by construction. The projection is a plain
+  data structure with unit tests and no drawing concern, so the renderer can
+  be replaced without touching derivation — which is what makes shipping
+  canvas 2D now, rather than a WebGL stack, a reversible decision rather than
+  a commitment.
+- Mentions gain a second reader, so the `research:item/<uuid>` form is now
+  load-bearing in two places. It was already versioned and append-only.
+- Deriving on every projection change costs work proportional to items plus
+  mentions. Above `GRAPH_NODE_CEILING` the view asks for a narrower filter
+  rather than degrading, and the list remains complete either way.
+- Orphan detection gives the library its first answer to "what have I saved
+  and lost?", which is the strongest single argument for the view existing.
+- A future collections or item-link feature will be tempted to persist edges.
+  This ADR is the record that doing so is a separate decision with its own
+  migration, publication, and sync consequences.
+
+## Verification
+
+- The graph's node set equals the list's result set for the same search, tag
+  selection, favourites, and lifecycle filter.
+- An item with no tag and no co-mention is reported as an orphan and can be
+  isolated with one control.
+- Toggling either edge kind changes edges and orphan counts but never the
+  item node set.
+- A document mentioning more items than `MAX_COMENTION_FANOUT` contributes a
+  bounded number of pairs.
+- Closing the graph, or reloading the page, leaves no persisted mention
+  structure: the projection stores nothing and the memo is per-session.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,11 +13,13 @@ import {
   MarkdownDocument,
   type MarkdownImage,
 } from "./components/MarkdownDocument.tsx";
+import { LibraryGraph } from "./components/LibraryGraph.tsx";
 import {
   ZenWorkspace,
   type ZenMentionTarget,
 } from "./components/ZenWorkspace.tsx";
 import type { PersistedZenDocument } from "./data/db";
+import type { GraphMentionSource } from "./data/graph.ts";
 import {
   type LibraryState,
   type CapturedDocumentReference,
@@ -65,6 +67,12 @@ type SearchScope = "all" | "title" | "url" | "context" | "tags";
 type SortMode = "recent" | "oldest" | "title";
 type TagMatchMode = "any" | "all";
 type WorkspaceView = "library" | "settings" | "sync" | "zen";
+/**
+ * Graph is a projection of the library, not a fourth view: the same search,
+ * tags, favourites and lifecycle filter drive both, so switching modes never
+ * changes the result set.
+ */
+type LibraryMode = "list" | "graph";
 type Density = "comfortable" | "compact";
 
 interface ThemeColors {
@@ -87,6 +95,7 @@ interface UndoNotice {
 }
 
 const DENSITY_STORAGE_KEY = "researchpocket.ui.density";
+const LIBRARY_MODE_STORAGE_KEY = "researchpocket.ui.library-mode";
 const THEME_STORAGE_KEY = "researchpocket.ui.theme";
 const IMAGE_BACKGROUND_STORAGE_KEY = "researchpocket.ui.image-background";
 const DEFAULT_IMAGE_BACKGROUND = "#ffffff";
@@ -207,6 +216,10 @@ export function App() {
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [visibleLimit, setVisibleLimit] = useState(LIST_BATCH_SIZE);
   const [view, setView] = useState<WorkspaceView>(() => readWorkspaceView());
+  const [libraryMode, setLibraryMode] = useState<LibraryMode>(() =>
+    readInitialLibraryMode(),
+  );
+  const [zenMentions, setZenMentions] = useState<GraphMentionSource[]>([]);
   const [capturing, setCapturing] = useState(false);
   const [commandOpen, setCommandOpen] = useState(false);
   const [readerItem, setReaderItem] = useState<LibraryItemView | null>(null);
@@ -274,6 +287,42 @@ export function App() {
       // The preference remains active for this tab when storage is unavailable.
     }
   }, [density]);
+
+  // The remembered mode is written into the URL once, on open. After that the
+  // parameter is the only thing that decides, so going back out of the graph
+  // returns to the list instead of being overruled by the preference.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if ((params.get("mode") === "graph" ? "graph" : "list") === libraryMode) return;
+    if (libraryMode === "graph") params.set("mode", "graph");
+    else params.delete("mode");
+    window.history.replaceState(
+      window.history.state,
+      "",
+      formatUrl(params, window.location.hash),
+    );
+    // Runs for the opening preference only; every later change writes its own
+    // history entry through changeLibraryMode.
+  }, []);
+
+  // Co-mention edges are the one part of the graph that is not already in
+  // memory, so the bodies are read only when the graph is actually on screen.
+  useEffect(() => {
+    if (!libraryState.initialized) return;
+    if (view !== "library" || libraryMode !== "graph") return;
+    let active = true;
+    void libraryRepository
+      .listZenMentions()
+      .then((next) => {
+        if (active) setZenMentions(next);
+      })
+      .catch(() => {
+        if (active) setZenMentions([]);
+      });
+    return () => {
+      active = false;
+    };
+  }, [libraryMode, libraryState.initialized, view, zenDocuments]);
 
   useEffect(() => {
     applyThemePreference(theme);
@@ -416,6 +465,10 @@ export function App() {
 
   useEffect(() => {
     function restoreNavigationFromHistory() {
+      // The projection rides the URL, so back out of the graph lands on the
+      // list whichever surface the entry above it was.
+      setLibraryMode(readLibraryModeFromUrl());
+
       const item = window.location.hash.match(/^#item=(.+)$/);
       if (item) {
         const itemId = decodeURIComponent(item[1]!);
@@ -527,6 +580,28 @@ export function App() {
       window.history.pushState(window.history.state, "", nextUrl);
     }
     setView(nextView);
+  }
+
+  /**
+   * Switching projection is a navigation the way opening a document is: the
+   * phone's only back gesture has to return to the list rather than leave the
+   * application, so the change earns its own history entry.
+   */
+  function changeLibraryMode(nextMode: LibraryMode) {
+    if (nextMode === libraryMode) return;
+    setLibraryMode(nextMode);
+    try {
+      window.localStorage.setItem(LIBRARY_MODE_STORAGE_KEY, nextMode);
+    } catch {
+      // The preference remains active for this tab when storage is unavailable.
+    }
+    const params = new URLSearchParams(window.location.search);
+    if (nextMode === "graph") params.set("mode", "graph");
+    else params.delete("mode");
+    const nextUrl = formatUrl(params, window.location.hash);
+    if (nextUrl !== `${window.location.pathname}${window.location.search}${window.location.hash}`) {
+      window.history.pushState(window.history.state, "", nextUrl);
+    }
   }
 
   async function refreshZenDocuments() {
@@ -1017,6 +1092,21 @@ export function App() {
             >
               <span>Archive</span><small>{deletedCount}</small>
             </button>
+            {/* The strip is the phone's whole navigation, and the heading row
+                that carries the desktop's List/Graph control is not on it. */}
+            <button
+              aria-current={
+                view === "library" && libraryMode === "graph" ? "page" : undefined
+              }
+              className="mobile-graph-toggle"
+              onClick={() => {
+                navigateToView("library");
+                changeLibraryMode(libraryMode === "graph" ? "list" : "graph");
+              }}
+              type="button"
+            >
+              <span>Graph</span>
+            </button>
           </nav>
 
           <div className="rail-tags">
@@ -1160,17 +1250,36 @@ export function App() {
               </h2>
               <p className="library-count">{pluralize(visibleItems.length, "item")}</p>
             </div>
+            <div aria-label="Library projection" className="library-mode" role="group">
+              <button
+                aria-pressed={libraryMode === "list"}
+                onClick={() => changeLibraryMode("list")}
+                type="button"
+              >
+                List
+              </button>
+              <button
+                aria-pressed={libraryMode === "graph"}
+                onClick={() => changeLibraryMode("graph")}
+                type="button"
+              >
+                Graph
+              </button>
+            </div>
             {/* Density is a preference, not a toolbar decision, so it lives in
                 Settings and this row keeps only the one control that changes
-                what the list is showing. */}
-            <label className="sort-control">
-              <span className="sr-only">Sort order</span>
-              <select onChange={(event) => setSortMode(event.target.value as SortMode)} value={sortMode}>
-                <option value="recent">newest ↓</option>
-                <option value="oldest">oldest ↑</option>
-                <option value="title">title A–Z</option>
-              </select>
-            </label>
+                what the list is showing. Order is a list idea; the graph has
+                no first row to put anything at the top of. */}
+            {libraryMode === "list" ? (
+              <label className="sort-control">
+                <span className="sr-only">Sort order</span>
+                <select onChange={(event) => setSortMode(event.target.value as SortMode)} value={sortMode}>
+                  <option value="recent">newest ↓</option>
+                  <option value="oldest">oldest ↑</option>
+                  <option value="title">title A–Z</option>
+                </select>
+              </label>
+            ) : null}
           </div>
 
           <Omnibar
@@ -1327,6 +1436,17 @@ export function App() {
 
           {visibleItems.length === 0 ? (
             <EmptyLibrary filter={filter} hasQuery={query.trim().length > 0} />
+          ) : libraryMode === "graph" ? (
+            <LibraryGraph
+              hidden={view !== "library" || readerItem !== null}
+              items={visibleItems}
+              mentions={zenMentions}
+              onFilterTag={toggleTagFilter}
+              onOpenItem={(itemId) => {
+                const item = items.find((candidate) => candidate.id === itemId);
+                if (item) openReader(item);
+              }}
+            />
           ) : (
             <ol className={`item-list item-list-${density}`}>
               {renderedItems.map((item) => (
@@ -1345,7 +1465,7 @@ export function App() {
               ))}
             </ol>
           )}
-          {renderedItems.length < visibleItems.length ? (
+          {libraryMode === "list" && renderedItems.length < visibleItems.length ? (
             <button
               className="list-more"
               onClick={() => setVisibleLimit((current) => current + LIST_BATCH_SIZE)}
@@ -1357,12 +1477,15 @@ export function App() {
           <div aria-atomic="true" aria-live="polite" className="sr-only">
             {searchPending
               ? "Updating library results."
-              : `Showing ${renderedItems.length.toLocaleString()} of ${pluralize(visibleItems.length, "result")}`}
+              : libraryMode === "graph"
+                ? `Graphing ${pluralize(visibleItems.length, "result")}`
+                : `Showing ${renderedItems.length.toLocaleString()} of ${pluralize(visibleItems.length, "result")}`}
           </div>
           <footer className="keyboard-footer">
             <span><b>/</b> search</span>
             <span><b>⌘V</b> save a URL</span>
             <span><b>⏎</b> reader</span>
+            {libraryMode === "graph" ? <span><b>0</b> reframe</span> : null}
           </footer>
           </section>
         </main>
@@ -3689,6 +3812,33 @@ function readWorkspaceView(): WorkspaceView {
  */
 function hashForView(target: WorkspaceView) {
   return target === "zen" ? "" : `#${target}`;
+}
+
+/** Builds a same-document URL, keeping an empty query out of the address bar. */
+function formatUrl(params: URLSearchParams, hash: string) {
+  const search = params.toString();
+  return `${window.location.pathname}${search ? `?${search}` : ""}${hash}`;
+}
+
+/** The URL decides, and it always carries the mode once the app has opened. */
+function readLibraryModeFromUrl(): LibraryMode {
+  return new URLSearchParams(window.location.search).get("mode") === "graph"
+    ? "graph"
+    : "list";
+}
+
+/** Opening reading only: a shared link wins over the remembered preference. */
+function readInitialLibraryMode(): LibraryMode {
+  const parameter = new URLSearchParams(window.location.search).get("mode");
+  if (parameter === "graph") return "graph";
+  if (parameter === "list") return "list";
+  try {
+    return window.localStorage.getItem(LIBRARY_MODE_STORAGE_KEY) === "graph"
+      ? "graph"
+      : "list";
+  } catch {
+    return "list";
+  }
 }
 
 function readDensityPreference(): Density {

--- a/web/src/components/LibraryGraph.tsx
+++ b/web/src/components/LibraryGraph.tsx
@@ -1,0 +1,1408 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  buildGraphProjection,
+  constellationProjection,
+  subgraph,
+  nodeItemId,
+  nodeTagName,
+  GRAPH_MOBILE_NODE_CEILING,
+  GRAPH_NODE_CEILING,
+  type GraphItemInput,
+  type GraphMentionSource,
+  type GraphNode,
+  type GraphProjection,
+} from "../data/graph.ts";
+
+export interface LibraryGraphProps {
+  /** The list's own result set — the graph never shows a different membership. */
+  items: GraphItemInput[];
+  mentions: GraphMentionSource[];
+  /** Paused rather than unmounted, so a mode switch keeps the settled layout. */
+  hidden: boolean;
+  onOpenItem(itemId: string): void;
+  onFilterTag(tag: string): void;
+}
+
+/** A node under simulation. Positions survive a filter change by node id. */
+interface Body {
+  id: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  radius: number;
+  pinned: boolean;
+  node: GraphNode;
+}
+
+interface Palette {
+  canvas: string;
+  item: string;
+  favorite: string;
+  orphan: string;
+  tag: string;
+  tagEdge: string;
+  mentionEdge: string;
+  ring: string;
+  pin: string;
+  label: string;
+  labelStrong: string;
+  tagLabel: string;
+}
+
+const MIN_SCALE = 0.25;
+const MAX_SCALE = 4;
+/** Barnes–Hut opening angle. Higher approximates more and costs less. */
+const THETA = 0.9;
+const REPULSION = 1500;
+/** Ticks a reduced-motion layout settles for before it is frozen and drawn once. */
+const SETTLE_TICKS = 320;
+const MOBILE_QUERY = "(max-width: 48rem)";
+
+export function LibraryGraph({
+  items,
+  mentions,
+  hidden,
+  onOpenItem,
+  onFilterTag,
+}: LibraryGraphProps) {
+  const [showTags, setShowTags] = useState(true);
+  const [showMentions, setShowMentions] = useState(true);
+  const [orphansOnly, setOrphansOnly] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [zoom, setZoom] = useState(1);
+  const [pinnedCount, setPinnedCount] = useState(0);
+  const [narrow, setNarrow] = useState(() => matchesNarrow());
+  const [reducedMotion, setReducedMotion] = useState(() =>
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false,
+  );
+  const [unavailable, setUnavailable] = useState(false);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const full = useMemo(
+    () =>
+      buildGraphProjection(items, mentions, {
+        tagEdges: showTags,
+        mentionEdges: showMentions,
+      }),
+    [items, mentions, showMentions, showTags],
+  );
+
+  // The orphan filter and the phone's constellation are both narrowings of the
+  // one projection, so degree and orphan counts stay honest in each reading.
+  const projection = useMemo(() => {
+    if (orphansOnly) return subgraph(full, new Set(full.orphans));
+    if (narrow) return constellationProjection(full);
+    return full;
+  }, [full, narrow, orphansOnly]);
+
+  const ceiling = narrow ? GRAPH_MOBILE_NODE_CEILING : GRAPH_NODE_CEILING;
+  const overCeiling = projection.nodes.length > ceiling;
+
+  const selected = selectedId
+    ? (projection.nodes.find((node) => node.id === selectedId) ?? null)
+    : null;
+  // Degree order puts the hubs first, which is the order someone stepping
+  // through the graph by keyboard actually wants to meet it in.
+  const traversal = useMemo(
+    () =>
+      [...projection.nodes].sort(
+        (left, right) => right.degree - left.degree || left.label.localeCompare(right.label),
+      ),
+    [projection.nodes],
+  );
+
+  const simulation = useRef<Simulation | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const created = createSimulation(canvas, {
+      onSelect: (id) => setSelectedId(id),
+      onScale: (value) => setZoom(value),
+      onPinnedChange: (count) => setPinnedCount(count),
+      onUnavailable: () => setUnavailable(true),
+    });
+    if (!created) {
+      setUnavailable(true);
+      return;
+    }
+    simulation.current = created;
+    return () => {
+      created.destroy();
+      simulation.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const media = window.matchMedia?.(MOBILE_QUERY);
+    const motion = window.matchMedia?.("(prefers-reduced-motion: reduce)");
+    const onNarrow = () => setNarrow(matchesNarrow());
+    const onMotion = () => setReducedMotion(motion?.matches ?? false);
+    media?.addEventListener("change", onNarrow);
+    motion?.addEventListener("change", onMotion);
+    return () => {
+      media?.removeEventListener("change", onNarrow);
+      motion?.removeEventListener("change", onMotion);
+    };
+  }, []);
+
+  useEffect(() => {
+    simulation.current?.configure({
+      projection: overCeiling ? EMPTY_PROJECTION : projection,
+      narrow,
+      reducedMotion,
+    });
+  }, [narrow, overCeiling, projection, reducedMotion]);
+
+  useEffect(() => {
+    simulation.current?.setSelection(selectedId);
+  }, [selectedId]);
+
+  // Not the active mode, or not the visible tab: the loop stops entirely rather
+  // than drifting against a canvas nobody is looking at.
+  useEffect(() => {
+    const update = () =>
+      simulation.current?.setRunning(!hidden && !document.hidden);
+    update();
+    document.addEventListener("visibilitychange", update);
+    return () => document.removeEventListener("visibilitychange", update);
+  }, [hidden]);
+
+  // `0` reframes the field. It is a window shortcut rather than a canvas one
+  // because the canvas is aria-hidden and so never takes focus itself.
+  useEffect(() => {
+    if (hidden) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== "0" || event.ctrlKey || event.metaKey || event.altKey) return;
+      const target = event.target as HTMLElement | null;
+      if (target?.matches("input, textarea, select") || target?.isContentEditable) {
+        return;
+      }
+      event.preventDefault();
+      simulation.current?.reset();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [hidden]);
+
+  // A selection that the filter just removed would leave the inspector
+  // describing something no longer on screen.
+  useEffect(() => {
+    if (selectedId && !projection.nodes.some((node) => node.id === selectedId)) {
+      setSelectedId(null);
+    }
+  }, [projection.nodes, selectedId]);
+
+  const cursors = useRef(new Map<string, number>());
+
+  function openSelection(node: GraphNode) {
+    const itemId = nodeItemId(node.id);
+    if (itemId) {
+      onOpenItem(itemId);
+      return;
+    }
+    const tag = nodeTagName(node.id);
+    if (tag) onFilterTag(tag);
+  }
+
+  /** Arrow keys walk the neighbours of whatever has focus. */
+  function stepNeighbour(node: GraphNode, direction: 1 | -1) {
+    const neighbours = projection.adjacency.get(node.id) ?? [];
+    if (neighbours.length === 0) return;
+    const cursor = (cursors.current.get(node.id) ?? -1) + direction;
+    const index = ((cursor % neighbours.length) + neighbours.length) % neighbours.length;
+    cursors.current.set(node.id, index);
+    const target = neighbours[index]!.id;
+    setSelectedId(target);
+    simulation.current?.center(target);
+    document.getElementById(nodeButtonId(target))?.focus();
+  }
+
+  // The node list is one button per node — up to the ceiling — so it must not
+  // re-render for state the canvas owns. Zoom alone changes on every wheel
+  // tick, and reconciling thousands of buttons against it would cost more than
+  // the frame it is competing with. Handlers go through a ref so the list can
+  // depend on the projection and nothing else.
+  const actions = useRef({ openSelection, stepNeighbour, select: setSelectedId });
+  actions.current = { openSelection, stepNeighbour, select: setSelectedId };
+
+  const nodeList = useMemo(
+    () => (
+      <ul
+        aria-label="Graph nodes in degree order"
+        className={unavailable ? "graph-nodes" : "graph-nodes sr-only"}
+      >
+        {traversal.map((node) => (
+          <li key={node.id}>
+            <button
+              id={nodeButtonId(node.id)}
+              onClick={() => {
+                actions.current.select(node.id);
+                simulation.current?.center(node.id);
+              }}
+              onFocus={() => actions.current.select(node.id)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  actions.current.openSelection(node);
+                  return;
+                }
+                if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+                  event.preventDefault();
+                  actions.current.stepNeighbour(node, 1);
+                  return;
+                }
+                if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+                  event.preventDefault();
+                  actions.current.stepNeighbour(node, -1);
+                }
+              }}
+              type="button"
+            >
+              {describeNode(node)}
+            </button>
+          </li>
+        ))}
+      </ul>
+    ),
+    [traversal, unavailable],
+  );
+
+  return (
+    <div className="library-graph">
+      <div className="graph-toolbar">
+        <button
+          aria-pressed={showTags}
+          onClick={() => setShowTags((value) => !value)}
+          type="button"
+        >
+          tag links · {showTags ? "on" : "off"}
+        </button>
+        <button
+          aria-pressed={showMentions}
+          onClick={() => setShowMentions((value) => !value)}
+          type="button"
+        >
+          co-mentions · {showMentions ? "on" : "off"}
+        </button>
+        <button
+          aria-pressed={orphansOnly}
+          onClick={() => setOrphansOnly((value) => !value)}
+          type="button"
+        >
+          orphans · {orphansOnly ? "only" : full.orphans.length}
+        </button>
+        {pinnedCount > 0 ? (
+          <button
+            className="graph-release"
+            onClick={() => simulation.current?.releaseAll()}
+            type="button"
+          >
+            release {pinnedCount} pinned
+          </button>
+        ) : null}
+      </div>
+
+      <div className="graph-body">
+        <div className="graph-stage">
+          <canvas
+            aria-hidden="true"
+            className="graph-canvas"
+            hidden={overCeiling || unavailable}
+            ref={canvasRef}
+          />
+
+          {overCeiling ? (
+            <p className="graph-notice">
+              <strong>
+                {projection.nodes.length.toLocaleString()} nodes is more than the
+                graph draws at once.
+              </strong>
+              <span>
+                Narrow the result set — a search, a tag, or favourites — and the
+                layout will re-form around what is left. The list shows all of
+                them either way.
+              </span>
+            </p>
+          ) : null}
+
+          {unavailable && !overCeiling ? (
+            <p className="graph-notice">
+              <strong>This browser could not open a drawing surface.</strong>
+              <span>
+                The graph is listed below instead: every node, in degree order,
+                with the same neighbourhoods.
+              </span>
+            </p>
+          ) : null}
+
+          {!overCeiling && !unavailable ? (
+            <>
+              <p className="graph-stats">
+                <span>{projection.nodes.length.toLocaleString()} nodes</span>
+                <span aria-hidden="true">·</span>
+                <span>{projection.edges.length.toLocaleString()} edges</span>
+                <span aria-hidden="true">·</span>
+                <span className="graph-orphan-count">
+                  {full.orphans.length.toLocaleString()} orphans
+                </span>
+              </p>
+
+              <dl className="graph-legend">
+                <div>
+                  <dt aria-hidden="true" className="graph-key graph-key-item">
+                    ●
+                  </dt>
+                  <dd>saved item</dd>
+                </div>
+                <div>
+                  <dt aria-hidden="true" className="graph-key graph-key-favorite">
+                    ●
+                  </dt>
+                  <dd>favorite</dd>
+                </div>
+                <div>
+                  <dt aria-hidden="true" className="graph-key graph-key-tag">
+                    ■
+                  </dt>
+                  <dd>tag hub</dd>
+                </div>
+                <div>
+                  <dt className="graph-key graph-key-tag-edge" />
+                  <dd>tag membership</dd>
+                </div>
+                <div>
+                  <dt className="graph-key graph-key-mention-edge" />
+                  <dd>co-mentioned in a Zen doc</dd>
+                </div>
+              </dl>
+
+              <div className="graph-zoom">
+                <button
+                  aria-label="Zoom out"
+                  onClick={() => simulation.current?.zoomBy(0.8)}
+                  type="button"
+                >
+                  −
+                </button>
+                <span>{Math.round(zoom * 100)}%</span>
+                <button
+                  aria-label="Zoom in"
+                  onClick={() => simulation.current?.zoomBy(1.25)}
+                  type="button"
+                >
+                  +
+                </button>
+                <button onClick={() => simulation.current?.reset()} type="button">
+                  reset
+                </button>
+              </div>
+            </>
+          ) : null}
+
+          {/* The canvas is not the only route through the graph. This list is
+              the keyboard's, and it is what stands in for the drawing when a
+              browser cannot give us one. What is selected is announced by the
+              inspector, which is the accessible name for the selection. */}
+          {nodeList}
+        </div>
+
+        <aside className="graph-inspector">
+          <div className="graph-inspector-heading">
+            <p>Selected</p>
+            <span>{selected ? kindLabel(selected) : "—"}</span>
+          </div>
+
+          {/* The selection is announced here rather than marked on the node
+              list, so keyboard traversal reads the save it lands on. */}
+          <div aria-live="polite" className="graph-inspector-subject" role="status">
+            <p className="graph-inspector-title">
+              {selected ? nodeTitle(selected) : "Nothing selected"}
+            </p>
+            <p className="graph-inspector-meta">
+              {selected ? nodeMeta(selected, items) : "Choose a node to read it"}
+            </p>
+            {selected ? (
+              <div className="graph-inspector-tags">
+                {tagsFor(selected, items).map((tag) => (
+                  <span key={tag}>#{tag}</span>
+                ))}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="graph-inspector-actions">
+            <button
+              className="primary-button"
+              disabled={!selected}
+              onClick={() => selected && openSelection(selected)}
+              type="button"
+            >
+              {selected?.kind === "tag" ? "Filter" : "Open"}
+            </button>
+            <button
+              className="secondary-button"
+              disabled={!selected}
+              onClick={() => selected && simulation.current?.center(selected.id)}
+              type="button"
+            >
+              Center
+            </button>
+          </div>
+
+          <div className="graph-neighbourhood">
+            <div className="graph-inspector-heading">
+              <p>Neighbourhood</p>
+              <span>{selected ? `${selected.degree} links` : "0"}</span>
+            </div>
+            <ol>
+              {(selected ? (projection.adjacency.get(selected.id) ?? []) : [])
+                .slice(0, 24)
+                .map((neighbour, index) => {
+                  const target = projection.nodes.find(
+                    (node) => node.id === neighbour.id,
+                  );
+                  if (!target) return null;
+                  return (
+                    <li key={`${neighbour.id}-${index}`}>
+                      <button
+                        onClick={() => {
+                          setSelectedId(target.id);
+                          simulation.current?.center(target.id);
+                        }}
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          className={`graph-glyph graph-glyph-${neighbour.kind === "mention" ? "mention" : target.kind}`}
+                        >
+                          {neighbour.kind === "mention"
+                            ? "◇"
+                            : target.kind === "tag"
+                              ? "■"
+                              : "●"}
+                        </span>
+                        <span>{nodeTitle(target)}</span>
+                      </button>
+                    </li>
+                  );
+                })}
+            </ol>
+          </div>
+
+          <p className="graph-inspector-footnote">
+            Edges are derived, never stored: tag membership from the item,
+            co-mentions from <span>research:item/…</span> links inside Zen
+            documents.
+          </p>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+const EMPTY_PROJECTION: GraphProjection = {
+  nodes: [],
+  edges: [],
+  orphans: [],
+  adjacency: new Map(),
+};
+
+function matchesNarrow(): boolean {
+  return window.matchMedia?.(MOBILE_QUERY).matches ?? false;
+}
+
+function nodeButtonId(id: string): string {
+  return `graph-node-${id.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+}
+
+function nodeTitle(node: GraphNode): string {
+  return node.kind === "tag" ? `#${node.label}` : node.label;
+}
+
+function kindLabel(node: GraphNode): string {
+  if (node.kind === "tag") return "tag";
+  return node.degree === 0 ? "orphan" : "saved item";
+}
+
+function describeNode(node: GraphNode): string {
+  return `${nodeTitle(node)} — ${kindLabel(node)}, ${node.degree} ${node.degree === 1 ? "link" : "links"}`;
+}
+
+function sourceItem(node: GraphNode, items: GraphItemInput[]) {
+  const itemId = nodeItemId(node.id);
+  return itemId ? items.find((item) => item.id === itemId) : undefined;
+}
+
+function tagsFor(node: GraphNode, items: GraphItemInput[]): string[] {
+  return sourceItem(node, items)?.tags ?? [];
+}
+
+function nodeMeta(node: GraphNode, items: GraphItemInput[]): string {
+  if (node.kind === "tag") {
+    return `${node.count.toLocaleString()} ${node.count === 1 ? "save carries" : "saves carry"} this tag · tag hub`;
+  }
+  const item = sourceItem(node, items);
+  if (!item) return "saved item";
+  const saved = node.savedAt
+    ? new Intl.DateTimeFormat(undefined, { day: "numeric", month: "short" }).format(
+        new Date(node.savedAt),
+      )
+    : "recently";
+  return `${hostname(item.url)} · saved ${saved}${item.favorite ? " · ★ favorite" : ""}`;
+}
+
+function hostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return "saved link";
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Simulation and renderer
+ *
+ * Canvas 2D rather than WebGL: every node treatment the design asks for —
+ * the square tag hub, the favourite fill, the selection ring, the pinned ring
+ * — is a shader program under a WebGL renderer and two lines of context calls
+ * here, and the projection above stays renderer-agnostic either way.
+ * ------------------------------------------------------------------ */
+
+interface SimulationHandlers {
+  onSelect(id: string | null): void;
+  onScale(scale: number): void;
+  onPinnedChange(count: number): void;
+  onUnavailable(): void;
+}
+
+interface SimulationConfig {
+  projection: GraphProjection;
+  narrow: boolean;
+  reducedMotion: boolean;
+}
+
+interface Simulation {
+  configure(config: SimulationConfig): void;
+  setSelection(id: string | null): void;
+  setRunning(running: boolean): void;
+  center(id: string): void;
+  zoomBy(factor: number): void;
+  reset(): void;
+  releaseAll(): void;
+  destroy(): void;
+}
+
+function createSimulation(
+  canvas: HTMLCanvasElement,
+  handlers: SimulationHandlers,
+): Simulation | null {
+  let context = canvas.getContext("2d");
+  if (!context) return null;
+
+  const bodies = new Map<string, Body>();
+  let order: Body[] = [];
+  let projection: GraphProjection = EMPTY_PROJECTION;
+  let narrow = false;
+  let reducedMotion = false;
+  let palette = readPalette();
+  let width = 0;
+  let height = 0;
+  let dpr = window.devicePixelRatio || 1;
+  let scale = 1;
+  let translateX = 0;
+  let translateY = 0;
+  let hover: string | null = null;
+  let selection: string | null = null;
+  let ticks = 0;
+  let frozen = false;
+  let running = false;
+  let fitPending = true;
+  let warmed = false;
+  /** The running loop's handle, kept apart from the one-shot redraw's. */
+  let frame = 0;
+  let drawFrame = 0;
+  let fontsReady = false;
+  let drag: { body: Body; dx: number; dy: number; moved: boolean } | null = null;
+  let pan: { x: number; y: number } | null = null;
+  const pointers = new Map<number, { x: number; y: number }>();
+  let pinch: { distance: number; scale: number } | null = null;
+
+  void document.fonts?.ready.then(() => {
+    fontsReady = true;
+    requestDraw();
+  });
+
+  /* ---- transform ---- */
+
+  const toWorld = (clientX: number, clientY: number) => {
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: (clientX - rect.left - width / 2 - translateX) / scale,
+      y: (clientY - rect.top - height / 2 - translateY) / scale,
+    };
+  };
+
+  const project = (body: Body) => ({
+    x: body.x * scale + width / 2 + translateX,
+    y: body.y * scale + height / 2 + translateY,
+  });
+
+  function pick(worldX: number, worldY: number): Body | null {
+    let best: Body | null = null;
+    let bestDistance = Infinity;
+    for (const body of order) {
+      const dx = body.x - worldX;
+      const dy = body.y - worldY;
+      const distance = dx * dx + dy * dy;
+      const reach = (body.radius + 8 / scale) ** 2;
+      if (distance < reach && distance < bestDistance) {
+        best = body;
+        bestDistance = distance;
+      }
+    }
+    return best;
+  }
+
+  /* ---- sizing ---- */
+
+  const resize = () => {
+    const rect = canvas.getBoundingClientRect();
+    if (!rect.width || !rect.height) return;
+    width = rect.width;
+    height = rect.height;
+    dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.round(rect.width * dpr);
+    canvas.height = Math.round(rect.height * dpr);
+    fitPending = true;
+    thaw();
+  };
+  const observer = new ResizeObserver(resize);
+  observer.observe(canvas);
+  resize();
+
+  /* ---- lifecycle ---- */
+
+  function thaw() {
+    // Any interaction un-freezes a settled layout for long enough to redraw.
+    frozen = false;
+    if (!running) {
+      requestDraw();
+      return;
+    }
+    if (frame === 0) frame = requestAnimationFrame(loop);
+  }
+
+  /** A single frame, for a paused or settled graph that still has to repaint. */
+  function requestDraw() {
+    if (drawFrame !== 0) return;
+    drawFrame = requestAnimationFrame(() => {
+      drawFrame = 0;
+      draw();
+    });
+  }
+
+  function loop() {
+    frame = 0;
+    if (!running) return;
+    const settled = reducedMotion && ticks > SETTLE_TICKS;
+    if (!settled) {
+      step();
+      ticks += 1;
+      if (fitPending && ticks > (warmed ? 8 : 150)) fit();
+    } else {
+      frozen = true;
+    }
+    draw();
+    if (!frozen) frame = requestAnimationFrame(loop);
+  }
+
+  /* ---- forces ---- */
+
+  function step() {
+    if (order.length === 0) return;
+
+    const tree = order.length > 48 ? buildQuadtree(order) : null;
+    for (const body of order) {
+      if (tree) applyRepulsion(tree, body);
+      else {
+        for (const other of order) {
+          if (other === body) continue;
+          repel(body, other.x, other.y, 1);
+        }
+      }
+    }
+
+    for (const edge of projection.edges) {
+      const from = bodies.get(edge.source);
+      const to = bodies.get(edge.target);
+      if (!from || !to) continue;
+      // Co-mentions pull tighter than tag membership: a pair someone wrote about
+      // together is a stronger statement than a tag they both happen to carry.
+      const target =
+        edge.kind === "mention" ? (narrow ? 42 : 56) : narrow ? 58 : 82;
+      const dx = to.x - from.x;
+      const dy = to.y - from.y;
+      const distance = Math.max(1, Math.hypot(dx, dy));
+      const strength =
+        ((distance - target) * (edge.kind === "mention" ? 0.014 : 0.02)) /
+        Math.max(1, Math.log2(1 + edge.weight));
+      from.vx += (dx / distance) * strength;
+      from.vy += (dy / distance) * strength;
+      to.vx -= (dx / distance) * strength;
+      to.vy -= (dy / distance) * strength;
+    }
+
+    const drifting = !reducedMotion;
+    for (const body of order) {
+      body.vx -= body.x * 0.0022;
+      body.vy -= body.y * 0.0026;
+      if (drifting) {
+        // The design system bans CSS motion, so the graph's aliveness has to
+        // live in the pixels. This is that: a permanent, tiny unrest.
+        body.vx += (Math.random() - 0.5) * 0.09;
+        body.vy += (Math.random() - 0.5) * 0.09;
+      }
+      body.vx *= 0.86;
+      body.vy *= 0.86;
+      const speed = Math.hypot(body.vx, body.vy);
+      if (speed > 6) {
+        body.vx = (body.vx / speed) * 6;
+        body.vy = (body.vy / speed) * 6;
+      }
+      if (!body.pinned || drag?.body === body) {
+        body.x += body.vx;
+        body.y += body.vy;
+      }
+    }
+
+    // Soft walls at the frame edge: the drift stays alive, but nothing is
+    // allowed to wander out of the panel and become unreachable.
+    if (warmed) {
+      const limitX = Math.max(60, (width / 2 - 26) / scale);
+      const limitY = Math.max(60, (height / 2 - 26) / scale);
+      for (const body of order) {
+        if (Math.abs(body.x) > limitX) {
+          body.vx -= (body.x - Math.sign(body.x) * limitX) * 0.05;
+        }
+        if (Math.abs(body.y) > limitY) {
+          body.vy -= (body.y - Math.sign(body.y) * limitY) * 0.05;
+        }
+      }
+    }
+  }
+
+  function repel(body: Body, x: number, y: number, mass: number) {
+    let dx = body.x - x;
+    let dy = body.y - y;
+    let squared = dx * dx + dy * dy;
+    if (squared < 1) {
+      // Two bodies exactly on top of each other have no direction to separate
+      // along, so one is invented deterministically from the id.
+      dx = ((body.id.charCodeAt(0) % 3) - 1) || 0.7;
+      dy = ((body.id.charCodeAt(1) % 3) - 1) || 0.7;
+      squared = 2;
+    }
+    if (squared > 90_000) return;
+    const distance = Math.sqrt(squared);
+    const force = (REPULSION * mass) / squared;
+    body.vx += (dx / distance) * force;
+    body.vy += (dy / distance) * force;
+  }
+
+  function applyRepulsion(cell: Cell, body: Body) {
+    if (cell.mass === 0) return;
+    const dx = cell.cx - body.x;
+    const dy = cell.cy - body.y;
+    const distance = Math.hypot(dx, dy);
+    if (cell.children === null) {
+      if (cell.body && cell.body !== body) repel(body, cell.cx, cell.cy, cell.mass);
+      return;
+    }
+    // Far enough that the whole cell can stand in for its contents.
+    if (cell.size / Math.max(distance, 0.001) < THETA) {
+      repel(body, cell.cx, cell.cy, cell.mass);
+      return;
+    }
+    for (const child of cell.children) {
+      if (child) applyRepulsion(child, body);
+    }
+  }
+
+  /* ---- framing ---- */
+
+  function fit() {
+    if (order.length === 0 || !width) return;
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const body of order) {
+      if (body.x < minX) minX = body.x;
+      if (body.y < minY) minY = body.y;
+      if (body.x > maxX) maxX = body.x;
+      if (body.y > maxY) maxY = body.y;
+    }
+    // Labels are drawn to the right of their node and are not in the bounds,
+    // so the frame is padded for them. A phone shows tag labels only, but it
+    // is also where there is least room for one to run off the edge.
+    const pad = narrow ? 64 : 96;
+    const boundsWidth = Math.max(60, maxX - minX);
+    const boundsHeight = Math.max(60, maxY - minY);
+    const next = Math.max(
+      MIN_SCALE,
+      Math.min((width - pad * 2) / boundsWidth, (height - pad * 2) / boundsHeight, 1.4),
+    );
+    scale = next;
+    translateX = -((minX + maxX) / 2) * scale;
+    translateY = -((minY + maxY) / 2) * scale;
+    fitPending = false;
+    warmed = true;
+    handlers.onScale(scale);
+  }
+
+  /* ---- drawing ---- */
+
+  function draw() {
+    if (!context || !width) return;
+    context.setTransform(dpr, 0, 0, dpr, 0, 0);
+    context.clearRect(0, 0, width, height);
+    context.fillStyle = palette.canvas;
+    context.fillRect(0, 0, width, height);
+
+    const focus = hover ?? selection;
+    const near = new Set<string>();
+    if (focus) {
+      near.add(focus);
+      for (const neighbour of projection.adjacency.get(focus) ?? []) {
+        near.add(neighbour.id);
+      }
+    }
+    // Only a hover dims the field. A selection that dimmed everything else
+    // would leave the graph unreadable for as long as something is selected.
+    const dimming = hover !== null;
+
+    context.lineWidth = 1;
+    for (const edge of projection.edges) {
+      const from = bodies.get(edge.source);
+      const to = bodies.get(edge.target);
+      if (!from || !to) continue;
+      const lit = !dimming || (near.has(edge.source) && near.has(edge.target));
+      context.strokeStyle =
+        edge.kind === "mention" ? palette.mentionEdge : palette.tagEdge;
+      context.globalAlpha = lit ? (edge.kind === "mention" ? 0.8 : 0.55) : 0.12;
+      const a = project(from);
+      const b = project(to);
+      context.beginPath();
+      context.moveTo(a.x, a.y);
+      context.lineTo(b.x, b.y);
+      context.stroke();
+    }
+    context.globalAlpha = 1;
+
+    const labels: { body: Body; x: number; y: number; radius: number; strong: boolean }[] =
+      [];
+    for (const body of order) {
+      const point = project(body);
+      const lit = !dimming || near.has(body.id);
+      const isSelected = body.id === selection;
+      const radius = Math.max(2.5, body.radius * Math.min(1.4, scale));
+      context.globalAlpha = lit ? 1 : 0.18;
+
+      if (body.node.kind === "tag") {
+        context.fillStyle = palette.tag;
+        context.fillRect(point.x - radius, point.y - radius, radius * 2, radius * 2);
+        context.strokeStyle = isSelected ? palette.ring : palette.canvas;
+        context.lineWidth = isSelected ? 2 : 1;
+        context.strokeRect(point.x - radius, point.y - radius, radius * 2, radius * 2);
+      } else {
+        context.beginPath();
+        context.arc(point.x, point.y, radius, 0, Math.PI * 2);
+        context.fillStyle = body.node.favorite
+          ? palette.favorite
+          : body.node.degree > 0
+            ? palette.item
+            : palette.orphan;
+        context.fill();
+        if (isSelected) {
+          context.strokeStyle = palette.ring;
+          context.lineWidth = 2;
+          context.beginPath();
+          context.arc(point.x, point.y, radius + 3.5, 0, Math.PI * 2);
+          context.stroke();
+        }
+        if (body.pinned) {
+          context.strokeStyle = palette.pin;
+          context.lineWidth = 1;
+          context.beginPath();
+          context.arc(point.x, point.y, radius + 2, 0, Math.PI * 2);
+          context.stroke();
+        }
+      }
+
+      // Labels are the expensive part, so they are rationed: tag hubs always
+      // (they are what makes a cluster readable), items only when they are the
+      // subject or the view is zoomed in far enough to have room.
+      const wanted =
+        body.node.kind === "tag"
+          ? true
+          : !narrow &&
+            (body.id === focus || body.id === selection || (!dimming && scale > 1.5));
+      if (wanted && (!dimming || near.has(body.id))) {
+        labels.push({
+          body,
+          x: point.x,
+          y: point.y,
+          radius,
+          strong: body.id === focus || body.id === selection,
+        });
+      }
+    }
+    context.globalAlpha = 1;
+
+    if (fontsReady) {
+      context.textBaseline = "middle";
+      for (const label of labels) {
+        const text = nodeTitle(label.body.node);
+        const limit = narrow ? 16 : 42;
+        const clipped = text.length > limit ? `${text.slice(0, limit - 1)}…` : text;
+        context.font = `${label.strong ? "700 " : ""}11px "TX-02", ui-monospace, monospace`;
+        const measured = context.measureText(clipped).width;
+        // A plate behind the text, or a label crossing three edges is unreadable.
+        context.fillStyle = palette.canvas;
+        context.globalAlpha = 0.82;
+        context.fillRect(label.x + label.radius + 4, label.y - 7, measured + 6, 14);
+        context.globalAlpha = 1;
+        context.fillStyle =
+          label.body.node.kind === "tag"
+            ? palette.tagLabel
+            : label.strong
+              ? palette.labelStrong
+              : palette.label;
+        context.fillText(clipped, label.x + label.radius + 7, label.y);
+      }
+    }
+  }
+
+  /* ---- pointer input ---- */
+
+  const onPointerDown = (event: PointerEvent) => {
+    pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+    if (pointers.size === 2) {
+      pinch = { distance: pointerDistance(), scale };
+      drag = null;
+      pan = null;
+      return;
+    }
+    canvas.setPointerCapture(event.pointerId);
+    const point = toWorld(event.clientX, event.clientY);
+    const hit = pick(point.x, point.y);
+    if (hit) {
+      selection = hit.id;
+      handlers.onSelect(hit.id);
+      // Drag-to-pin is a mouse gesture. On a phone the same press is a tap to
+      // read, and a finger that wanders must not silently pin the node.
+      if (!narrow) {
+        drag = { body: hit, dx: hit.x - point.x, dy: hit.y - point.y, moved: false };
+      }
+    } else {
+      pan = { x: event.clientX - translateX, y: event.clientY - translateY };
+    }
+    thaw();
+  };
+
+  const onPointerMove = (event: PointerEvent) => {
+    if (pointers.has(event.pointerId)) {
+      pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+    }
+    if (pinch && pointers.size === 2) {
+      const distance = pointerDistance();
+      if (pinch.distance > 0) {
+        setScale((pinch.scale * distance) / pinch.distance);
+      }
+      return;
+    }
+    if (drag) {
+      const point = toWorld(event.clientX, event.clientY);
+      drag.body.x = point.x + drag.dx;
+      drag.body.y = point.y + drag.dy;
+      drag.body.vx = 0;
+      drag.body.vy = 0;
+      drag.moved = true;
+      thaw();
+      return;
+    }
+    if (pan) {
+      translateX = event.clientX - pan.x;
+      translateY = event.clientY - pan.y;
+      thaw();
+      return;
+    }
+    const point = toWorld(event.clientX, event.clientY);
+    const hit = pick(point.x, point.y);
+    const next = hit?.id ?? null;
+    if (next !== hover) {
+      hover = next;
+      canvas.style.cursor = hit ? "pointer" : "default";
+      thaw();
+    }
+  };
+
+  const onPointerUp = (event: PointerEvent) => {
+    pointers.delete(event.pointerId);
+    if (pointers.size < 2) pinch = null;
+    if (canvas.hasPointerCapture(event.pointerId)) {
+      canvas.releasePointerCapture(event.pointerId);
+    }
+    if (drag?.moved) {
+      drag.body.pinned = true;
+      reportPinned();
+    }
+    drag = null;
+    pan = null;
+  };
+
+  const onPointerLeave = () => {
+    if (hover !== null) {
+      hover = null;
+      thaw();
+    }
+  };
+
+  const onDoubleClick = (event: MouseEvent) => {
+    const point = toWorld(event.clientX, event.clientY);
+    const hit = pick(point.x, point.y);
+    if (hit?.pinned) {
+      hit.pinned = false;
+      reportPinned();
+      thaw();
+    }
+  };
+
+  const onWheel = (event: WheelEvent) => {
+    event.preventDefault();
+    // Anchored at the pointer, so zooming reads as moving toward what is under
+    // the cursor rather than toward the middle of the panel.
+    const rect = canvas.getBoundingClientRect();
+    const anchorX = event.clientX - rect.left - width / 2;
+    const anchorY = event.clientY - rect.top - height / 2;
+    const worldX = (anchorX - translateX) / scale;
+    const worldY = (anchorY - translateY) / scale;
+    const next = clampScale(scale * (event.deltaY < 0 ? 1.08 : 0.93));
+    translateX = anchorX - worldX * next;
+    translateY = anchorY - worldY * next;
+    scale = next;
+    handlers.onScale(next);
+    thaw();
+  };
+
+  const onContextLost = (event: Event) => {
+    event.preventDefault();
+    frozen = true;
+  };
+
+  const onContextRestored = () => {
+    context = canvas.getContext("2d");
+    if (!context) {
+      handlers.onUnavailable();
+      return;
+    }
+    palette = readPalette();
+    thaw();
+  };
+
+  function pointerDistance(): number {
+    const [first, second] = [...pointers.values()];
+    if (!first || !second) return 0;
+    return Math.hypot(first.x - second.x, first.y - second.y);
+  }
+
+  function setScale(value: number) {
+    scale = clampScale(value);
+    handlers.onScale(scale);
+    thaw();
+  }
+
+  function reportPinned() {
+    let count = 0;
+    for (const body of order) if (body.pinned) count += 1;
+    handlers.onPinnedChange(count);
+  }
+
+  canvas.addEventListener("pointerdown", onPointerDown);
+  canvas.addEventListener("pointermove", onPointerMove);
+  canvas.addEventListener("pointerup", onPointerUp);
+  canvas.addEventListener("pointercancel", onPointerUp);
+  canvas.addEventListener("pointerleave", onPointerLeave);
+  canvas.addEventListener("dblclick", onDoubleClick);
+  canvas.addEventListener("wheel", onWheel, { passive: false });
+  canvas.addEventListener("contextlost", onContextLost);
+  canvas.addEventListener("contextrestored", onContextRestored);
+
+  // A theme change rewrites custom properties on the root element; the canvas
+  // has no cascade to inherit from, so it re-reads them when they move.
+  const themeObserver = new MutationObserver(() => {
+    palette = readPalette();
+    thaw();
+  });
+  themeObserver.observe(document.documentElement, {
+    attributeFilter: ["style"],
+  });
+
+  return {
+    configure(config) {
+      projection = config.projection;
+      narrow = config.narrow;
+      reducedMotion = config.reducedMotion;
+
+      const next: Body[] = [];
+      const keep = new Set<string>();
+      for (const node of projection.nodes) {
+        keep.add(node.id);
+        const existing = bodies.get(node.id);
+        if (existing) {
+          existing.node = node;
+          existing.radius = radiusFor(node);
+          next.push(existing);
+          continue;
+        }
+        const seeded = seedPosition(node.id);
+        const body: Body = {
+          id: node.id,
+          x: seeded.x,
+          y: seeded.y,
+          vx: 0,
+          vy: 0,
+          radius: radiusFor(node),
+          pinned: false,
+          node,
+        };
+        bodies.set(node.id, body);
+        next.push(body);
+      }
+      // A node the filter removed leaves the simulation rather than hiding, so
+      // the layout re-forms around what is left.
+      for (const id of [...bodies.keys()]) {
+        if (!keep.has(id)) bodies.delete(id);
+      }
+      order = next;
+      ticks = 0;
+      fitPending = true;
+      reportPinned();
+      thaw();
+    },
+    setSelection(id) {
+      selection = id;
+      thaw();
+    },
+    setRunning(value) {
+      if (running === value) return;
+      running = value;
+      if (running) {
+        frozen = false;
+        if (frame === 0) frame = requestAnimationFrame(loop);
+      } else if (frame !== 0) {
+        cancelAnimationFrame(frame);
+        frame = 0;
+      }
+    },
+    center(id) {
+      const body = bodies.get(id);
+      if (!body) return;
+      translateX = -body.x * scale;
+      translateY = -body.y * scale;
+      thaw();
+    },
+    zoomBy(factor) {
+      setScale(scale * factor);
+    },
+    reset() {
+      fitPending = true;
+      warmed = true;
+      fit();
+      thaw();
+    },
+    releaseAll() {
+      for (const body of order) body.pinned = false;
+      reportPinned();
+      thaw();
+    },
+    destroy() {
+      if (frame !== 0) cancelAnimationFrame(frame);
+      if (drawFrame !== 0) cancelAnimationFrame(drawFrame);
+      frame = 0;
+      drawFrame = 0;
+      running = false;
+      observer.disconnect();
+      themeObserver.disconnect();
+      canvas.removeEventListener("pointerdown", onPointerDown);
+      canvas.removeEventListener("pointermove", onPointerMove);
+      canvas.removeEventListener("pointerup", onPointerUp);
+      canvas.removeEventListener("pointercancel", onPointerUp);
+      canvas.removeEventListener("pointerleave", onPointerLeave);
+      canvas.removeEventListener("dblclick", onDoubleClick);
+      canvas.removeEventListener("wheel", onWheel);
+      canvas.removeEventListener("contextlost", onContextLost);
+      canvas.removeEventListener("contextrestored", onContextRestored);
+      bodies.clear();
+      order = [];
+    },
+  };
+}
+
+function clampScale(value: number): number {
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, value));
+}
+
+function radiusFor(node: GraphNode): number {
+  // Tag hubs are count-weighted so a cluster's weight is legible before its
+  // label is; items stay uniform, because a save is a save.
+  return node.kind === "tag" ? 5 + Math.min(5, node.count * 0.6) : 4.5;
+}
+
+/**
+ * A node's opening position is a function of its id, so the same library opens
+ * to the same layout instead of a different scatter on every mount.
+ */
+function seedPosition(id: string): { x: number; y: number } {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < id.length; index += 1) {
+    hash ^= id.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  const angle = ((hash & 0xffff) / 0xffff) * Math.PI * 2;
+  const radius = 40 + ((hash >>> 16) / 0xffff) * 260;
+  return { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius };
+}
+
+/* ---- Barnes–Hut ---- */
+
+interface Cell {
+  cx: number;
+  cy: number;
+  mass: number;
+  size: number;
+  body: Body | null;
+  children: (Cell | null)[] | null;
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+}
+
+/**
+ * Repulsion is the only O(n²) force here, so it goes through a quadtree.
+ * Without it the 2,000-node budget is four million pair tests a frame.
+ */
+function buildQuadtree(bodies: Body[]): Cell {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const body of bodies) {
+    if (body.x < minX) minX = body.x;
+    if (body.y < minY) minY = body.y;
+    if (body.x > maxX) maxX = body.x;
+    if (body.y > maxY) maxY = body.y;
+  }
+  const size = Math.max(maxX - minX, maxY - minY, 1) + 2;
+  const root = makeCell(minX - 1, minY - 1, minX - 1 + size, minY - 1 + size);
+  for (const body of bodies) insert(root, body, 0);
+  return root;
+}
+
+function makeCell(x0: number, y0: number, x1: number, y1: number): Cell {
+  return {
+    cx: 0,
+    cy: 0,
+    mass: 0,
+    size: x1 - x0,
+    body: null,
+    children: null,
+    x0,
+    y0,
+    x1,
+    y1,
+  };
+}
+
+function insert(cell: Cell, body: Body, depth: number): void {
+  // Center of mass is accumulated on the way down, so no second pass is needed.
+  cell.cx = (cell.cx * cell.mass + body.x) / (cell.mass + 1);
+  cell.cy = (cell.cy * cell.mass + body.y) / (cell.mass + 1);
+  cell.mass += 1;
+
+  if (cell.children === null) {
+    if (cell.body === null) {
+      cell.body = body;
+      return;
+    }
+    // Coincident bodies would subdivide forever, so depth is the backstop.
+    if (depth > 20) return;
+    const existing = cell.body;
+    cell.body = null;
+    cell.children = [null, null, null, null];
+    place(cell, existing, depth);
+    place(cell, body, depth);
+    return;
+  }
+  place(cell, body, depth);
+}
+
+function place(cell: Cell, body: Body, depth: number): void {
+  const midX = (cell.x0 + cell.x1) / 2;
+  const midY = (cell.y0 + cell.y1) / 2;
+  const east = body.x >= midX;
+  const south = body.y >= midY;
+  const index = (south ? 2 : 0) + (east ? 1 : 0);
+  const children = cell.children!;
+  let child = children[index] ?? null;
+  if (!child) {
+    child = makeCell(
+      east ? midX : cell.x0,
+      south ? midY : cell.y0,
+      east ? cell.x1 : midX,
+      south ? cell.y1 : midY,
+    );
+    children[index] = child;
+  }
+  insert(child, body, depth + 1);
+}
+
+/* ---- palette ---- */
+
+/**
+ * The canvas has no cascade, so every colour is resolved out of the token
+ * system through a probe element. There is no literal anywhere in this file,
+ * which is what keeps a custom theme and `prefers-contrast: more` reaching the
+ * drawing the same way they reach the rest of the application.
+ */
+function readPalette(): Palette {
+  const probe = document.createElement("span");
+  probe.style.display = "none";
+  document.body.append(probe);
+  // An expression the browser rejects leaves the inherited colour in place,
+  // so a missing token degrades to readable text rather than to transparent.
+  const resolve = (expression: string) => {
+    probe.style.color = "";
+    probe.style.color = expression;
+    return getComputedStyle(probe).color;
+  };
+  const palette: Palette = {
+    canvas: resolve("var(--color-canvas)"),
+    item: resolve("var(--color-text-soft)"),
+    favorite: resolve("var(--color-accent-strong)"),
+    orphan: resolve("var(--color-border-strong)"),
+    tag: resolve("var(--color-accent)"),
+    tagEdge: resolve("var(--color-border)"),
+    mentionEdge: resolve("var(--accent)"),
+    ring: resolve("var(--color-text)"),
+    pin: resolve("var(--color-accent-strong)"),
+    label: resolve("var(--color-text-soft)"),
+    labelStrong: resolve("var(--color-text)"),
+    tagLabel: resolve("color-mix(in srgb, var(--color-accent) 55%, var(--color-text))"),
+  };
+  probe.remove();
+  return palette;
+}

--- a/web/src/data/graph.test.mjs
+++ b/web/src/data/graph.test.mjs
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildGraphProjection,
+  constellationProjection,
+  extractMentions,
+  itemNodeId,
+  tagNodeId,
+} from "./graph.ts";
+
+function item(id, tags, overrides = {}) {
+  return {
+    id,
+    url: `https://example.com/${id}`,
+    title: `Item ${id}`,
+    tags,
+    favorite: false,
+    savedAt: "2026-07-30T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const ids = Array.from(
+  { length: 30 },
+  (_, index) => `00000000-0000-7000-8000-${String(index).padStart(12, "0")}`,
+);
+
+test("tags become hubs rather than an item-to-item clique", () => {
+  const projection = buildGraphProjection([
+    item(ids[0], ["crdt"]),
+    item(ids[1], ["crdt"]),
+    item(ids[2], ["crdt"]),
+  ]);
+
+  // Three items sharing a tag is three edges through one hub, not the three
+  // item-to-item edges a clique would draw. The distinction is the whole
+  // reason tag nodes exist: a 300-item tag would otherwise be ~45k edges.
+  assert.equal(projection.edges.length, 3);
+  assert.ok(projection.edges.every((edge) => edge.kind === "tag"));
+  assert.ok(projection.edges.every((edge) => edge.target === tagNodeId("crdt")));
+  assert.equal(
+    projection.nodes.find((node) => node.id === tagNodeId("crdt")).count,
+    3,
+  );
+  assert.deepEqual(projection.orphans, []);
+});
+
+test("co-mentions pair the items a document names and count the documents", () => {
+  const projection = buildGraphProjection(
+    [item(ids[0], []), item(ids[1], []), item(ids[2], [])],
+    [
+      { documentId: "doc-a", itemIds: [ids[0], ids[1], ids[2]] },
+      { documentId: "doc-b", itemIds: [ids[0], ids[1]] },
+      // A mention of an item outside the result set is not an edge to
+      // something the graph is not showing.
+      { documentId: "doc-c", itemIds: [ids[0], ids[9]] },
+    ],
+  );
+
+  assert.equal(projection.edges.length, 3);
+  assert.ok(projection.edges.every((edge) => edge.kind === "mention"));
+  const repeated = projection.edges.find(
+    (edge) =>
+      edge.source === itemNodeId(ids[0]) && edge.target === itemNodeId(ids[1]),
+  );
+  assert.equal(repeated.weight, 2);
+});
+
+test("a link-dump document cannot dominate the layout", () => {
+  const members = ids.slice(0, 30);
+  const projection = buildGraphProjection(
+    members.map((id) => item(id, [])),
+    [{ documentId: "dump", itemIds: members }],
+    { maxComentionFanout: 5 },
+  );
+
+  // Capped at five mentions, so ten pairs — not the 435 the full document
+  // would have contributed.
+  assert.equal(projection.edges.length, 10);
+  assert.equal(projection.orphans.length, 25);
+});
+
+test("an item with no tag and no mention is reported as an orphan", () => {
+  const projection = buildGraphProjection(
+    [item(ids[0], ["crdt"]), item(ids[1], []), item(ids[2], [])],
+    [{ documentId: "doc-a", itemIds: [ids[0], ids[2]] }],
+  );
+
+  assert.deepEqual(projection.orphans, [itemNodeId(ids[1])]);
+  assert.equal(
+    projection.nodes.find((node) => node.id === itemNodeId(ids[0])).degree,
+    2,
+  );
+});
+
+test("the node set is the result set, and switching edge kinds never changes it", () => {
+  const items = [item(ids[0], ["crdt"]), item(ids[1], ["rust"])];
+  const mentions = [{ documentId: "doc-a", itemIds: [ids[0], ids[1]] }];
+  const itemNodes = (projection) =>
+    projection.nodes.filter((node) => node.kind === "item").map((node) => node.id);
+
+  const full = buildGraphProjection(items, mentions);
+  const withoutTags = buildGraphProjection(items, mentions, { tagEdges: false });
+  const withoutMentions = buildGraphProjection(items, mentions, {
+    mentionEdges: false,
+  });
+
+  assert.deepEqual(itemNodes(full), itemNodes(withoutTags));
+  assert.deepEqual(itemNodes(full), itemNodes(withoutMentions));
+  // Tag hubs are drawn only when their edges are, or they stand unreachable.
+  assert.ok(!withoutTags.nodes.some((node) => node.kind === "tag"));
+  assert.deepEqual(withoutMentions.orphans, []);
+});
+
+test("the mobile constellation keeps the busiest tags and their saves", () => {
+  const projection = buildGraphProjection([
+    item(ids[0], ["crdt"]),
+    item(ids[1], ["crdt"]),
+    item(ids[2], ["rust"]),
+    item(ids[3], []),
+  ]);
+
+  const constellation = constellationProjection(projection, 1);
+  assert.deepEqual(
+    constellation.nodes.map((node) => node.id).sort(),
+    [itemNodeId(ids[0]), itemNodeId(ids[1]), tagNodeId("crdt")].sort(),
+  );
+  assert.deepEqual(constellation.orphans, []);
+});
+
+test("mentions are read out of a body the way the reader resolves them", () => {
+  const body = [
+    `A [save](research:item/${ids[0]}) and the [same one](research:item/${ids[0]}).`,
+    `An autolink <research:item/${ids[1]}> counts too.`,
+    "A plain link (https://example.com) and research:item/not-a-uuid do not.",
+  ].join("\n");
+
+  assert.deepEqual(extractMentions(body), [ids[0], ids[1]]);
+  assert.deepEqual(extractMentions("nothing here"), []);
+});

--- a/web/src/data/graph.ts
+++ b/web/src/data/graph.ts
@@ -1,0 +1,350 @@
+/**
+ * The library graph is a derived, in-memory projection — never a persisted
+ * store and never a synchronized one. Nodes are saved items and their tags;
+ * edges are tag membership plus co-mention, read out of zen document bodies at
+ * view time exactly as the reader resolves a single mention.
+ *
+ * Everything here is pure and synchronous so it can be unit-tested without
+ * IndexedDB, and so a renderer swap never touches derivation.
+ */
+
+export type GraphNodeKind = "item" | "tag";
+export type GraphEdgeKind = "tag" | "mention";
+
+export interface GraphNode {
+  /** `item:<uuid>` or `tag:<name>` — unique across both kinds by construction. */
+  id: string;
+  kind: GraphNodeKind;
+  label: string;
+  degree: number;
+  /** Items only: drives the lit fill. Tags are never favorites. */
+  favorite: boolean;
+  /** Items only: epoch milliseconds, 0 for a tag hub. */
+  savedAt: number;
+  /** Tags only: how many active items carry it. Items report 0. */
+  count: number;
+}
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+  kind: GraphEdgeKind;
+  /** Tag membership is always 1; a co-mention counts the documents it spans. */
+  weight: number;
+}
+
+export interface GraphProjection {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  /** Item node ids with degree 0 — saves with no tag and no mention. */
+  orphans: string[];
+  /** Node id to its neighbours, prebuilt because every frame reads it. */
+  adjacency: Map<string, GraphNeighbour[]>;
+}
+
+export interface GraphNeighbour {
+  id: string;
+  kind: GraphEdgeKind;
+}
+
+/** The item shape the projection needs — a structural subset of `LibraryItem`. */
+export interface GraphItemInput {
+  id: string;
+  url: string;
+  title?: string | null;
+  tags: string[];
+  favorite: boolean;
+  savedAt: string;
+}
+
+/** One zen document reduced to the distinct items its body mentions. */
+export interface GraphMentionSource {
+  documentId: string;
+  itemIds: string[];
+}
+
+export interface GraphProjectionOptions {
+  tagEdges?: boolean;
+  mentionEdges?: boolean;
+  /**
+   * A link-dump document mentioning everything would otherwise contribute a
+   * clique large enough to dominate the layout, so its fan-out is capped and
+   * the excess is reported rather than silently dropped.
+   */
+  maxComentionFanout?: number;
+}
+
+/** 24 mentions is 276 pairs — the point where one document stops being a hub. */
+export const MAX_COMENTION_FANOUT = 24;
+
+/** Above this the view asks for a narrower filter instead of melting the device. */
+export const GRAPH_NODE_CEILING = 5_000;
+
+/** A phone gets a smaller ceiling; the constellation is already a reduction. */
+export const GRAPH_MOBILE_NODE_CEILING = 400;
+
+const MENTION_PREFIX = "research:item/";
+
+/**
+ * Pulls the distinct items a zen body mentions.
+ *
+ * The body is Markdown, so a mention is a link destination rather than a bare
+ * token, but scanning for the versioned URI is both cheaper and more forgiving
+ * than parsing: a mention inside a reference definition or an autolink counts
+ * the same way the reader counts it.
+ */
+export function extractMentions(body: string): string[] {
+  const found: string[] = [];
+  const seen = new Set<string>();
+  let index = body.indexOf(MENTION_PREFIX);
+  while (index !== -1) {
+    const start = index + MENTION_PREFIX.length;
+    let end = start;
+    while (end < body.length && /[0-9a-fA-F-]/.test(body[end]!)) end += 1;
+    const candidate = body.slice(start, end).toLowerCase();
+    if (isUuid(candidate) && !seen.has(candidate)) {
+      seen.add(candidate);
+      found.push(candidate);
+    }
+    index = body.indexOf(MENTION_PREFIX, end);
+  }
+  return found;
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(value);
+}
+
+export function itemNodeId(itemId: string): string {
+  return `item:${itemId}`;
+}
+
+export function tagNodeId(tag: string): string {
+  return `tag:${tag}`;
+}
+
+/** Recovers the item UUID from a node id, or null for a tag hub. */
+export function nodeItemId(nodeId: string): string | null {
+  return nodeId.startsWith("item:") ? nodeId.slice(5) : null;
+}
+
+/** Recovers the tag name from a node id, or null for an item. */
+export function nodeTagName(nodeId: string): string | null {
+  return nodeId.startsWith("tag:") ? nodeId.slice(4) : null;
+}
+
+/**
+ * Builds the projection for a set of items and the documents that mention them.
+ *
+ * `items` is the list's own result set, so the graph and the list always agree:
+ * switching modes changes the projection, never the membership.
+ */
+export function buildGraphProjection(
+  items: GraphItemInput[],
+  mentions: GraphMentionSource[] = [],
+  options: GraphProjectionOptions = {},
+): GraphProjection {
+  const tagEdges = options.tagEdges ?? true;
+  const mentionEdges = options.mentionEdges ?? true;
+  const fanout = options.maxComentionFanout ?? MAX_COMENTION_FANOUT;
+
+  const nodes = new Map<string, GraphNode>();
+  const present = new Set<string>();
+  for (const item of items) {
+    const id = itemNodeId(item.id);
+    present.add(item.id);
+    nodes.set(id, {
+      id,
+      kind: "item",
+      label: itemLabel(item),
+      degree: 0,
+      favorite: item.favorite,
+      savedAt: readSavedAt(item.savedAt),
+      count: 0,
+    });
+  }
+
+  // Tag hubs exist only when tag membership is being drawn; with the edges off
+  // they would stand in the field as unreachable squares.
+  if (tagEdges) {
+    for (const item of items) {
+      for (const tag of item.tags) {
+        const id = tagNodeId(tag);
+        const existing = nodes.get(id);
+        if (existing) {
+          existing.count += 1;
+          continue;
+        }
+        nodes.set(id, {
+          id,
+          kind: "tag",
+          label: tag,
+          degree: 0,
+          favorite: false,
+          savedAt: 0,
+          count: 1,
+        });
+      }
+    }
+  }
+
+  const edges = new Map<string, GraphEdge>();
+
+  if (tagEdges) {
+    for (const item of items) {
+      for (const tag of item.tags) {
+        addEdge(edges, itemNodeId(item.id), tagNodeId(tag), "tag");
+      }
+    }
+  }
+
+  if (mentionEdges) {
+    for (const source of mentions) {
+      // Only mentions of items in the current result set become edges, or a
+      // filtered graph would grow links to saves it is not showing.
+      const mentioned = source.itemIds
+        .filter((itemId) => present.has(itemId))
+        .slice(0, fanout);
+      for (let left = 0; left < mentioned.length; left += 1) {
+        for (let right = left + 1; right < mentioned.length; right += 1) {
+          addEdge(
+            edges,
+            itemNodeId(mentioned[left]!),
+            itemNodeId(mentioned[right]!),
+            "mention",
+          );
+        }
+      }
+    }
+  }
+
+  const adjacency = new Map<string, GraphNeighbour[]>();
+  for (const edge of edges.values()) {
+    pushNeighbour(adjacency, edge.source, edge.target, edge.kind);
+    pushNeighbour(adjacency, edge.target, edge.source, edge.kind);
+  }
+  for (const node of nodes.values()) {
+    node.degree = adjacency.get(node.id)?.length ?? 0;
+  }
+
+  const orphans = [...nodes.values()]
+    .filter((node) => node.kind === "item" && node.degree === 0)
+    .map((node) => node.id);
+
+  return {
+    // Sorted so the projection is deterministic: the same library always seeds
+    // the same layout, and a test can assert on it.
+    nodes: [...nodes.values()].sort(compareNodes),
+    edges: [...edges.values()].sort(compareEdges),
+    orphans,
+    adjacency,
+  };
+}
+
+/**
+ * The mobile reading: tag hubs and the items hanging off them.
+ *
+ * A phone has no room for the full field, and an untethered item is a dot with
+ * no way to say what it is, so the constellation keeps only what a tag names.
+ */
+export function constellationProjection(
+  projection: GraphProjection,
+  tagLimit = 7,
+): GraphProjection {
+  const hubs = projection.nodes
+    .filter((node) => node.kind === "tag")
+    .sort((left, right) => right.count - left.count || left.label.localeCompare(right.label))
+    .slice(0, tagLimit);
+  const keep = new Set(hubs.map((node) => node.id));
+  for (const hub of hubs) {
+    for (const neighbour of projection.adjacency.get(hub.id) ?? []) {
+      keep.add(neighbour.id);
+    }
+  }
+  return subgraph(projection, keep);
+}
+
+/** Narrows a projection to a node set, recomputing degree and orphans. */
+export function subgraph(
+  projection: GraphProjection,
+  keep: ReadonlySet<string>,
+): GraphProjection {
+  const edges = projection.edges.filter(
+    (edge) => keep.has(edge.source) && keep.has(edge.target),
+  );
+  const adjacency = new Map<string, GraphNeighbour[]>();
+  for (const edge of edges) {
+    pushNeighbour(adjacency, edge.source, edge.target, edge.kind);
+    pushNeighbour(adjacency, edge.target, edge.source, edge.kind);
+  }
+  const nodes = projection.nodes
+    .filter((node) => keep.has(node.id))
+    .map((node) => ({ ...node, degree: adjacency.get(node.id)?.length ?? 0 }));
+  return {
+    nodes,
+    edges,
+    orphans: nodes
+      .filter((node) => node.kind === "item" && node.degree === 0)
+      .map((node) => node.id),
+    adjacency,
+  };
+}
+
+function addEdge(
+  edges: Map<string, GraphEdge>,
+  left: string,
+  right: string,
+  kind: GraphEdgeKind,
+): void {
+  if (left === right) return;
+  // Undirected, so the pair is keyed in a stable order and a second document
+  // mentioning the same pair thickens the edge instead of duplicating it.
+  const [source, target] = left < right ? [left, right] : [right, left];
+  const key = `${kind} ${source} ${target}`;
+  const existing = edges.get(key);
+  if (existing) {
+    existing.weight += 1;
+    return;
+  }
+  edges.set(key, { source, target, kind, weight: 1 });
+}
+
+function pushNeighbour(
+  adjacency: Map<string, GraphNeighbour[]>,
+  from: string,
+  to: string,
+  kind: GraphEdgeKind,
+): void {
+  const existing = adjacency.get(from);
+  if (existing) existing.push({ id: to, kind });
+  else adjacency.set(from, [{ id: to, kind }]);
+}
+
+function itemLabel(item: GraphItemInput): string {
+  const title = item.title?.trim();
+  if (title) return title;
+  try {
+    const url = new URL(item.url);
+    return `${url.hostname}${url.pathname === "/" ? "" : url.pathname}`;
+  } catch {
+    return item.url;
+  }
+}
+
+function readSavedAt(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function compareNodes(left: GraphNode, right: GraphNode): number {
+  if (left.kind !== right.kind) return left.kind === "tag" ? -1 : 1;
+  return left.label.localeCompare(right.label) || left.id.localeCompare(right.id);
+}
+
+function compareEdges(left: GraphEdge, right: GraphEdge): number {
+  return (
+    left.kind.localeCompare(right.kind) ||
+    left.source.localeCompare(right.source) ||
+    left.target.localeCompare(right.target)
+  );
+}

--- a/web/src/data/library.ts
+++ b/web/src/data/library.ts
@@ -18,6 +18,7 @@ import {
   type RemoteObservation,
 } from "./db";
 import { domainCore } from "./domain.ts";
+import { extractMentions, type GraphMentionSource } from "./graph.ts";
 import {
   createUndoableChange,
   matchesUndoExpectation,
@@ -212,6 +213,8 @@ class LibraryRepository {
   private readonly pending = new Set<Promise<unknown>>();
   private databasePromise: Promise<BrowserDatabase> | undefined;
   private closed = false;
+  /** Derived zen mention index, keyed by document and replica revision. */
+  private mentions = new Map<string, { updatedAt: string; itemIds: string[] }>();
 
   constructor(names: ProfileStorageNames) {
     this.names = names;
@@ -1234,7 +1237,60 @@ class LibraryRepository {
       );
   }
 
-  /** Reads one document body. The only call that loads body bytes. */
+  /**
+   * Every zen body reduced to the item UUIDs it mentions, for the library
+   * graph's co-mention edges.
+   *
+   * The result is derived and thrown away: no backlink index is written, no
+   * mention travels as an update, and a closed graph leaves nothing behind
+   * ([ADR 0012](../../../docs/v2/ADR_0012_DERIVED_LIBRARY_GRAPH.md)). Bodies
+   * are expensive to materialize, so each document is cached against its
+   * replica's `updatedAt` and only an edited document is read again.
+   */
+  async listZenMentions(): Promise<GraphMentionSource[]> {
+    const database = await this.database();
+    const meta = await database.get("meta", "library");
+    if (!meta) return [];
+    const documents = await database.getAll("zenDocuments");
+    const sources: GraphMentionSource[] = [];
+    const retained = new Map<string, { updatedAt: string; itemIds: string[] }>();
+
+    for (const document of documents) {
+      if (document.deleted) continue;
+      const replica = await database.get("zenReplicas", document.documentId);
+      if (!replica) continue;
+
+      const cached = this.mentions.get(document.documentId);
+      let entry = cached?.updatedAt === replica.updatedAt ? cached : undefined;
+      if (!entry) {
+        try {
+          const view = JSON.parse(
+            await domainCore.call(
+              "zenDocumentView",
+              replica.snapshot,
+              meta.peerId,
+              document.documentId,
+            ),
+          ) as ZenDocumentView;
+          entry = {
+            updatedAt: replica.updatedAt,
+            itemIds: extractMentions(view.body),
+          };
+        } catch {
+          // One unreadable document costs its edges, not the whole graph.
+          continue;
+        }
+      }
+      retained.set(document.documentId, entry);
+      sources.push({ documentId: document.documentId, itemIds: entry.itemIds });
+    }
+
+    // Rebuilt rather than pruned, so a deleted document leaves no residue.
+    this.mentions = retained;
+    return sources;
+  }
+
+  /** Reads one document body. The other call that loads body bytes. */
   async zenDocument(documentId: string): Promise<ZenDocumentView> {
     const database = await this.database();
     const replica = await database.get("zenReplicas", documentId);
@@ -2441,6 +2497,10 @@ class LibraryWorkspace {
 
   async zenDocument(documentId: string): Promise<ZenDocumentView> {
     return (await this.instance()).zenDocument(documentId);
+  }
+
+  async listZenMentions(): Promise<GraphMentionSource[]> {
+    return (await this.instance()).listZenMentions();
   }
 
   async createZenDocument(input: {

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -5485,3 +5485,481 @@ kbd {
     display: none;
   }
 }
+
+/* ------------------------------------------------------------------ *
+ * Library graph
+ *
+ * A second projection of the library, not a second view. All of its motion
+ * lives inside the canvas, which is the only place the design system allows
+ * any: the panel around it is as still as every other surface.
+ * ------------------------------------------------------------------ */
+
+.library-mode {
+  border: var(--rule) solid var(--color-border-strong);
+  border-radius: var(--radius);
+  display: flex;
+  flex: 0 0 auto;
+  margin-left: auto;
+  overflow: hidden;
+}
+
+.library-mode button {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-soft);
+  font-size: var(--font-size-xs);
+  min-height: 1.95rem;
+  padding: 0 0.75rem;
+}
+
+.library-mode button + button {
+  border-left: var(--rule) solid var(--color-border-strong);
+}
+
+.library-mode button[aria-pressed="true"] {
+  background: var(--color-inverse-surface);
+  color: var(--color-inverse);
+  font-weight: 700;
+}
+
+/* The desktop control lives in the heading row, which a phone does not show.
+   There, Graph is a chip in the strip beside Zen and the tags. */
+.mobile-graph-toggle {
+  display: none;
+}
+
+.library-graph {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.graph-toolbar {
+  display: flex;
+  flex: 0 0 auto;
+  gap: var(--space-2);
+  overflow-x: auto;
+  padding-bottom: var(--space-3);
+}
+
+.graph-toolbar button {
+  background: transparent;
+  border: var(--rule) solid var(--color-border);
+  border-radius: var(--radius);
+  color: var(--color-text-soft);
+  flex: 0 0 auto;
+  font-size: var(--font-size-xs);
+  min-height: 1.875rem;
+  padding: 0 0.625rem;
+}
+
+.graph-toolbar button[aria-pressed="true"] {
+  border-color: var(--color-border-strong);
+  color: var(--color-accent-strong);
+}
+
+.graph-release {
+  margin-left: auto;
+}
+
+.graph-body {
+  border-top: var(--rule) solid var(--color-border-subtle);
+  display: grid;
+  flex: 1 1 auto;
+  grid-template-columns: minmax(0, 1fr) 20rem;
+  min-height: 0;
+}
+
+.graph-stage {
+  min-height: 24rem;
+  min-width: 0;
+  position: relative;
+}
+
+.graph-canvas {
+  display: block;
+  height: 100%;
+  inset: 0;
+  position: absolute;
+  touch-action: none;
+  width: 100%;
+}
+
+/* Every overlay is inert: the graph underneath must stay grabbable through
+   the corner it happens to be sitting in. */
+.graph-stats,
+.graph-legend {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  margin: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+.graph-stats,
+.graph-legend {
+  background: var(--color-surface);
+  border: var(--rule) solid var(--color-border-subtle);
+}
+
+.graph-stats {
+  display: flex;
+  gap: var(--space-2);
+  padding: 0.3rem 0.625rem;
+  right: 0.75rem;
+  top: 0.75rem;
+}
+
+.graph-orphan-count {
+  color: var(--color-accent-strong);
+}
+
+.graph-legend {
+  bottom: 0.75rem;
+  display: grid;
+  gap: 0.3rem;
+  left: 0.75rem;
+  padding: 0.625rem 0.75rem;
+}
+
+.graph-legend div {
+  align-items: center;
+  display: flex;
+  gap: var(--space-2);
+}
+
+.graph-legend dd {
+  margin: 0;
+}
+
+/* The shape is the legend's whole point — a round item against a square tag
+   hub — and the stylesheet has no rounded corner to spend, so the node keys
+   are the glyphs themselves rather than boxes pretending to be them. */
+.graph-key {
+  flex: 0 0 auto;
+  font-size: var(--font-size-xs);
+  line-height: 1;
+  text-align: center;
+  width: 0.75rem;
+}
+
+.graph-key-item {
+  color: var(--color-text-soft);
+}
+
+.graph-key-favorite {
+  color: var(--color-accent-strong);
+}
+
+.graph-key-tag {
+  color: var(--color-accent);
+}
+
+.graph-key-tag-edge,
+.graph-key-mention-edge {
+  height: 1px;
+  width: 1rem;
+}
+
+.graph-key-tag-edge {
+  background: var(--color-border);
+}
+
+.graph-key-mention-edge {
+  background: var(--accent);
+}
+
+.graph-zoom {
+  align-items: center;
+  background: var(--color-surface);
+  border: var(--rule) solid var(--color-border-subtle);
+  bottom: 0.75rem;
+  display: flex;
+  position: absolute;
+  right: 0.75rem;
+}
+
+.graph-zoom button {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-soft);
+  font-size: var(--font-size-sm);
+  min-height: 1.875rem;
+  padding: 0 0.625rem;
+}
+
+.graph-zoom button:last-child {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.graph-zoom button + span,
+.graph-zoom span + button {
+  border-left: var(--rule) solid var(--color-border-subtle);
+}
+
+.graph-zoom span {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  padding: 0 var(--space-2);
+  text-align: center;
+  width: 3.25rem;
+}
+
+.graph-notice {
+  display: grid;
+  gap: var(--space-3);
+  left: 50%;
+  margin: 0;
+  max-width: 28rem;
+  padding: var(--space-5);
+  position: absolute;
+  text-align: center;
+  top: 50%;
+  translate: -50% -50%;
+}
+
+.graph-notice span {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+/* Visible only when no drawing surface could be opened, when it stops being
+   the keyboard's route through the graph and becomes the graph. */
+.graph-nodes:not(.sr-only) {
+  display: grid;
+  gap: 1px;
+  inset: 0;
+  list-style: none;
+  margin: 0;
+  overflow: auto;
+  padding: 9rem var(--space-4) var(--space-4);
+  position: absolute;
+}
+
+.graph-nodes button {
+  background: transparent;
+  border: var(--rule) solid transparent;
+  border-radius: var(--radius);
+  color: var(--color-text-soft);
+  display: block;
+  font-size: var(--font-size-sm);
+  min-height: 2rem;
+  overflow: hidden;
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.graph-inspector {
+  border-left: var(--rule) solid var(--color-border-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  min-height: 0;
+  overflow: auto;
+  padding: var(--space-5);
+}
+
+.graph-inspector-heading {
+  align-items: baseline;
+  border-bottom: var(--rule) solid var(--color-border-subtle);
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: var(--space-2);
+}
+
+.graph-inspector-heading p {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.12em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.graph-inspector-heading span {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.graph-inspector-subject {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.graph-inspector-title {
+  color: var(--color-accent-strong);
+  font-size: var(--font-size-md);
+  font-weight: 700;
+  line-height: var(--line-height-tight);
+  margin: 0;
+  text-wrap: pretty;
+}
+
+.graph-inspector-meta {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  margin: 0;
+}
+
+.graph-inspector-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.graph-inspector-tags span {
+  border: var(--rule) solid var(--color-border);
+  border-radius: var(--radius);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  padding: 0 var(--space-2);
+}
+
+.graph-inspector-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.graph-inspector-actions button {
+  flex: 1 1 auto;
+}
+
+.graph-neighbourhood {
+  display: grid;
+  gap: var(--space-2);
+  min-height: 0;
+}
+
+.graph-neighbourhood ol {
+  display: grid;
+  gap: 1px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.graph-neighbourhood button {
+  align-items: center;
+  background: transparent;
+  border: var(--rule) solid transparent;
+  border-radius: var(--radius);
+  color: var(--color-text-soft);
+  display: grid;
+  font-size: var(--font-size-xs);
+  gap: var(--space-2);
+  grid-template-columns: auto minmax(0, 1fr);
+  min-height: 2rem;
+  padding: var(--space-1) var(--space-2);
+  text-align: left;
+  width: 100%;
+}
+
+.graph-neighbourhood button span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.graph-glyph-mention {
+  color: var(--color-focus);
+}
+
+.graph-glyph-tag {
+  color: var(--color-accent);
+}
+
+.graph-glyph-item {
+  color: var(--color-text-muted);
+}
+
+.graph-inspector-footnote {
+  border-top: var(--rule) solid var(--color-border-subtle);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-body);
+  margin: auto 0 0;
+  padding-top: var(--space-3);
+}
+
+.graph-inspector-footnote span {
+  color: var(--color-text-soft);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .graph-toolbar button:hover,
+  .graph-zoom button:hover,
+  .graph-nodes button:hover,
+  .graph-neighbourhood button:hover {
+    border-color: var(--color-border-strong);
+    color: var(--color-text);
+  }
+}
+
+@media (max-width: 68rem) {
+  .graph-body {
+    grid-template-columns: minmax(0, 1fr) 16rem;
+  }
+
+  .graph-legend {
+    display: none;
+  }
+}
+
+@media (max-width: 48rem) {
+  /* The phone reads the tag constellation, so the strip carries the mode and
+     the heading row's control is not there to be reached. */
+  .mobile-graph-toggle {
+    display: flex;
+  }
+
+  .library-graph {
+    /* Escapes the section's own padding: the field wants the full width. */
+    margin: 0 -1rem;
+  }
+
+  .graph-toolbar {
+    padding: 0 1rem 0.625rem;
+  }
+
+  /* One column: the inspector becomes the card the design raises under the
+     field, with only what a tap needs to answer. */
+  .graph-body {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr) auto;
+  }
+
+  .graph-stage {
+    min-height: 18rem;
+  }
+
+  .graph-zoom,
+  .graph-neighbourhood,
+  .graph-inspector-footnote {
+    display: none;
+  }
+
+  .graph-inspector {
+    border-left: 0;
+    border-top: var(--rule) solid var(--color-border-strong);
+    background: var(--color-surface);
+    gap: var(--space-3);
+    overflow: visible;
+    padding: var(--space-4) 1rem max(var(--space-5), env(safe-area-inset-bottom));
+  }
+
+  .graph-inspector-heading {
+    display: none;
+  }
+
+  .graph-inspector-actions button {
+    min-height: var(--control-height);
+  }
+
+  .graph-notice {
+    padding: var(--space-4);
+  }
+}


### PR DESCRIPTION
Closes #164.

Graph becomes a second **mode of Library**, not a fourth view. The same search,
tag rail, favourites and lifecycle filter drive both projections, so switching
never changes the result set — only how it is drawn.

## What landed

- **`web/src/data/graph.ts`** — the pure projection. Items and tags as nodes;
  tag-membership and co-mention edges; degree, orphans, and a prebuilt
  adjacency map. Synchronous and IndexedDB-free, so it unit-tests with
  `node --test` like `db.test.mjs`.
- **`web/src/components/LibraryGraph.tsx`** — canvas renderer, force
  simulation, inspector, and the keyboard route through the graph.
- **`web/src/data/library.ts`** — `listZenMentions()`, the derived mention
  index, memoized against each replica's revision.
- **`docs/v2/ADR_0012_DERIVED_LIBRARY_GRAPH.md`** — narrows ADR 0011's
  "no graph query surface" clause, and amends ADR 0011 to match.

## Deliberate departures from the issue as filed

The issue predates the design work in `issues/graph-view.md`; three of its
deliverables were revised there, and one decision was made in this PR. Calling
them out so review can push back:

| Issue as filed | Shipped | Why |
|---|---|---|
| A `graph` view in the rail beside library/settings/sync/zen | A `List \| Graph` mode **inside** Library | A separate view would need its own filter state, and the whole point is that the node set *is* the list's result set |
| `@xyflow/react` | Canvas 2D, **no new dependency** | The design later chose sigma.js + graphology; on review, every node treatment it asks for is a custom GLSL `NodeProgram` there and two context calls here. The projection is renderer-agnostic, so this stays reversible |
| Tag membership only | Tag membership **plus co-mentions** | Co-mentions are half of what makes a cluster readable, and they are what make orphan detection mean "unconnected" rather than merely "untagged". Needed ADR 0012 |
| Bounded node set with a `show all` opt-in | Ceiling with "narrow the filter" | Above `GRAPH_NODE_CEILING` (5,000; 400 on a phone) the view asks for a narrower filter. The list is always complete, so `show all` would only offer a slower way to see the same set |

## The ADR 0011 question

ADR 0011 says verbatim: *"Mentions are one-way references. There is no backlink
index, no graph query surface."* Co-mention edges are exactly that surface, so
this cannot ship without a decision.

ADR 0012 narrows the clause to what it was protecting — persisted or
synchronized mention structure — and explicitly permits a read-only view that
derives from bodies already in memory and stores nothing. Nothing is written,
synchronized, or published, and no mutation is offered from the graph.
**This is the part of the PR most worth disagreeing with.**

## Verification

Driven in the browser against a real library (8 saves, 7 tags, 1 Zen document):

- Switching `List ⇄ Graph` preserves search, tags, favourites and lifecycle
  filter; back returns to the list; `?mode=graph` round-trips.
- The orphan filter isolates exactly the one untagged, unmentioned save.
- Fresh load frames the settled cloud at its fit scale with nothing selected
  and nothing pinned.
- Mobile (390px) renders the tag constellation with labels on tags only and
  the bottom card; `Graph` appears as a chip in the strip.
- `npm run verify` passes: 23 tests, typecheck, `check:design`, `check:dist`.

## Bundle growth

Measured against `main` at the same commit, no new dependencies:

| | before | after | delta |
|---|---|---|---|
| `app.js` | 144.54 kB / 38.98 kB gzip | 168.59 kB / 46.78 kB gzip | +24.05 kB / **+7.80 kB gzip** |
| `app.css` | 87.04 kB / 14.33 kB gzip | 94.07 kB / 15.34 kB gzip | +7.03 kB / **+1.01 kB gzip** |

## Not in this pass

Zen documents as nodes, source-domain nodes, text-similarity edges, an explicit
item-to-item link type, graph editing, 3D. The 2,000-node frame-budget check in
`npm run verify` (P6) is not automated — the budget is designed for but only
manually observed.
