### PR TITLE
Collapse the sidebar to a glyph rail

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -995,6 +995,29 @@ export function App() {
                 <span>{pushedScreen.label}</span>
               </button>
             ) : null}
+            {/* Ahead of the wordmark, where the design puts it: the control
+                belongs to the panel it opens, not to the brand. */}
+            {railApplies ? (
+              <button
+                aria-controls="workspace-sidebar"
+                aria-expanded={!railCollapsed}
+                className="workspace-rail-toggle"
+                onClick={() => setRailCollapsed((collapsed) => !collapsed)}
+                title={railCollapsed ? "Show sidebar" : "Hide sidebar"}
+                type="button"
+              >
+                {/* Three rules rather than the word "sidebar": the button sits
+                    beside the wordmark, where a second label competes with it. */}
+                <span aria-hidden="true" className="rail-toggle-glyph">
+                  <span />
+                  <span />
+                  <span />
+                </span>
+                <span className="sr-only">
+                  {railCollapsed ? "Show sidebar" : "Hide sidebar"}
+                </span>
+              </button>
+            ) : null}
             <button
               aria-label={view === "library" ? "ResearchPocket library" : "Back to library"}
               className="brand-lockup"
@@ -1009,21 +1032,6 @@ export function App() {
                   say which screen it is on, so the two swap places there. */}
               <p className="brand-view">{formatViewLabel(view)}</p>
             </button>
-            {railApplies ? (
-              <button
-                aria-controls="workspace-sidebar"
-                aria-expanded={!railCollapsed}
-                className="workspace-rail-toggle"
-                onClick={() => setRailCollapsed((collapsed) => !collapsed)}
-                title={railCollapsed ? "Show sidebar" : "Hide sidebar"}
-                type="button"
-              >
-                <span aria-hidden="true">{railCollapsed ? "sidebar →" : "sidebar ←"}</span>
-                <span className="sr-only">
-                  {railCollapsed ? "Show sidebar" : "Hide sidebar"}
-                </span>
-              </button>
-            ) : null}
           </div>
 
           <div className="masthead-actions">
@@ -1083,24 +1091,40 @@ export function App() {
       </div>
 
       <div
-        className={`workspace-layout${railCollapsed || !railApplies ? " workspace-layout-rail-collapsed" : ""}`}
+        className={`workspace-layout${
+          !railApplies
+            ? " workspace-layout-rail-hidden"
+            : railCollapsed
+              ? " workspace-layout-rail-collapsed"
+              : ""
+        }`}
       >
         <aside
-          className={`tag-rail${railApplies ? "" : " tag-rail-empty"}`}
+          className={`tag-rail${railApplies ? "" : " tag-rail-empty"}${
+            railCollapsed ? " tag-rail-collapsed" : ""
+          }`}
           id="workspace-sidebar"
         >
-          <nav aria-label="Library views" className="rail-nav">
+          {/* Collapsed, the sidebar keeps its destinations as a glyph rail
+              instead of leaving the screen: the counts and the tag list are
+              what there is no room for, not the navigation. CSS shows exactly
+              one of these two, so only one reaches the accessibility tree. */}
+          <nav aria-label="Workspace navigation" className="rail-glyphs">
             <button
-              aria-current={view === "library" && filter === "active" && !favoriteOnly ? "page" : undefined}
+              aria-current={
+                view === "library" && filter === "active" && !favoriteOnly ? "page" : undefined
+              }
               onClick={() => {
                 navigateToView("library");
                 setFilter("active");
                 setFavoriteOnly(false);
                 setSelectedTags([]);
               }}
+              title="All saves"
               type="button"
             >
-              <span>All saves</span><small>{activeCount}</small>
+              <span aria-hidden="true">▣</span>
+              <span className="sr-only">All saves</span>
             </button>
             <button
               aria-current={view === "library" && favoriteOnly ? "page" : undefined}
@@ -1110,10 +1134,11 @@ export function App() {
                 setFavoriteOnly(true);
                 setSelectedTags([]);
               }}
+              title="Favorites"
               type="button"
             >
-              <span>★ Favorites</span>
-              <small>{items.filter((item) => !item.deleted && item.favorite).length}</small>
+              <span aria-hidden="true">★</span>
+              <span className="sr-only">Favorites</span>
             </button>
             <button
               aria-current={view === "library" && filter === "deleted" ? "page" : undefined}
@@ -1123,108 +1148,192 @@ export function App() {
                 setFavoriteOnly(false);
                 setSelectedTags([]);
               }}
+              title="Archive"
               type="button"
             >
-              <span>Archive</span><small>{deletedCount}</small>
+              <span aria-hidden="true">▤</span>
+              <span className="sr-only">Archive</span>
             </button>
-            {/* The strip is the phone's whole navigation, and the heading row
-                that carries the desktop's List/Graph control is not on it. */}
+
+            <span aria-hidden="true" className="rail-glyph-divider" />
+
             <button
-              aria-current={
-                view === "library" && libraryMode === "graph" ? "page" : undefined
-              }
-              className="mobile-graph-toggle"
+              aria-current={view === "zen" ? "page" : undefined}
               onClick={() => {
-                navigateToView("library");
-                changeLibraryMode(libraryMode === "graph" ? "list" : "graph");
+                setOpenZen(null);
+                navigateToView("zen");
               }}
+              title="Zen documents"
               type="button"
             >
-              <span>Graph</span>
+              <span aria-hidden="true">¶</span>
+              <span className="sr-only">Zen documents</span>
+            </button>
+            {/* Tags are a list, and a list has nowhere to go in a 52px rail, so
+                the tag glyph is the way back to the full sidebar. */}
+            <button
+              aria-controls="workspace-sidebar"
+              aria-expanded={false}
+              onClick={() => setRailCollapsed(false)}
+              title="Tags"
+              type="button"
+            >
+              <span aria-hidden="true">#</span>
+              <span className="sr-only">Tags — show sidebar</span>
+            </button>
+
+            <span aria-hidden="true" className="rail-glyph-spacer" />
+
+            <button
+              aria-current={view === "settings" ? "page" : undefined}
+              className="rail-glyph-quiet"
+              onClick={() => navigateToView("settings")}
+              title="Settings"
+              type="button"
+            >
+              <span aria-hidden="true">⚙</span>
+              <span className="sr-only">Settings</span>
             </button>
           </nav>
 
-          <div className="rail-tags">
-            <div className="rail-heading">
-              <p>Zen</p>
-            </div>
-            <nav aria-label="Zen" className="rail-nav">
+          <div className="rail-full">
+            <nav aria-label="Library views" className="rail-nav">
               <button
-                aria-current={view === "zen" ? "page" : undefined}
+                aria-current={view === "library" && filter === "active" && !favoriteOnly ? "page" : undefined}
                 onClick={() => {
-                  // Closes the open document too, or this reads as a dead
-                  // control for anyone already inside one.
-                  setOpenZen(null);
-                  navigateToView("zen");
+                  navigateToView("library");
+                  setFilter("active");
+                  setFavoriteOnly(false);
+                  setSelectedTags([]);
                 }}
                 type="button"
               >
-                {/* The rail heading says ZEN above it; the chip strip drops
-                    headings, so the chip has to name itself. */}
-                <span className="rail-label-wide">Documents</span>
-                <span className="rail-label-narrow">Zen</span>
-                <small>{zenDocuments.length}</small>
+                <span>All saves</span><small>{activeCount}</small>
+              </button>
+              <button
+                aria-current={view === "library" && favoriteOnly ? "page" : undefined}
+                onClick={() => {
+                  navigateToView("library");
+                  setFilter("active");
+                  setFavoriteOnly(true);
+                  setSelectedTags([]);
+                }}
+                type="button"
+              >
+                <span>★ Favorites</span>
+                <small>{items.filter((item) => !item.deleted && item.favorite).length}</small>
+              </button>
+              <button
+                aria-current={view === "library" && filter === "deleted" ? "page" : undefined}
+                onClick={() => {
+                  navigateToView("library");
+                  setFilter("deleted");
+                  setFavoriteOnly(false);
+                  setSelectedTags([]);
+                }}
+                type="button"
+              >
+                <span>Archive</span><small>{deletedCount}</small>
+              </button>
+              {/* The strip is the phone's whole navigation, and the heading row
+                  that carries the desktop's List/Graph control is not on it. */}
+              <button
+                aria-current={
+                  view === "library" && libraryMode === "graph" ? "page" : undefined
+                }
+                className="mobile-graph-toggle"
+                onClick={() => {
+                  navigateToView("library");
+                  changeLibraryMode(libraryMode === "graph" ? "list" : "graph");
+                }}
+                type="button"
+              >
+                <span>Graph</span>
+              </button>
+            </nav>
+
+            <div className="rail-tags">
+              <div className="rail-heading">
+                <p>Zen</p>
+              </div>
+              <nav aria-label="Zen" className="rail-nav">
+                <button
+                  aria-current={view === "zen" ? "page" : undefined}
+                  onClick={() => {
+                    // Closes the open document too, or this reads as a dead
+                    // control for anyone already inside one.
+                    setOpenZen(null);
+                    navigateToView("zen");
+                  }}
+                  type="button"
+                >
+                  {/* The rail heading says ZEN above it; the chip strip drops
+                      headings, so the chip has to name itself. */}
+                  <span className="rail-label-wide">Documents</span>
+                  <span className="rail-label-narrow">Zen</span>
+                  <small>{zenDocuments.length}</small>
+                </button>
+              </nav>
+            </div>
+
+            {/* Tags belong to the library, but they stay reachable from Zen: on a
+                phone this strip is the whole navigation, and a filter that
+                disappears when a document opens is a filter nobody trusts. */}
+            <div className="rail-tags">
+              <div className="rail-heading">
+                <p>Tags</p>
+                {/* With the omnibar carrying search and saving, this is the way
+                    into the filters the strip has no room for. */}
+                <button
+                  aria-controls="library-filters"
+                  aria-expanded={filtersOpen}
+                  onClick={() => setFiltersOpen((open) => !open)}
+                  type="button"
+                >
+                  {appliedFilterCount > 0
+                    ? `filters · ${appliedFilterCount}`
+                    : hiddenTagCount > 0
+                      ? `+${hiddenTagCount} more`
+                      : "manage"}
+                </button>
+              </div>
+              <div className="rail-tag-list">
+                {railTags.map(({ count, tag }) => (
+                  <button
+                    aria-current={selectedTags.includes(tag) ? "page" : undefined}
+                    key={tag}
+                    onClick={() => toggleTagFilter(tag)}
+                    type="button"
+                  >
+                    <span>#{tag}</span><small>{count}</small>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <button
+              aria-controls="library-filters"
+              aria-expanded={filtersOpen}
+              className="mobile-tag-filter-trigger"
+              onClick={() => setFiltersOpen(true)}
+              type="button"
+            >
+              Filters{appliedFilterCount > 0 ? ` · ${appliedFilterCount}` : ""}
+            </button>
+
+            <nav aria-label="Workspace utilities" className="rail-utilities">
+              <button onClick={() => navigateToView("sync")} type="button">
+                <span>Sync</span><small>{libraryState.pendingCount} pending</small>
+              </button>
+              <button
+                aria-current={view === "settings" ? "page" : undefined}
+                onClick={() => navigateToView("settings")}
+                type="button"
+              >
+                <span>Settings</span>
               </button>
             </nav>
           </div>
-
-          {/* Tags belong to the library, but they stay reachable from Zen: on a
-              phone this strip is the whole navigation, and a filter that
-              disappears when a document opens is a filter nobody trusts. */}
-          <div className="rail-tags">
-            <div className="rail-heading">
-              <p>Tags</p>
-              {/* With the omnibar carrying search and saving, this is the way
-                  into the filters the strip has no room for. */}
-              <button
-                aria-controls="library-filters"
-                aria-expanded={filtersOpen}
-                onClick={() => setFiltersOpen((open) => !open)}
-                type="button"
-              >
-                {appliedFilterCount > 0
-                  ? `filters · ${appliedFilterCount}`
-                  : hiddenTagCount > 0
-                    ? `+${hiddenTagCount} more`
-                    : "manage"}
-              </button>
-            </div>
-            <div className="rail-tag-list">
-              {railTags.map(({ count, tag }) => (
-                <button
-                  aria-current={selectedTags.includes(tag) ? "page" : undefined}
-                  key={tag}
-                  onClick={() => toggleTagFilter(tag)}
-                  type="button"
-                >
-                  <span>#{tag}</span><small>{count}</small>
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <button
-            aria-controls="library-filters"
-            aria-expanded={filtersOpen}
-            className="mobile-tag-filter-trigger"
-            onClick={() => setFiltersOpen(true)}
-            type="button"
-          >
-            Filters{appliedFilterCount > 0 ? ` · ${appliedFilterCount}` : ""}
-          </button>
-
-          <nav aria-label="Workspace utilities" className="rail-utilities">
-            <button onClick={() => navigateToView("sync")} type="button">
-              <span>Sync</span><small>{libraryState.pendingCount} pending</small>
-            </button>
-            <button
-              aria-current={view === "settings" ? "page" : undefined}
-              onClick={() => navigateToView("settings")}
-              type="button"
-            >
-              <span>Settings</span>
-            </button>
-          </nav>
         </aside>
 
         <main id="workspace" tabIndex={-1}>

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2220,23 +2220,45 @@ kbd {
   position: relative;
 }
 
+/* Collapsed the sidebar narrows to a glyph rail; only outside the library and
+   Zen, where it has nothing to say, does it leave the grid entirely. */
 .workspace-layout-rail-collapsed {
+  grid-template-columns: 3.25rem minmax(0, 1fr);
+}
+
+.workspace-layout-rail-hidden {
   grid-template-columns: minmax(0, 1fr);
 }
 
-.workspace-layout-rail-collapsed .tag-rail,
 .tag-rail.tag-rail-empty {
   display: none;
 }
 
 .workspace-rail-toggle {
+  align-items: center;
   background: transparent;
   border: var(--rule) solid var(--color-border);
   border-radius: var(--radius);
-  color: var(--color-text-muted);
-  font-size: var(--font-size-xs);
-  min-height: 2rem;
-  padding: 0 var(--space-2);
+  color: var(--color-text-soft);
+  display: inline-flex;
+  flex: 0 0 auto;
+  height: 1.875rem;
+  justify-content: center;
+  min-height: 0;
+  padding: 0;
+  width: 1.875rem;
+}
+
+.rail-toggle-glyph {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1875rem;
+}
+
+.rail-toggle-glyph span {
+  background: currentcolor;
+  height: var(--rule);
+  width: 0.75rem;
 }
 
 .mobile-actions {
@@ -2255,6 +2277,89 @@ kbd {
   min-height: 0;
   overflow: hidden;
   padding: 1rem 0;
+}
+
+/* A wrapper only so the collapse has one thing to hide; it stays out of the
+   rail's own column so `margin-top: auto` on the utilities still reaches the
+   bottom of the sidebar. */
+.rail-full {
+  display: contents;
+}
+
+.tag-rail-collapsed {
+  padding: 0.875rem 0;
+}
+
+.tag-rail-collapsed .rail-full {
+  display: none;
+}
+
+.tag-rail-collapsed .rail-glyphs {
+  display: flex;
+}
+
+.rail-glyphs {
+  align-items: center;
+  display: none;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-height: 0;
+  width: 100%;
+}
+
+.rail-glyphs button {
+  align-items: center;
+  background: transparent;
+  border: var(--rule) solid transparent;
+  border-radius: var(--radius);
+  color: var(--color-text-soft);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: var(--font-size-sm);
+  height: 2.125rem;
+  justify-content: center;
+  min-height: 0;
+  padding: 0;
+  width: 2.125rem;
+}
+
+.rail-glyphs .rail-glyph-quiet {
+  color: var(--color-text-muted);
+}
+
+.rail-glyphs button[aria-current="page"] {
+  background: var(--color-surface-raised);
+  border-color: var(--color-border-strong);
+  color: var(--color-accent-strong);
+}
+
+.rail-glyph-divider {
+  background: var(--color-border-subtle);
+  flex: 0 0 auto;
+  height: var(--rule);
+  margin: var(--space-2) 0;
+  width: 1.25rem;
+}
+
+/* Settings sits at the foot of the rail the way it does in the open sidebar. */
+.rail-glyph-spacer {
+  margin-top: auto;
+}
+
+/* A finger needs the full control height, and the rail is only ever as wide as
+   the targets it holds. */
+@media (pointer: coarse) {
+  .workspace-rail-toggle,
+  .rail-glyphs button {
+    height: var(--control-height);
+    min-height: var(--control-height);
+    width: var(--control-height);
+  }
+
+  .workspace-layout-rail-collapsed {
+    grid-template-columns: calc(var(--control-height) + 0.75rem) minmax(0, 1fr);
+  }
 }
 
 .rail-nav,
@@ -3251,10 +3356,13 @@ kbd {
     overflow: visible;
   }
 
-  .workspace-layout-rail-collapsed .tag-rail:not(.tag-rail-empty) {
-    display: flex;
+  /* The strip is the phone's whole navigation, so it never collapses and the
+     glyph rail — which exists to save horizontal room — has no job here. */
+  .tag-rail-collapsed .rail-full {
+    display: contents;
   }
 
+  .tag-rail-collapsed .rail-glyphs,
   .workspace-rail-toggle {
     display: none;
   }


### PR DESCRIPTION
Implements the sidebar half of `Library Graph.dc.html` from the [Library Graph design](https://claude.ai/design/p/95af5d5e-1cbc-4ab7-af63-d21fa3539c36?file=Library+Graph.dc.html), which says both panels collapse — "nav to a glyph rail, inspector away entirely".

The inspector already collapsed that way behind the `details` chip. The nav did not: the toggle removed the whole panel, so collapsing it cost the navigation as well as the counts and the tag list it was meant to reclaim room from.

## Changes

**Collapsed nav becomes a glyph rail.** A 52px column keeps All saves, Favorites, Archive, Zen and Settings as glyph buttons, each carrying the same handler and `aria-current` state as its counterpart in the open sidebar, each with an `sr-only` name since the glyphs are decorative. A tag list has nowhere to go in a 52px column, so the `#` glyph is the way back to the full sidebar rather than a filter.

**Hamburger toggle.** The masthead control becomes the design's three-rule glyph in a 30×30 bordered box, and moves ahead of the wordmark where the design puts it — the control belongs to the panel it opens, not to the brand. The `sr-only` label and `aria-expanded`/`aria-controls` wiring are unchanged.

**Layout class split in two.** One class used to mean both "collapsed" and "this view has no rail". That cannot hold now that collapsed still reserves a column, so `workspace-layout-rail-hidden` takes the second meaning.

**`.rail-full` wrapper.** Exists only so the collapse has one thing to hide; `display: contents` keeps it out of the rail's own column, so `margin-top: auto` on the utilities still reaches the bottom of the sidebar. Most of the diff is the re-indent this caused — `git diff -w` is 143 lines against 293.

**Mobile is untouched in effect.** The strip is the phone's whole navigation, so it never collapses and the glyph rail — which exists to save horizontal room — has no job there. This replaces the old `:not(.tag-rail-empty)` re-show rule, which the class split made unnecessary.

Colours are tokens throughout; a `@media (pointer: coarse)` block grows the rail and its targets to `--control-height`.

## Verification

- `npm test` — 30 pass, 0 fail
- `npm run check:design` — passed (no raw colours, no transitions/shadows, tokenised radii)
- `npm run typecheck` — clean apart from a pre-existing error

CI is green on everything this change touches: Build static owner app, Browser convergence, Format and lint, and Test on ubuntu/macos/windows. That covers the `npm run build` chain (`wasm` → `typecheck` → `check:design` → `vite build` → `check:dist`) which I could not run locally — `wasm-bindgen-cli` 0.2.126 would not install on my machine, so `src/generated/research_domain` was missing and `typecheck` reported that one error. CI resolves it.

**Dependency audit fails, unrelated to this PR.** It is `cargo audit` on `Cargo.lock`, flagging `lru` 0.18.1 (RUSTSEC-2026-0253) and `sized-chunks` 0.6.5 (RUSTSEC-2026-0255, published 2026-08-11 — after main last ran CI). This branch touches no Rust and no `Cargo.lock`; the Dependabot PR #173, which touches only `web/package-lock.json`, fails the same check. Worth its own change.

**Still worth a human eye:** I have not seen this rendered. The collapsed rail at coarse-pointer widths is the part I would look at first.
