### PR TITLE
Clear the cargo audit failures

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -8,9 +8,16 @@ ignore = [
   # Loro 1.13.7 uses im::HashMap and im::HashSet, not the OrdSet insertion
   # affected by RUSTSEC-2023-0126. Upstream still carries im 15.1.0 as of
   # Loro 1.14.1. Issue #170 tracks replacing this pinned dependency and
-  # removing all four exceptions below.
+  # removing all five exceptions below.
   "RUSTSEC-2023-0126",
   "RUSTSEC-2026-0247",
   "RUSTSEC-2026-0248",
   "RUSTSEC-2026-0251",
+  # RUSTSEC-2026-0255 is the same archived sized-chunks that 0251 reports as
+  # unmaintained, now with a panic-safety finding and no patched version to
+  # move to. It reaches us only through im 15.1.0, and the unsoundness needs
+  # an element destructor to panic: the values ResearchPocket stores are
+  # strings, booleans and integers, whose drops cannot. Nothing to move to
+  # short of #170.
+  "RUSTSEC-2026-0255",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]


### PR DESCRIPTION
`Dependency audit` (`cargo audit --deny warnings`) has failed on every branch since two RustSec advisories landed after main last ran CI. It is currently red on #174 and on Dependabot's #173, neither of which touches Rust. This clears it.

The two advisories need different answers.

## RUSTSEC-2026-0253 — `lru`, fixed

`lru` 0.18.1 lacks panic safety in `LruCache::pop()`: if a stored key's `Drop` panics, the internal linked list is left holding dangling pointers, and a later cache operation can use-after-free or double-free. 0.18.2 patches it.

It reaches us through `ratatui-core` 0.1.2 → `ratatui` 0.30.2, whose existing requirement already admits 0.18.2, so this is `cargo update -p lru` and a two-line lock change. No manifest edit.

## RUSTSEC-2026-0255 — `sized-chunks`, ignored

There is no patched version to move to. This is the same archived `sized-chunks` that RUSTSEC-2026-0251 already reports as unmaintained — repository archived 2026-05-03 with issues and PRs disabled — now carrying a panic-safety finding across `Chunk`, `RingBuffer` and `InlineArray`.

It reaches us only through Loro's pinned `im` 15.1.0:

```
sized-chunks 0.6.5 → im 15.1.0 → loro-internal 1.13.7 → loro 1.13.7 → research-domain
```

That is the same root as the four exceptions `.cargo/audit.toml` already carries (RUSTSEC-2023-0126, 2026-0247, 2026-0248, 2026-0251), all tracked by #170 for removal when the pinned Loro dependency goes. So this joins them there rather than being given a fix it does not have. The unsoundness also needs an element destructor to panic, and the values ResearchPocket stores are strings, booleans and integers, whose drops cannot.

If ignoring it is the wrong call, the alternative is bringing #170 forward — but that is replacing a pinned CRDT dependency, not a lockfile bump, and it should not ride along with an unblocking change.

## Verification

**None locally — this needs CI.** I could not compile any Rust on this machine: the toolchain is `x86_64-pc-windows-msvc` but there is no MSVC linker installed, and MSYS2's `link.exe` shadows it on PATH, so every build script fails to link. That blocks `cargo check`, `cargo test` and installing `cargo-audit` alike.

So the claims above are read off `cargo tree -i`, `cargo update --dry-run` and the advisory text, all of which work without compiling. What CI needs to confirm: `Dependency audit` goes green, and `Test` still passes on all three platforms with `lru` 0.18.2.
