### PR TITLE
Let the graph layout come to rest

### DIFF
--- a/web/src/components/LibraryGraph.tsx
+++ b/web/src/components/LibraryGraph.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { GraphLayout, type LayoutBody } from "../data/graphLayout.ts";
 import {
   buildGraphProjection,
   constellationProjection,
@@ -23,18 +24,6 @@ export interface LibraryGraphProps {
   onFilterTag(tag: string): void;
 }
 
-/** A node under simulation. Positions survive a filter change by node id. */
-interface Body {
-  id: string;
-  x: number;
-  y: number;
-  vx: number;
-  vy: number;
-  radius: number;
-  pinned: boolean;
-  node: GraphNode;
-}
-
 interface Palette {
   canvas: string;
   item: string;
@@ -52,11 +41,6 @@ interface Palette {
 
 const MIN_SCALE = 0.25;
 const MAX_SCALE = 4;
-/** Barnes–Hut opening angle. Higher approximates more and costs less. */
-const THETA = 0.9;
-const REPULSION = 1500;
-/** Ticks a reduced-motion layout settles for before it is frozen and drawn once. */
-const SETTLE_TICKS = 320;
 const MOBILE_QUERY = "(max-width: 48rem)";
 
 export function LibraryGraph({
@@ -601,11 +585,11 @@ function createSimulation(
   let context = canvas.getContext("2d");
   if (!context) return null;
 
-  const bodies = new Map<string, Body>();
-  let order: Body[] = [];
+  const layout = new GraphLayout();
+  const bodies = layout.bodies;
+  let nodesById = new Map<string, GraphNode>();
   let projection: GraphProjection = EMPTY_PROJECTION;
   let narrow = false;
-  let reducedMotion = false;
   let palette = readPalette();
   let width = 0;
   let height = 0;
@@ -624,7 +608,7 @@ function createSimulation(
   let frame = 0;
   let drawFrame = 0;
   let fontsReady = false;
-  let drag: { body: Body; dx: number; dy: number; moved: boolean } | null = null;
+  let drag: { body: LayoutBody; dx: number; dy: number; moved: boolean } | null = null;
   let pan: { x: number; y: number } | null = null;
   const pointers = new Map<number, { x: number; y: number }>();
   let pinch: { distance: number; scale: number } | null = null;
@@ -644,15 +628,15 @@ function createSimulation(
     };
   };
 
-  const project = (body: Body) => ({
+  const project = (body: LayoutBody) => ({
     x: body.x * scale + width / 2 + translateX,
     y: body.y * scale + height / 2 + translateY,
   });
 
-  function pick(worldX: number, worldY: number): Body | null {
-    let best: Body | null = null;
+  function pick(worldX: number, worldY: number): LayoutBody | null {
+    let best: LayoutBody | null = null;
     let bestDistance = Infinity;
-    for (const body of order) {
+    for (const body of layout.order) {
       const dx = body.x - worldX;
       const dy = body.y - worldY;
       const distance = dx * dx + dy * dy;
@@ -706,144 +690,32 @@ function createSimulation(
   function loop() {
     frame = 0;
     if (!running) return;
-    const settled = reducedMotion && ticks > SETTLE_TICKS;
-    if (!settled) {
-      step();
-      ticks += 1;
-      if (fitPending && ticks > (warmed ? 8 : 150)) fit();
-    } else {
-      frozen = true;
-    }
+
+    // Soft walls only once the view has been framed, or a layout that has not
+    // spread yet is clamped into the opening viewport and never escapes it.
+    const moving = layout.step({
+      narrow,
+      dragging: drag?.body.id ?? null,
+      limitX: warmed ? Math.max(60, (width / 2 - 26) / scale) : undefined,
+      limitY: warmed ? Math.max(60, (height / 2 - 26) / scale) : undefined,
+    });
+    ticks += 1;
+    if (fitPending && (ticks > (warmed ? 8 : 150) || !moving)) fit();
+
     draw();
+
+    // A large graph settles and the loop stops; a small one drifts forever by
+    // design, so it never reports settled and keeps asking for frames.
+    if (!moving) frozen = true;
     if (!frozen) frame = requestAnimationFrame(loop);
-  }
-
-  /* ---- forces ---- */
-
-  function step() {
-    if (order.length === 0) return;
-
-    const tree = order.length > 48 ? buildQuadtree(order) : null;
-    for (const body of order) {
-      if (tree) applyRepulsion(tree, body);
-      else {
-        for (const other of order) {
-          if (other === body) continue;
-          repel(body, other.x, other.y, 1);
-        }
-      }
-    }
-
-    for (const edge of projection.edges) {
-      const from = bodies.get(edge.source);
-      const to = bodies.get(edge.target);
-      if (!from || !to) continue;
-      // Co-mentions pull tighter than tag membership: a pair someone wrote about
-      // together is a stronger statement than a tag they both happen to carry.
-      const target =
-        edge.kind === "mention" ? (narrow ? 42 : 56) : narrow ? 58 : 82;
-      const dx = to.x - from.x;
-      const dy = to.y - from.y;
-      const distance = Math.max(1, Math.hypot(dx, dy));
-      const strength =
-        ((distance - target) * (edge.kind === "mention" ? 0.014 : 0.02)) /
-        Math.max(1, Math.log2(1 + edge.weight));
-      from.vx += (dx / distance) * strength;
-      from.vy += (dy / distance) * strength;
-      to.vx -= (dx / distance) * strength;
-      to.vy -= (dy / distance) * strength;
-    }
-
-    const drifting = !reducedMotion;
-    for (const body of order) {
-      body.vx -= body.x * 0.0022;
-      body.vy -= body.y * 0.0026;
-      if (drifting) {
-        // The design system bans CSS motion, so the graph's aliveness has to
-        // live in the pixels. This is that: a permanent, tiny unrest.
-        body.vx += (Math.random() - 0.5) * 0.09;
-        body.vy += (Math.random() - 0.5) * 0.09;
-      }
-      body.vx *= 0.86;
-      body.vy *= 0.86;
-      const speed = Math.hypot(body.vx, body.vy);
-      if (speed > 6) {
-        body.vx = (body.vx / speed) * 6;
-        body.vy = (body.vy / speed) * 6;
-      }
-      if (!body.pinned || drag?.body === body) {
-        body.x += body.vx;
-        body.y += body.vy;
-      }
-    }
-
-    // Soft walls at the frame edge: the drift stays alive, but nothing is
-    // allowed to wander out of the panel and become unreachable.
-    if (warmed) {
-      const limitX = Math.max(60, (width / 2 - 26) / scale);
-      const limitY = Math.max(60, (height / 2 - 26) / scale);
-      for (const body of order) {
-        if (Math.abs(body.x) > limitX) {
-          body.vx -= (body.x - Math.sign(body.x) * limitX) * 0.05;
-        }
-        if (Math.abs(body.y) > limitY) {
-          body.vy -= (body.y - Math.sign(body.y) * limitY) * 0.05;
-        }
-      }
-    }
-  }
-
-  function repel(body: Body, x: number, y: number, mass: number) {
-    let dx = body.x - x;
-    let dy = body.y - y;
-    let squared = dx * dx + dy * dy;
-    if (squared < 1) {
-      // Two bodies exactly on top of each other have no direction to separate
-      // along, so one is invented deterministically from the id.
-      dx = ((body.id.charCodeAt(0) % 3) - 1) || 0.7;
-      dy = ((body.id.charCodeAt(1) % 3) - 1) || 0.7;
-      squared = 2;
-    }
-    if (squared > 90_000) return;
-    const distance = Math.sqrt(squared);
-    const force = (REPULSION * mass) / squared;
-    body.vx += (dx / distance) * force;
-    body.vy += (dy / distance) * force;
-  }
-
-  function applyRepulsion(cell: Cell, body: Body) {
-    if (cell.mass === 0) return;
-    const dx = cell.cx - body.x;
-    const dy = cell.cy - body.y;
-    const distance = Math.hypot(dx, dy);
-    if (cell.children === null) {
-      if (cell.body && cell.body !== body) repel(body, cell.cx, cell.cy, cell.mass);
-      return;
-    }
-    // Far enough that the whole cell can stand in for its contents.
-    if (cell.size / Math.max(distance, 0.001) < THETA) {
-      repel(body, cell.cx, cell.cy, cell.mass);
-      return;
-    }
-    for (const child of cell.children) {
-      if (child) applyRepulsion(child, body);
-    }
   }
 
   /* ---- framing ---- */
 
   function fit() {
-    if (order.length === 0 || !width) return;
-    let minX = Infinity;
-    let minY = Infinity;
-    let maxX = -Infinity;
-    let maxY = -Infinity;
-    for (const body of order) {
-      if (body.x < minX) minX = body.x;
-      if (body.y < minY) minY = body.y;
-      if (body.x > maxX) maxX = body.x;
-      if (body.y > maxY) maxY = body.y;
-    }
+    const box = layout.bounds();
+    if (!box || !width) return;
+    const { minX, minY, maxX, maxY } = box;
     // Labels are drawn to the right of their node and are not in the bounds,
     // so the frame is padded for them. A phone shows tag labels only, but it
     // is also where there is least room for one to run off the edge.
@@ -901,16 +773,23 @@ function createSimulation(
     }
     context.globalAlpha = 1;
 
-    const labels: { body: Body; x: number; y: number; radius: number; strong: boolean }[] =
-      [];
-    for (const body of order) {
+    const labels: {
+      node: GraphNode;
+      x: number;
+      y: number;
+      radius: number;
+      strong: boolean;
+    }[] = [];
+    for (const body of layout.order) {
+      const node = nodesById.get(body.id);
+      if (!node) continue;
       const point = project(body);
       const lit = !dimming || near.has(body.id);
       const isSelected = body.id === selection;
       const radius = Math.max(2.5, body.radius * Math.min(1.4, scale));
       context.globalAlpha = lit ? 1 : 0.18;
 
-      if (body.node.kind === "tag") {
+      if (node.kind === "tag") {
         context.fillStyle = palette.tag;
         context.fillRect(point.x - radius, point.y - radius, radius * 2, radius * 2);
         context.strokeStyle = isSelected ? palette.ring : palette.canvas;
@@ -919,9 +798,9 @@ function createSimulation(
       } else {
         context.beginPath();
         context.arc(point.x, point.y, radius, 0, Math.PI * 2);
-        context.fillStyle = body.node.favorite
+        context.fillStyle = node.favorite
           ? palette.favorite
-          : body.node.degree > 0
+          : node.degree > 0
             ? palette.item
             : palette.orphan;
         context.fill();
@@ -945,13 +824,13 @@ function createSimulation(
       // (they are what makes a cluster readable), items only when they are the
       // subject or the view is zoomed in far enough to have room.
       const wanted =
-        body.node.kind === "tag"
+        node.kind === "tag"
           ? true
           : !narrow &&
             (body.id === focus || body.id === selection || (!dimming && scale > 1.5));
       if (wanted && (!dimming || near.has(body.id))) {
         labels.push({
-          body,
+          node,
           x: point.x,
           y: point.y,
           radius,
@@ -964,7 +843,7 @@ function createSimulation(
     if (fontsReady) {
       context.textBaseline = "middle";
       for (const label of labels) {
-        const text = nodeTitle(label.body.node);
+        const text = nodeTitle(label.node);
         const limit = narrow ? 16 : 42;
         const clipped = text.length > limit ? `${text.slice(0, limit - 1)}…` : text;
         context.font = `${label.strong ? "700 " : ""}11px "TX-02", ui-monospace, monospace`;
@@ -975,7 +854,7 @@ function createSimulation(
         context.fillRect(label.x + label.radius + 4, label.y - 7, measured + 6, 14);
         context.globalAlpha = 1;
         context.fillStyle =
-          label.body.node.kind === "tag"
+          label.node.kind === "tag"
             ? palette.tagLabel
             : label.strong
               ? palette.labelStrong
@@ -1005,6 +884,7 @@ function createSimulation(
       // read, and a finger that wanders must not silently pin the node.
       if (!narrow) {
         drag = { body: hit, dx: hit.x - point.x, dy: hit.y - point.y, moved: false };
+        layout.reheat();
       }
     } else {
       pan = { x: event.clientX - translateX, y: event.clientY - translateY };
@@ -1076,6 +956,7 @@ function createSimulation(
     if (hit?.pinned) {
       hit.pinned = false;
       reportPinned();
+      layout.reheat();
       thaw();
     }
   };
@@ -1126,7 +1007,7 @@ function createSimulation(
 
   function reportPinned() {
     let count = 0;
-    for (const body of order) if (body.pinned) count += 1;
+    for (const body of layout.order) if (body.pinned) count += 1;
     handlers.onPinnedChange(count);
   }
 
@@ -1154,39 +1035,16 @@ function createSimulation(
     configure(config) {
       projection = config.projection;
       narrow = config.narrow;
-      reducedMotion = config.reducedMotion;
+      layout.setReducedMotion(config.reducedMotion);
+      nodesById = new Map(projection.nodes.map((node) => [node.id, node]));
 
-      const next: Body[] = [];
-      const keep = new Set<string>();
-      for (const node of projection.nodes) {
-        keep.add(node.id);
-        const existing = bodies.get(node.id);
-        if (existing) {
-          existing.node = node;
-          existing.radius = radiusFor(node);
-          next.push(existing);
-          continue;
-        }
-        const seeded = seedPosition(node.id);
-        const body: Body = {
-          id: node.id,
-          x: seeded.x,
-          y: seeded.y,
-          vx: 0,
-          vy: 0,
-          radius: radiusFor(node),
-          pinned: false,
-          node,
-        };
-        bodies.set(node.id, body);
-        next.push(body);
-      }
-      // A node the filter removed leaves the simulation rather than hiding, so
-      // the layout re-forms around what is left.
-      for (const id of [...bodies.keys()]) {
-        if (!keep.has(id)) bodies.delete(id);
-      }
-      order = next;
+      // The layout reconciles the body set: a surviving node keeps its
+      // position and velocity, a filtered node leaves the simulation rather
+      // than hiding, and the whole thing reheats around what is left.
+      layout.sync(
+        projection.nodes.map((node) => ({ id: node.id, radius: radiusFor(node) })),
+        projection.edges,
+      );
       ticks = 0;
       fitPending = true;
       reportPinned();
@@ -1221,11 +1079,13 @@ function createSimulation(
       fitPending = true;
       warmed = true;
       fit();
+      layout.reheat();
       thaw();
     },
     releaseAll() {
-      for (const body of order) body.pinned = false;
+      for (const body of layout.order) body.pinned = false;
       reportPinned();
+      layout.reheat();
       thaw();
     },
     destroy() {
@@ -1245,8 +1105,7 @@ function createSimulation(
       canvas.removeEventListener("wheel", onWheel);
       canvas.removeEventListener("contextlost", onContextLost);
       canvas.removeEventListener("contextrestored", onContextRestored);
-      bodies.clear();
-      order = [];
+      layout.sync([], []);
     },
   };
 }
@@ -1259,115 +1118,6 @@ function radiusFor(node: GraphNode): number {
   // Tag hubs are count-weighted so a cluster's weight is legible before its
   // label is; items stay uniform, because a save is a save.
   return node.kind === "tag" ? 5 + Math.min(5, node.count * 0.6) : 4.5;
-}
-
-/**
- * A node's opening position is a function of its id, so the same library opens
- * to the same layout instead of a different scatter on every mount.
- */
-function seedPosition(id: string): { x: number; y: number } {
-  let hash = 0x811c9dc5;
-  for (let index = 0; index < id.length; index += 1) {
-    hash ^= id.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193) >>> 0;
-  }
-  const angle = ((hash & 0xffff) / 0xffff) * Math.PI * 2;
-  const radius = 40 + ((hash >>> 16) / 0xffff) * 260;
-  return { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius };
-}
-
-/* ---- Barnes–Hut ---- */
-
-interface Cell {
-  cx: number;
-  cy: number;
-  mass: number;
-  size: number;
-  body: Body | null;
-  children: (Cell | null)[] | null;
-  x0: number;
-  y0: number;
-  x1: number;
-  y1: number;
-}
-
-/**
- * Repulsion is the only O(n²) force here, so it goes through a quadtree.
- * Without it the 2,000-node budget is four million pair tests a frame.
- */
-function buildQuadtree(bodies: Body[]): Cell {
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  for (const body of bodies) {
-    if (body.x < minX) minX = body.x;
-    if (body.y < minY) minY = body.y;
-    if (body.x > maxX) maxX = body.x;
-    if (body.y > maxY) maxY = body.y;
-  }
-  const size = Math.max(maxX - minX, maxY - minY, 1) + 2;
-  const root = makeCell(minX - 1, minY - 1, minX - 1 + size, minY - 1 + size);
-  for (const body of bodies) insert(root, body, 0);
-  return root;
-}
-
-function makeCell(x0: number, y0: number, x1: number, y1: number): Cell {
-  return {
-    cx: 0,
-    cy: 0,
-    mass: 0,
-    size: x1 - x0,
-    body: null,
-    children: null,
-    x0,
-    y0,
-    x1,
-    y1,
-  };
-}
-
-function insert(cell: Cell, body: Body, depth: number): void {
-  // Center of mass is accumulated on the way down, so no second pass is needed.
-  cell.cx = (cell.cx * cell.mass + body.x) / (cell.mass + 1);
-  cell.cy = (cell.cy * cell.mass + body.y) / (cell.mass + 1);
-  cell.mass += 1;
-
-  if (cell.children === null) {
-    if (cell.body === null) {
-      cell.body = body;
-      return;
-    }
-    // Coincident bodies would subdivide forever, so depth is the backstop.
-    if (depth > 20) return;
-    const existing = cell.body;
-    cell.body = null;
-    cell.children = [null, null, null, null];
-    place(cell, existing, depth);
-    place(cell, body, depth);
-    return;
-  }
-  place(cell, body, depth);
-}
-
-function place(cell: Cell, body: Body, depth: number): void {
-  const midX = (cell.x0 + cell.x1) / 2;
-  const midY = (cell.y0 + cell.y1) / 2;
-  const east = body.x >= midX;
-  const south = body.y >= midY;
-  const index = (south ? 2 : 0) + (east ? 1 : 0);
-  const children = cell.children!;
-  let child = children[index] ?? null;
-  if (!child) {
-    child = makeCell(
-      east ? midX : cell.x0,
-      south ? midY : cell.y0,
-      east ? cell.x1 : midX,
-      south ? cell.y1 : midY,
-    );
-    children[index] = child;
-  }
-  insert(child, body, depth + 1);
 }
 
 /* ---- palette ---- */

--- a/web/src/data/graphLayout.test.mjs
+++ b/web/src/data/graphLayout.test.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { DRIFT_NODE_LIMIT, GraphLayout, seedPosition } from "./graphLayout.ts";
+
+/** A library-shaped graph: items around tag hubs, a few co-mentions. */
+function fixture(itemCount, tagCount = Math.ceil(itemCount / 12)) {
+  const nodes = [];
+  const edges = [];
+  for (let tag = 0; tag < tagCount; tag += 1) {
+    nodes.push({ id: `tag:t${tag}`, radius: 7 });
+  }
+  for (let item = 0; item < itemCount; item += 1) {
+    nodes.push({ id: `item:i${item}`, radius: 4.5 });
+    edges.push({
+      source: `item:i${item}`,
+      target: `tag:t${item % tagCount}`,
+      kind: "tag",
+      weight: 1,
+    });
+    // A second tag for every third save, so clusters actually overlap.
+    if (item % 3 === 0) {
+      edges.push({
+        source: `item:i${item}`,
+        target: `tag:t${(item * 7) % tagCount}`,
+        kind: "tag",
+        weight: 1,
+      });
+    }
+    if (item % 25 === 0 && item > 0) {
+      edges.push({
+        source: `item:i${item}`,
+        target: `item:i${item - 25}`,
+        kind: "mention",
+        weight: 1,
+      });
+    }
+  }
+  return { nodes, edges };
+}
+
+function run(layout, ticks) {
+  let moving = 0;
+  for (let tick = 0; tick < ticks; tick += 1) {
+    if (layout.step()) moving = tick + 1;
+    else break;
+  }
+  return moving;
+}
+
+test("a thousand-save library comes to rest", () => {
+  const { nodes, edges } = fixture(1000);
+  const layout = new GraphLayout();
+  layout.sync(nodes, edges);
+  assert.equal(layout.order.length, 1000 + Math.ceil(1000 / 12));
+
+  const ticks = run(layout, 1200);
+
+  // The defect this test exists for: with no alpha the layout ran at full
+  // energy forever, so every node moved at the speed cap indefinitely.
+  assert.ok(layout.settled, `layout never settled (ran ${ticks} ticks)`);
+  assert.ok(ticks < 1200, "settling must not need the whole budget");
+
+  for (const body of layout.order) {
+    assert.ok(Number.isFinite(body.x) && Number.isFinite(body.y), "position diverged");
+  }
+
+  // Bounded, not exploded: a settled thousand-node cloud is large but finite.
+  const bounds = layout.bounds();
+  const width = bounds.maxX - bounds.minX;
+  const height = bounds.maxY - bounds.minY;
+  assert.ok(width > 200 && height > 200, "the cloud collapsed to a point");
+  assert.ok(width < 40_000 && height < 40_000, `the cloud exploded: ${width}x${height}`);
+});
+
+test("a settled layout stays still when it is stepped again", () => {
+  const { nodes, edges } = fixture(600);
+  const layout = new GraphLayout();
+  layout.sync(nodes, edges);
+  run(layout, 1200);
+  assert.ok(layout.settled);
+
+  const before = layout.order.map((body) => ({ x: body.x, y: body.y }));
+  for (let tick = 0; tick < 60; tick += 1) layout.step();
+
+  // A second of frames must not move a settled large graph perceptibly.
+  let furthest = 0;
+  layout.order.forEach((body, index) => {
+    furthest = Math.max(furthest, Math.hypot(body.x - before[index].x, body.y - before[index].y));
+  });
+  assert.ok(furthest < 1, `settled layout drifted ${furthest.toFixed(2)}px in 60 ticks`);
+});
+
+test("a small library keeps breathing, and a large one does not", () => {
+  const small = new GraphLayout();
+  const smallFixture = fixture(40, 5);
+  small.sync(smallFixture.nodes, smallFixture.edges);
+  run(small, 1200);
+  // Drift is the design's "never fully cools": below the limit it never
+  // reports settled, so the render loop keeps running.
+  assert.equal(small.settled, false);
+  assert.ok(small.order.length < DRIFT_NODE_LIMIT);
+
+  const large = new GraphLayout();
+  const largeFixture = fixture(1000);
+  large.sync(largeFixture.nodes, largeFixture.edges);
+  run(large, 1200);
+  assert.equal(large.settled, true);
+});
+
+test("reduced motion settles a graph that would otherwise drift", () => {
+  const layout = new GraphLayout();
+  const { nodes, edges } = fixture(40, 5);
+  layout.setReducedMotion(true);
+  layout.sync(nodes, edges);
+  run(layout, 1200);
+  assert.equal(layout.settled, true);
+});
+
+test("a filter change keeps surviving positions and re-forms around them", () => {
+  const layout = new GraphLayout();
+  const { nodes, edges } = fixture(200);
+  layout.sync(nodes, edges);
+  run(layout, 600);
+
+  const kept = layout.bodies.get("item:i5");
+  const position = { x: kept.x, y: kept.y };
+  // Every tag, and the even-numbered saves — so i5 survives and i1 does not.
+  const half = nodes.filter(
+    (node) => !node.id.startsWith("item:i") || Number(node.id.slice(6)) % 2 === 1,
+  );
+  const keptIds = new Set(half.map((node) => node.id));
+  layout.sync(
+    half,
+    edges.filter((edge) => keptIds.has(edge.source) && keptIds.has(edge.target)),
+  );
+
+  const survivor = layout.bodies.get("item:i5");
+  assert.ok(survivor, "a surviving node must keep its body");
+  assert.equal(survivor.x, position.x);
+  assert.equal(survivor.y, position.y);
+  assert.equal(layout.bodies.has("item:i2"), false, "a filtered node must leave");
+  assert.equal(layout.settled, false, "a new node set must reheat");
+});
+
+test("seed positions are deterministic and spread with the population", () => {
+  assert.deepEqual(seedPosition("item:a"), seedPosition("item:a"));
+
+  const near = Math.hypot(...Object.values(seedPosition("item:a", 1)));
+  const far = Math.hypot(...Object.values(seedPosition("item:a", 4)));
+  // A thousand nodes must not be seeded into the same disc as fifty, or the
+  // view opens on a dense knot and spends its first seconds exploding.
+  assert.ok(far > near * 3.5, "the seed disc must grow with the node count");
+});

--- a/web/src/data/graphLayout.ts
+++ b/web/src/data/graphLayout.ts
@@ -1,0 +1,420 @@
+/**
+ * The force layout behind the library graph, kept apart from the renderer so
+ * the property that actually matters — that it settles, at any size — can be
+ * tested without a canvas.
+ *
+ * The layout cools. An uncooled simulation looks alive at fifty nodes and
+ * looks broken at a thousand: every constant below is either scaled by density
+ * or damped by `alpha`, and both were missing in the first cut.
+ */
+
+export interface LayoutBody {
+  id: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  radius: number;
+  pinned: boolean;
+}
+
+export interface LayoutNode {
+  id: string;
+  radius: number;
+}
+
+export interface LayoutEdge {
+  source: string;
+  target: string;
+  kind: "tag" | "mention";
+  weight: number;
+}
+
+export interface StepOptions {
+  /** The phone's constellation packs tighter, so its links sit shorter. */
+  narrow?: boolean;
+  /** One body is being dragged and must move even though it is pinned. */
+  dragging?: string | null;
+  /** Frame bounds in world units, applied as soft walls once framed. */
+  limitX?: number;
+  limitY?: number;
+}
+
+/**
+ * Above this the drift is switched off and the layout comes to a full stop.
+ *
+ * Perpetual motion is an aesthetic that stops working at scale: a thousand
+ * points each on their own random walk is not life, it is noise, and it costs
+ * a frame's work forever to draw. Small libraries keep the breathing.
+ */
+export const DRIFT_NODE_LIMIT = 300;
+
+/**
+ * Cooling schedule. Roughly 200 ticks to a standstill — about three seconds,
+ * which is long enough for the layout to find its shape and short enough that
+ * nobody watches it wander.
+ */
+const ALPHA_DECAY = 0.03;
+/** Alpha below this is motion nobody can see, so the loop may stop. */
+const ALPHA_MIN = 0.002;
+const DRIFT_ALPHA_FLOOR = 0.05;
+const REPULSION = 1500;
+const VELOCITY_DECAY = 0.86;
+const MAX_SPEED = 6;
+/** Below this the layout is standing still to the eye and the loop can stop. */
+const SETTLED_SPEED = 0.05;
+
+/**
+ * Density-aware constants.
+ *
+ * A thousand nodes need a bigger world than fifty, not the same world with
+ * more things crushed into it. Everything spatial scales with the square root
+ * of the node count, which is how the area grows with the population.
+ */
+export function layoutScale(nodeCount: number): number {
+  return Math.max(1, Math.sqrt(nodeCount / 48));
+}
+
+export class GraphLayout {
+  readonly bodies = new Map<string, LayoutBody>();
+  order: LayoutBody[] = [];
+  private edges: LayoutEdge[] = [];
+  private alphaValue = 1;
+  private floor = DRIFT_ALPHA_FLOOR;
+  private scale = 1;
+  private settledValue = false;
+  private reduced = false;
+
+  get alpha(): number {
+    return this.alphaValue;
+  }
+
+  /** True once nothing is moving and nothing will move without a nudge. */
+  get settled(): boolean {
+    return this.settledValue;
+  }
+
+  /** Under reduced motion the floor is zero, so it stops rather than breathes. */
+  setReducedMotion(reduced: boolean): void {
+    this.reduced = reduced;
+    this.applyFloor();
+  }
+
+  /**
+   * Reconciles the body set against a projection.
+   *
+   * Surviving nodes keep their position and velocity, so a filter change
+   * re-forms the layout around what is left rather than restarting it.
+   */
+  sync(nodes: LayoutNode[], edges: LayoutEdge[]): void {
+    this.edges = edges;
+    this.scale = layoutScale(nodes.length);
+    const next: LayoutBody[] = [];
+    const keep = new Set<string>();
+
+    for (const node of nodes) {
+      keep.add(node.id);
+      const existing = this.bodies.get(node.id);
+      if (existing) {
+        existing.radius = node.radius;
+        next.push(existing);
+        continue;
+      }
+      const seeded = seedPosition(node.id, this.scale);
+      const body: LayoutBody = {
+        id: node.id,
+        x: seeded.x,
+        y: seeded.y,
+        vx: 0,
+        vy: 0,
+        radius: node.radius,
+        pinned: false,
+      };
+      this.bodies.set(node.id, body);
+      next.push(body);
+    }
+    for (const id of [...this.bodies.keys()]) {
+      if (!keep.has(id)) this.bodies.delete(id);
+    }
+
+    this.order = next;
+    this.applyFloor();
+    this.reheat();
+  }
+
+  /** Returns the layout to full energy — a new node set, or a released pin. */
+  reheat(): void {
+    this.alphaValue = 1;
+    this.settledValue = false;
+  }
+
+  private applyFloor(): void {
+    this.floor =
+      this.reduced || this.order.length > DRIFT_NODE_LIMIT ? 0 : DRIFT_ALPHA_FLOOR;
+  }
+
+  /**
+   * One tick. Returns false once the layout has settled and the caller can
+   * stop asking.
+   */
+  step(options: StepOptions = {}): boolean {
+    const bodies = this.order;
+    if (bodies.length === 0) return false;
+
+    this.alphaValue += (this.floor - this.alphaValue) * ALPHA_DECAY;
+    const alpha = this.alphaValue;
+    const narrow = options.narrow ?? false;
+
+    // Repulsion through a quadtree: the only O(n²) force here, and the reason
+    // a thousand nodes is four million pair tests a frame without one.
+    const cutoff = (300 * this.scale) ** 2;
+    const tree = bodies.length > 48 ? buildQuadtree(bodies) : null;
+    for (const body of bodies) {
+      if (tree) applyRepulsion(tree, body, cutoff);
+      else {
+        for (const other of bodies) {
+          if (other !== body) repel(body, other.x, other.y, 1, cutoff);
+        }
+      }
+    }
+
+    for (const edge of this.edges) {
+      const from = this.bodies.get(edge.source);
+      const to = this.bodies.get(edge.target);
+      if (!from || !to) continue;
+      // Co-mentions pull tighter than tag membership: a pair someone wrote
+      // about together is a stronger statement than a shared tag.
+      const rest = edge.kind === "mention" ? (narrow ? 42 : 56) : narrow ? 58 : 82;
+      const dx = to.x - from.x;
+      const dy = to.y - from.y;
+      const distance = Math.max(1, Math.hypot(dx, dy));
+      const strength =
+        ((distance - rest) * (edge.kind === "mention" ? 0.014 : 0.02)) /
+        Math.max(1, Math.log2(1 + edge.weight));
+      from.vx += (dx / distance) * strength;
+      from.vy += (dy / distance) * strength;
+      to.vx -= (dx / distance) * strength;
+      to.vy -= (dy / distance) * strength;
+    }
+
+    // Centring has to weaken as the population grows or it crushes a large
+    // library into one over-energised ball that can never come to rest.
+    const gravity = 0.0022 / this.scale;
+    const drift = this.floor > 0;
+    let fastest = 0;
+
+    for (const body of bodies) {
+      body.vx -= body.x * gravity;
+      body.vy -= body.y * gravity * 1.18;
+      if (drift) {
+        // The design system bans CSS motion, so what life the graph has must
+        // live in the pixels. Damped by alpha, this is a breath, not a walk.
+        body.vx += (Math.random() - 0.5) * 0.09 * alpha;
+        body.vy += (Math.random() - 0.5) * 0.09 * alpha;
+      }
+      body.vx *= VELOCITY_DECAY;
+      body.vy *= VELOCITY_DECAY;
+      const speed = Math.hypot(body.vx, body.vy);
+      if (speed > MAX_SPEED) {
+        body.vx = (body.vx / speed) * MAX_SPEED;
+        body.vy = (body.vy / speed) * MAX_SPEED;
+      }
+      if (!body.pinned || options.dragging === body.id) {
+        // Alpha scales the displacement, not the forces: the layout still
+        // resolves its structure, it just stops travelling to do it.
+        body.x += body.vx * alpha;
+        body.y += body.vy * alpha;
+      }
+      const moved = speed * alpha;
+      if (moved > fastest) fastest = moved;
+    }
+
+    // Soft walls at the frame edge: drift stays alive, but nothing wanders out
+    // of the panel and becomes unreachable.
+    if (options.limitX && options.limitY) {
+      for (const body of bodies) {
+        if (Math.abs(body.x) > options.limitX) {
+          body.vx -= (body.x - Math.sign(body.x) * options.limitX) * 0.05;
+        }
+        if (Math.abs(body.y) > options.limitY) {
+          body.vy -= (body.y - Math.sign(body.y) * options.limitY) * 0.05;
+        }
+      }
+    }
+
+    this.settledValue =
+      this.alphaValue <= this.floor + ALPHA_MIN && fastest < SETTLED_SPEED;
+    return !this.settledValue;
+  }
+
+  /** The world-space box the layout currently occupies. */
+  bounds(): { minX: number; minY: number; maxX: number; maxY: number } | null {
+    if (this.order.length === 0) return null;
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const body of this.order) {
+      if (body.x < minX) minX = body.x;
+      if (body.y < minY) minY = body.y;
+      if (body.x > maxX) maxX = body.x;
+      if (body.y > maxY) maxY = body.y;
+    }
+    return { minX, minY, maxX, maxY };
+  }
+}
+
+/**
+ * A node's opening position is a function of its id, so the same library opens
+ * to the same layout instead of a different scatter every time — and the disc
+ * grows with the population, or a large library starts as one dense knot and
+ * spends its first seconds exploding out of it.
+ */
+export function seedPosition(id: string, scale = 1): { x: number; y: number } {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < id.length; index += 1) {
+    hash ^= id.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  const angle = ((hash & 0xffff) / 0xffff) * Math.PI * 2;
+  const radius = (40 + ((hash >>> 16) / 0xffff) * 260) * scale;
+  return { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius };
+}
+
+function repel(
+  body: LayoutBody,
+  x: number,
+  y: number,
+  mass: number,
+  cutoff: number,
+): void {
+  let dx = body.x - x;
+  let dy = body.y - y;
+  let squared = dx * dx + dy * dy;
+  if (squared < 1) {
+    // Coincident bodies have no direction to separate along, so one is
+    // invented deterministically from the id.
+    dx = (body.id.charCodeAt(0) % 3) - 1 || 0.7;
+    dy = (body.id.charCodeAt(1) % 3) - 1 || 0.7;
+    squared = 2;
+  }
+  if (squared > cutoff) return;
+  const distance = Math.sqrt(squared);
+  const force = (REPULSION * mass) / squared;
+  body.vx += (dx / distance) * force;
+  body.vy += (dy / distance) * force;
+}
+
+/* ---- Barnes–Hut ---- */
+
+interface Cell {
+  cx: number;
+  cy: number;
+  mass: number;
+  size: number;
+  body: LayoutBody | null;
+  children: (Cell | null)[] | null;
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+}
+
+/** Opening angle. Higher approximates more aggressively and costs less. */
+const THETA = 0.9;
+
+function applyRepulsion(cell: Cell, body: LayoutBody, cutoff: number): void {
+  if (cell.mass === 0) return;
+  const dx = cell.cx - body.x;
+  const dy = cell.cy - body.y;
+  const distance = Math.hypot(dx, dy);
+  if (cell.children === null) {
+    if (cell.body && cell.body !== body) {
+      repel(body, cell.cx, cell.cy, cell.mass, cutoff);
+    }
+    return;
+  }
+  // Far enough that the whole cell can stand in for its contents.
+  if (cell.size / Math.max(distance, 0.001) < THETA) {
+    repel(body, cell.cx, cell.cy, cell.mass, cutoff);
+    return;
+  }
+  for (const child of cell.children) {
+    if (child) applyRepulsion(child, body, cutoff);
+  }
+}
+
+function buildQuadtree(bodies: LayoutBody[]): Cell {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const body of bodies) {
+    if (body.x < minX) minX = body.x;
+    if (body.y < minY) minY = body.y;
+    if (body.x > maxX) maxX = body.x;
+    if (body.y > maxY) maxY = body.y;
+  }
+  const size = Math.max(maxX - minX, maxY - minY, 1) + 2;
+  const root = makeCell(minX - 1, minY - 1, minX - 1 + size, minY - 1 + size);
+  for (const body of bodies) insert(root, body, 0);
+  return root;
+}
+
+function makeCell(x0: number, y0: number, x1: number, y1: number): Cell {
+  return {
+    cx: 0,
+    cy: 0,
+    mass: 0,
+    size: x1 - x0,
+    body: null,
+    children: null,
+    x0,
+    y0,
+    x1,
+    y1,
+  };
+}
+
+function insert(cell: Cell, body: LayoutBody, depth: number): void {
+  // Centre of mass accumulates on the way down, so no second pass is needed.
+  cell.cx = (cell.cx * cell.mass + body.x) / (cell.mass + 1);
+  cell.cy = (cell.cy * cell.mass + body.y) / (cell.mass + 1);
+  cell.mass += 1;
+
+  if (cell.children === null) {
+    if (cell.body === null) {
+      cell.body = body;
+      return;
+    }
+    // Coincident bodies would subdivide forever, so depth is the backstop.
+    if (depth > 20) return;
+    const existing = cell.body;
+    cell.body = null;
+    cell.children = [null, null, null, null];
+    place(cell, existing, depth);
+    place(cell, body, depth);
+    return;
+  }
+  place(cell, body, depth);
+}
+
+function place(cell: Cell, body: LayoutBody, depth: number): void {
+  const midX = (cell.x0 + cell.x1) / 2;
+  const midY = (cell.y0 + cell.y1) / 2;
+  const east = body.x >= midX;
+  const south = body.y >= midY;
+  const index = (south ? 2 : 0) + (east ? 1 : 0);
+  const children = cell.children!;
+  let child = children[index] ?? null;
+  if (!child) {
+    child = makeCell(
+      east ? midX : cell.x0,
+      south ? midY : cell.y0,
+      east ? cell.x1 : midX,
+      south ? cell.y1 : midY,
+    );
+    children[index] = child;
+  }
+  insert(child, body, depth + 1);
+}


### PR DESCRIPTION
Fixes a regression in #166: a thousand-save library opened the graph into
permanent churn. Everything moved, at full speed, forever.

## What was wrong

Three defects compounded, all in the first cut of the layout, and all of them
invisible at the eight-save library it was verified against.

1. **The simulation never cooled.** `issues/graph-view.md` asks for drift that
   *"never fully cools (**alpha floor**)"*. What shipped was the never-cools
   half with no alpha at all — the forces ran at full strength indefinitely.
2. **Every constant was tuned for the ~50-node prototype and was blind to
   density.** Centring (`0.0022`) crushed a thousand nodes toward one origin
   while repulsion pushed back, leaving most nodes permanently inside each
   other's repulsion range. The 6px/frame speed cap then saturated, so every
   node moved at maximum speed on every frame.
3. **Seed positions ignored the population.** A thousand nodes were scattered
   into the same 40–300px disc as forty-four, so the view opened on a dense
   knot and spent its first seconds exploding out of it.

## What changed

- **Alpha decays to a floor and scales displacement, not force.** The layout
  still resolves its structure; it just stops travelling to do it.
- **Gravity and the repulsion cutoff scale with `sqrt(nodeCount)`.** A large
  library gets a larger world rather than the same world packed tighter.
- **The seed disc grows with the count**, so nothing opens as a knot.
- **Above `DRIFT_NODE_LIMIT` (300) the drift is off and the layout fully
  stops**, which lets the render loop stop too. Perpetual motion is an
  aesthetic that stops working at scale — a thousand independent random walks
  is noise, and it costs a frame's work forever. Small libraries keep it.
- Grabbing a node, unpinning, releasing all, and `reset` now reheat the layout,
  so a settled graph still responds to being handled.

## Why it moved to its own module

`web/src/data/graphLayout.ts` exists so the property that broke — *does it
settle, at any size* — can be asserted without a canvas. It was previously
buried in a closure inside the renderer and could only be checked by eye, which
is exactly how a 1,000-node defect shipped past a 8-node check.

`graphLayout.test.mjs` asserts settling at 1,000 nodes, that a settled layout
does not drift more than 1px over 60 further ticks, that small libraries keep
breathing while large ones stop, that reduced motion always stops, that a
filter change preserves surviving positions, and that seeds spread with count.

## Measured

Library-shaped fixture — items around tag hubs, some multi-tagged:

| nodes | behaviour | cost | settled extent |
|---|---|---|---|
| 52 | drifts (by design) | 0.03 ms/tick | 585 × 485 |
| 325 | settles in 243 ticks | 0.26 ms/tick | 1014 × 951 |
| **1080** | **settles in 289 ticks (~4.8 s)** | **1.24 ms/tick** | 2341 × 2424 |
| 2120 | settles in 319 ticks | 2.71 ms/tick | 3596 × 3624 |

Comfortably inside the 8 ms/tick budget at the 2,000-node target, and zero
cost once settled because the loop stops.

## Verification

- `npm run verify` passes: 29 tests (6 new), typecheck, `check:design`,
  `check:dist`.
- Browser-checked at the small end (8 saves) to confirm no regression in the
  drift case: same framing, same clusters, no console errors.
- **Not** browser-checked at 1,000 saves — that would have meant writing a
  thousand junk items into a real library. The settling property is covered by
  the unit tests above instead.
