### PR TITLE
Add graph navigation and collapsible sidebars

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -96,6 +96,7 @@ interface UndoNotice {
 
 const DENSITY_STORAGE_KEY = "researchpocket.ui.density";
 const LIBRARY_MODE_STORAGE_KEY = "researchpocket.ui.library-mode";
+const RAIL_COLLAPSED_STORAGE_KEY = "researchpocket.ui.rail-collapsed";
 const THEME_STORAGE_KEY = "researchpocket.ui.theme";
 const IMAGE_BACKGROUND_STORAGE_KEY = "researchpocket.ui.image-background";
 const DEFAULT_IMAGE_BACKGROUND = "#ffffff";
@@ -219,6 +220,9 @@ export function App() {
   const [libraryMode, setLibraryMode] = useState<LibraryMode>(() =>
     readInitialLibraryMode(),
   );
+  const [railCollapsed, setRailCollapsed] = useState(() =>
+    readRailCollapsedPreference(),
+  );
   const [zenMentions, setZenMentions] = useState<GraphMentionSource[]>([]);
   const [capturing, setCapturing] = useState(false);
   const [commandOpen, setCommandOpen] = useState(false);
@@ -287,6 +291,17 @@ export function App() {
       // The preference remains active for this tab when storage is unavailable.
     }
   }, [density]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        RAIL_COLLAPSED_STORAGE_KEY,
+        String(railCollapsed),
+      );
+    } catch {
+      // The preference remains active for this tab when storage is unavailable.
+    }
+  }, [railCollapsed]);
 
   // The remembered mode is written into the URL once, on open. After that the
   // parameter is the only thing that decides, so going back out of the graph
@@ -994,6 +1009,21 @@ export function App() {
                   say which screen it is on, so the two swap places there. */}
               <p className="brand-view">{formatViewLabel(view)}</p>
             </button>
+            {railApplies ? (
+              <button
+                aria-controls="workspace-sidebar"
+                aria-expanded={!railCollapsed}
+                className="workspace-rail-toggle"
+                onClick={() => setRailCollapsed((collapsed) => !collapsed)}
+                title={railCollapsed ? "Show sidebar" : "Hide sidebar"}
+                type="button"
+              >
+                <span aria-hidden="true">{railCollapsed ? "sidebar →" : "sidebar ←"}</span>
+                <span className="sr-only">
+                  {railCollapsed ? "Show sidebar" : "Hide sidebar"}
+                </span>
+              </button>
+            ) : null}
           </div>
 
           <div className="masthead-actions">
@@ -1052,8 +1082,13 @@ export function App() {
         </header>
       </div>
 
-      <div className="workspace-layout">
-        <aside className={`tag-rail${railApplies ? "" : " tag-rail-empty"}`}>
+      <div
+        className={`workspace-layout${railCollapsed || !railApplies ? " workspace-layout-rail-collapsed" : ""}`}
+      >
+        <aside
+          className={`tag-rail${railApplies ? "" : " tag-rail-empty"}`}
+          id="workspace-sidebar"
+        >
           <nav aria-label="Library views" className="rail-nav">
             <button
               aria-current={view === "library" && filter === "active" && !favoriteOnly ? "page" : undefined}
@@ -1508,7 +1543,9 @@ export function App() {
             <span><b>/</b> search</span>
             <span><b>⌘V</b> save a URL</span>
             <span><b>⏎</b> reader</span>
-            {libraryMode === "graph" ? <span><b>0</b> reframe</span> : null}
+            {libraryMode === "graph" ? <span><b>0</b> fit all</span> : null}
+            {libraryMode === "graph" ? <span><b>+/-</b> zoom</span> : null}
+            {libraryMode === "graph" ? <span><b>C</b> focus</span> : null}
           </footer>
           </section>
         </main>
@@ -3871,6 +3908,14 @@ function readDensityPreference(): Density {
       : "comfortable";
   } catch {
     return "comfortable";
+  }
+}
+
+function readRailCollapsedPreference(): boolean {
+  try {
+    return window.localStorage.getItem(RAIL_COLLAPSED_STORAGE_KEY) === "true";
+  } catch {
+    return false;
   }
 }
 

--- a/web/src/components/LibraryGraph.tsx
+++ b/web/src/components/LibraryGraph.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
 import { GraphLayout, type LayoutBody } from "../data/graphLayout.ts";
 import {
   buildGraphProjection,
@@ -50,6 +56,7 @@ interface Palette {
 const MIN_SCALE = 0.08;
 const MAX_SCALE = 4;
 const MOBILE_QUERY = "(max-width: 48rem)";
+const INSPECTOR_OPEN_STORAGE_KEY = "researchpocket.ui.graph-inspector-open";
 
 export function LibraryGraph({
   items,
@@ -71,6 +78,9 @@ export function LibraryGraph({
   const [zoom, setZoom] = useState(1);
   const [pinnedCount, setPinnedCount] = useState(0);
   const [legendOpen, setLegendOpen] = useState(false);
+  const [inspectorOpen, setInspectorOpen] = useState(() =>
+    readInspectorPreference(),
+  );
   const [narrow, setNarrow] = useState(() => matchesNarrow());
   const [unavailable, setUnavailable] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -94,6 +104,7 @@ export function LibraryGraph({
 
   const ceiling = narrow ? GRAPH_MOBILE_NODE_CEILING : GRAPH_NODE_CEILING;
   const overCeiling = projection.nodes.length > ceiling;
+  const drawable = !overCeiling && !unavailable;
 
   const selected = selectedId
     ? (projection.nodes.find((node) => node.id === selectedId) ?? null)
@@ -132,6 +143,17 @@ export function LibraryGraph({
   }, []);
 
   useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        INSPECTOR_OPEN_STORAGE_KEY,
+        String(inspectorOpen),
+      );
+    } catch {
+      // The preference remains active for this tab when storage is unavailable.
+    }
+  }, [inspectorOpen]);
+
+  useEffect(() => {
     const media = window.matchMedia?.(MOBILE_QUERY);
     const onNarrow = () => setNarrow(matchesNarrow());
     media?.addEventListener("change", onNarrow);
@@ -161,23 +183,6 @@ export function LibraryGraph({
     return () => document.removeEventListener("visibilitychange", update);
   }, [hidden]);
 
-  // `0` reframes the field. It is a window shortcut rather than a canvas one
-  // because the canvas is aria-hidden and so never takes focus itself.
-  useEffect(() => {
-    if (hidden) return;
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key !== "0" || event.ctrlKey || event.metaKey || event.altKey) return;
-      const target = event.target as HTMLElement | null;
-      if (target?.matches("input, textarea, select") || target?.isContentEditable) {
-        return;
-      }
-      event.preventDefault();
-      simulation.current?.reset();
-    }
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [hidden]);
-
   // A selection that the filter just removed would leave the inspector
   // describing something no longer on screen.
   useEffect(() => {
@@ -187,6 +192,24 @@ export function LibraryGraph({
   }, [projection.nodes, selectedId]);
 
   const cursors = useRef(new Map<string, number>());
+
+  function handleCameraKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (!drawable || event.ctrlKey || event.metaKey || event.altKey) return;
+    if (event.target !== event.currentTarget) return;
+    if (event.key === "0") {
+      event.preventDefault();
+      simulation.current?.reset();
+    } else if (event.key === "+" || event.key === "=") {
+      event.preventDefault();
+      simulation.current?.zoomBy(1.25);
+    } else if (event.key === "-" || event.key === "_") {
+      event.preventDefault();
+      simulation.current?.zoomBy(0.8);
+    } else if (event.key.toLowerCase() === "c" && selectedId) {
+      event.preventDefault();
+      simulation.current?.focus(selectedId);
+    }
+  }
 
   function openSelection(node: GraphNode) {
     const itemId = nodeItemId(node.id);
@@ -265,6 +288,38 @@ export function LibraryGraph({
   return (
     <div className="library-graph">
       <div className="graph-toolbar">
+        {drawable ? (
+          <div aria-label="Graph camera" className="graph-camera" role="group">
+            <button
+              aria-label="Zoom out"
+              onClick={() => simulation.current?.zoomBy(0.8)}
+              type="button"
+            >
+              −
+            </button>
+            <output aria-label="Zoom level">{Math.round(zoom * 100)}%</output>
+            <button
+              aria-label="Zoom in"
+              onClick={() => simulation.current?.zoomBy(1.25)}
+              type="button"
+            >
+              +
+            </button>
+            <button
+              disabled={!selected}
+              onClick={() => selected && simulation.current?.focus(selected.id)}
+              type="button"
+            >
+              Focus
+            </button>
+            <button
+              onClick={() => simulation.current?.reset()}
+              type="button"
+            >
+              Fit all
+            </button>
+          </div>
+        ) : null}
         <button
           aria-pressed={showTags}
           onClick={() => setShowTags((value) => !value)}
@@ -286,7 +341,7 @@ export function LibraryGraph({
         >
           orphans · {orphansOnly ? "only" : full.orphans.length}
         </button>
-        {!overCeiling && !unavailable ? (
+        {drawable ? (
           <button
             aria-controls="graph-legend"
             aria-expanded={legendOpen}
@@ -294,6 +349,16 @@ export function LibraryGraph({
             type="button"
           >
             legend
+          </button>
+        ) : null}
+        {!narrow ? (
+          <button
+            aria-controls="graph-inspector"
+            aria-expanded={inspectorOpen}
+            onClick={() => setInspectorOpen((open) => !open)}
+            type="button"
+          >
+            details
           </button>
         ) : null}
         {pinnedCount > 0 ? (
@@ -307,8 +372,20 @@ export function LibraryGraph({
         ) : null}
       </div>
 
-      <div className="graph-body">
-        <div className="graph-stage">
+      <div
+        className={`graph-body${!narrow && !inspectorOpen ? " graph-body-inspector-closed" : ""}`}
+      >
+        <div
+          aria-describedby={drawable ? "graph-camera-shortcuts" : undefined}
+          aria-label={drawable ? "Graph canvas" : undefined}
+          className="graph-stage"
+          onKeyDown={handleCameraKeyDown}
+          tabIndex={!hidden && drawable ? 0 : -1}
+        >
+          <p className="sr-only" id="graph-camera-shortcuts">
+            When this graph has focus, plus and minus zoom, 0 fits all nodes,
+            and C focuses the selected node.
+          </p>
           <canvas
             aria-hidden="true"
             className="graph-canvas"
@@ -382,27 +459,6 @@ export function LibraryGraph({
                   </div>
                 </dl>
               ) : null}
-
-              <div className="graph-zoom">
-                <button
-                  aria-label="Zoom out"
-                  onClick={() => simulation.current?.zoomBy(0.8)}
-                  type="button"
-                >
-                  −
-                </button>
-                <span>{Math.round(zoom * 100)}%</span>
-                <button
-                  aria-label="Zoom in"
-                  onClick={() => simulation.current?.zoomBy(1.25)}
-                  type="button"
-                >
-                  +
-                </button>
-                <button onClick={() => simulation.current?.reset()} type="button">
-                  reset
-                </button>
-              </div>
             </>
           ) : null}
 
@@ -413,7 +469,10 @@ export function LibraryGraph({
           {nodeList}
         </div>
 
-        <aside className="graph-inspector">
+        <aside
+          className={`graph-inspector${!narrow && !inspectorOpen ? " graph-inspector-closed" : ""}`}
+          id="graph-inspector"
+        >
           <div className="graph-inspector-heading">
             <p>Selected</p>
             <span>{selected ? kindLabel(selected) : "—"}</span>
@@ -582,6 +641,14 @@ function matchesNarrow(): boolean {
   return window.matchMedia?.(MOBILE_QUERY).matches ?? false;
 }
 
+function readInspectorPreference(): boolean {
+  try {
+    return window.localStorage.getItem(INSPECTOR_OPEN_STORAGE_KEY) !== "false";
+  } catch {
+    return true;
+  }
+}
+
 function nodeButtonId(id: string): string {
   return `graph-node-${id.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
 }
@@ -656,6 +723,7 @@ interface Simulation {
   setSelection(id: string | null): void;
   setRunning(running: boolean): void;
   center(id: string): void;
+  focus(id: string): void;
   zoomBy(factor: number): void;
   reset(): void;
   releaseAll(): void;
@@ -750,7 +818,7 @@ function createSimulation(
     dpr = window.devicePixelRatio || 1;
     canvas.width = Math.round(rect.width * dpr);
     canvas.height = Math.round(rect.height * dpr);
-    fitPending = true;
+    if (!warmed) fitPending = true;
     thaw();
   };
   const observer = new ResizeObserver(resize);
@@ -958,6 +1026,7 @@ function createSimulation(
   /* ---- pointer input ---- */
 
   const onPointerDown = (event: PointerEvent) => {
+    canvas.parentElement?.focus({ preventScroll: true });
     pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
     if (pointers.size === 2) {
       pinch = { distance: pointerDistance(), scale };
@@ -968,7 +1037,7 @@ function createSimulation(
     canvas.setPointerCapture(event.pointerId);
     const point = toWorld(event.clientX, event.clientY);
     const hit = pick(point.x, point.y);
-      if (hit) {
+    if (hit) {
       selection = hit.id;
       handlers.onSelect(hit.id);
       // Drag-to-pin is a mouse gesture. On a phone the same press is a tap to
@@ -1189,6 +1258,15 @@ function createSimulation(
       if (!body) return;
       translateX = -body.x * scale;
       translateY = -body.y * scale;
+      thaw();
+    },
+    focus(id) {
+      const body = bodies.get(id);
+      if (!body) return;
+      scale = Math.max(scale, 1);
+      translateX = -body.x * scale;
+      translateY = -body.y * scale;
+      handlers.onScale(scale);
       thaw();
     },
     zoomBy(factor) {

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1969,7 +1969,6 @@ footer {
   .selected-tags > span,
   .selected-tags button,
   .graph-toolbar button,
-  .graph-zoom button,
   .graph-inspector-actions button,
   .graph-inspector-actions a,
   .graph-inspector-tags button,
@@ -2219,6 +2218,25 @@ kbd {
   grid-template-columns: 14rem minmax(0, 1fr);
   min-height: 0;
   position: relative;
+}
+
+.workspace-layout-rail-collapsed {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.workspace-layout-rail-collapsed .tag-rail,
+.tag-rail.tag-rail-empty {
+  display: none;
+}
+
+.workspace-rail-toggle {
+  background: transparent;
+  border: var(--rule) solid var(--color-border);
+  border-radius: var(--radius);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  min-height: 2rem;
+  padding: 0 var(--space-2);
 }
 
 .mobile-actions {
@@ -3231,6 +3249,14 @@ kbd {
     flex: 1 1 auto;
     flex-direction: column;
     overflow: visible;
+  }
+
+  .workspace-layout-rail-collapsed .tag-rail:not(.tag-rail-empty) {
+    display: flex;
+  }
+
+  .workspace-rail-toggle {
+    display: none;
   }
 
   .tag-rail {
@@ -5553,11 +5579,39 @@ kbd {
 }
 
 .graph-toolbar {
+  align-items: center;
   display: flex;
   flex: 0 0 auto;
   gap: var(--space-2);
   overflow-x: auto;
   padding-bottom: var(--space-3);
+}
+
+.graph-camera {
+  align-items: center;
+  border: var(--rule) solid var(--color-border-strong);
+  border-radius: var(--radius);
+  display: flex;
+  flex: 0 0 auto;
+  overflow: hidden;
+}
+
+.graph-toolbar .graph-camera button {
+  border: 0;
+}
+
+.graph-camera button + button,
+.graph-camera output + button,
+.graph-camera button + output {
+  border-left: var(--rule) solid var(--color-border-subtle);
+}
+
+.graph-camera output {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  padding: 0 var(--space-2);
+  text-align: center;
+  width: 3.25rem;
 }
 
 .graph-toolbar button {
@@ -5591,6 +5645,10 @@ kbd {
   flex: 1 1 auto;
   grid-template-columns: minmax(0, 1fr) 20rem;
   min-height: 0;
+}
+
+.graph-body.graph-body-inspector-closed {
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .graph-stage {
@@ -5692,43 +5750,6 @@ kbd {
   background: var(--accent);
 }
 
-.graph-zoom {
-  align-items: center;
-  background: var(--color-surface);
-  border: var(--rule) solid var(--color-border-subtle);
-  bottom: 0.75rem;
-  display: flex;
-  position: absolute;
-  right: 0.75rem;
-}
-
-.graph-zoom button {
-  background: transparent;
-  border: 0;
-  color: var(--color-text-soft);
-  font-size: var(--font-size-sm);
-  min-height: 1.875rem;
-  padding: 0 0.625rem;
-}
-
-.graph-zoom button:last-child {
-  color: var(--color-text-muted);
-  font-size: var(--font-size-xs);
-}
-
-.graph-zoom button + span,
-.graph-zoom span + button {
-  border-left: var(--rule) solid var(--color-border-subtle);
-}
-
-.graph-zoom span {
-  color: var(--color-text-muted);
-  font-size: var(--font-size-xs);
-  padding: 0 var(--space-2);
-  text-align: center;
-  width: 3.25rem;
-}
-
 .graph-notice {
   display: grid;
   gap: var(--space-3);
@@ -5784,6 +5805,10 @@ kbd {
   min-height: 0;
   overflow: auto;
   padding: var(--space-5);
+}
+
+.graph-inspector-closed {
+  display: none;
 }
 
 .graph-inspector-heading {
@@ -5932,7 +5957,6 @@ kbd {
 
 @media (hover: hover) and (pointer: fine) {
   .graph-toolbar button:hover,
-  .graph-zoom button:hover,
   .graph-nodes button:hover,
   .graph-neighbourhood button:hover,
   .graph-inspector-tags button:hover,
@@ -5975,7 +5999,6 @@ kbd {
     min-height: 18rem;
   }
 
-  .graph-zoom,
   .graph-neighbourhood {
     display: none;
   }


### PR DESCRIPTION
Closes #171.

## User-visible changes

- Adds grouped Zoom out, Zoom in, Focus selected, and Fit all camera controls to the graph toolbar.
- Keeps graph shortcuts scoped to the focused graph stage, with an accessible shortcut description.
- Makes the desktop workspace rail collapsible and returns its full 14rem column to the active view.
- Makes the graph inspector independently collapsible and returns its full column to the canvas.
- Persists both desktop panel preferences in local storage while leaving the mobile navigation strip available.
- Preserves the current graph pan and zoom when either panel changes the canvas size.

## Architecture and protocol impact

- Camera controls change only canvas scale and translation.
- Panel preferences are local UI state and are not synchronized, published, or stored in protocol data.
- Force constants, node coordinates, graph topology, and item mutation semantics are unchanged.

## Verification

- `npm run verify`: 30 tests, TypeScript, design-system checks, production Vite build, and artifact checks passed.
- `git diff --check` passed.
- Independent regression review found no remaining code issues.

## UI evidence

Responsive behavior was checked against the desktop/mobile CSS boundaries and production build. Live DevTools capture remains unavailable because the local Chrome instance does not expose remote debugging.