### PR TITLE
Give the graph toolbar back to the filters

### DIFF
--- a/web/src/components/LibraryGraph.tsx
+++ b/web/src/components/LibraryGraph.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -110,6 +111,15 @@ export function LibraryGraph({
     ? (projection.nodes.find((node) => node.id === selectedId) ?? null)
     : null;
   const selectedItem = selected ? sourceItem(selected, items) : undefined;
+
+  // The inspector is what a selection is for, so selecting brings it back.
+  // Without this, closing it once would strand every later selection in a
+  // panel nobody can see — and the toolbar no longer carries a way to reopen.
+  const selectNode = useCallback((id: string | null) => {
+    setSelectedId(id);
+    if (id) setInspectorOpen(true);
+  }, []);
+
   // Degree order puts the hubs first, which is the order someone stepping
   // through the graph by keyboard actually wants to meet it in.
   const traversal = useMemo(
@@ -126,7 +136,7 @@ export function LibraryGraph({
     const canvas = canvasRef.current;
     if (!canvas) return;
     const created = createSimulation(canvas, {
-      onSelect: (id) => setSelectedId(id),
+      onSelect: (id) => selectNode(id),
       onScale: (value) => setZoom(value),
       onPinnedChange: (count) => setPinnedCount(count),
       onUnavailable: () => setUnavailable(true),
@@ -230,7 +240,7 @@ export function LibraryGraph({
     const index = ((cursor % neighbours.length) + neighbours.length) % neighbours.length;
     cursors.current.set(node.id, index);
     const target = neighbours[index]!.id;
-    setSelectedId(target);
+    selectNode(target);
     simulation.current?.center(target);
     document.getElementById(nodeButtonId(target))?.focus();
   }
@@ -240,8 +250,8 @@ export function LibraryGraph({
   // tick, and reconciling thousands of buttons against it would cost more than
   // the frame it is competing with. Handlers go through a ref so the list can
   // depend on the projection and nothing else.
-  const actions = useRef({ openSelection, stepNeighbour, select: setSelectedId });
-  actions.current = { openSelection, stepNeighbour, select: setSelectedId };
+  const actions = useRef({ openSelection, stepNeighbour, select: selectNode });
+  actions.current = { openSelection, stepNeighbour, select: selectNode };
 
   const nodeList = useMemo(
     () => (
@@ -287,39 +297,10 @@ export function LibraryGraph({
 
   return (
     <div className="library-graph">
+      {/* Filters only. The camera and the key belong to the drawing, and they
+          live on it — a toolbar carrying both plus a panel toggle was ten
+          controls deep and scrolled sideways before the filters were reached. */}
       <div className="graph-toolbar">
-        {drawable ? (
-          <div aria-label="Graph camera" className="graph-camera" role="group">
-            <button
-              aria-label="Zoom out"
-              onClick={() => simulation.current?.zoomBy(0.8)}
-              type="button"
-            >
-              −
-            </button>
-            <output aria-label="Zoom level">{Math.round(zoom * 100)}%</output>
-            <button
-              aria-label="Zoom in"
-              onClick={() => simulation.current?.zoomBy(1.25)}
-              type="button"
-            >
-              +
-            </button>
-            <button
-              disabled={!selected}
-              onClick={() => selected && simulation.current?.focus(selected.id)}
-              type="button"
-            >
-              Focus
-            </button>
-            <button
-              onClick={() => simulation.current?.reset()}
-              type="button"
-            >
-              Fit all
-            </button>
-          </div>
-        ) : null}
         <button
           aria-pressed={showTags}
           onClick={() => setShowTags((value) => !value)}
@@ -341,26 +322,6 @@ export function LibraryGraph({
         >
           orphans · {orphansOnly ? "only" : full.orphans.length}
         </button>
-        {drawable ? (
-          <button
-            aria-controls="graph-legend"
-            aria-expanded={legendOpen}
-            onClick={() => setLegendOpen((value) => !value)}
-            type="button"
-          >
-            legend
-          </button>
-        ) : null}
-        {!narrow ? (
-          <button
-            aria-controls="graph-inspector"
-            aria-expanded={inspectorOpen}
-            onClick={() => setInspectorOpen((open) => !open)}
-            type="button"
-          >
-            details
-          </button>
-        ) : null}
         {pinnedCount > 0 ? (
           <button
             className="graph-release"
@@ -459,6 +420,38 @@ export function LibraryGraph({
                   </div>
                 </dl>
               ) : null}
+
+              {/* Its own toggle sits under it, on the drawing it explains. */}
+              <button
+                aria-controls="graph-legend"
+                aria-expanded={legendOpen}
+                className="graph-key-toggle"
+                onClick={() => setLegendOpen((value) => !value)}
+                type="button"
+              >
+                key
+              </button>
+
+              <div aria-label="Graph camera" className="graph-camera" role="group">
+                <button
+                  aria-label="Zoom out"
+                  onClick={() => simulation.current?.zoomBy(0.8)}
+                  type="button"
+                >
+                  −
+                </button>
+                <output aria-label="Zoom level">{Math.round(zoom * 100)}%</output>
+                <button
+                  aria-label="Zoom in"
+                  onClick={() => simulation.current?.zoomBy(1.25)}
+                  type="button"
+                >
+                  +
+                </button>
+                <button onClick={() => simulation.current?.reset()} type="button">
+                  reset
+                </button>
+              </div>
             </>
           ) : null}
 
@@ -473,9 +466,26 @@ export function LibraryGraph({
           className={`graph-inspector${!narrow && !inspectorOpen ? " graph-inspector-closed" : ""}`}
           id="graph-inspector"
         >
+          {/* The right of this row used to hold the kind label, which rendered
+              as a bare em dash with nothing selected — a dash sitting exactly
+              where a close button belongs, which is what it got clicked as.
+              The label moved left; the slot now holds the control it looked
+              like. Selecting anything opens the panel again. */}
           <div className="graph-inspector-heading">
-            <p>Selected</p>
-            <span>{selected ? kindLabel(selected) : "—"}</span>
+            <p>{selected ? kindLabel(selected) : "Selected"}</p>
+            {!narrow ? (
+              <button
+                aria-controls="graph-inspector"
+                aria-expanded={inspectorOpen}
+                className="graph-inspector-close"
+                onClick={() => setInspectorOpen(false)}
+                title="Close details"
+                type="button"
+              >
+                <span aria-hidden="true">×</span>
+                <span className="sr-only">Close details</span>
+              </button>
+            ) : null}
           </div>
 
           {/* The selection is announced here rather than marked on the node

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -5695,17 +5695,27 @@ kbd {
   padding-bottom: var(--space-3);
 }
 
+/* On the drawing, bottom right, opposite the key. Unlike the other overlays
+   this one is a control, so it keeps its pointer events. */
 .graph-camera {
   align-items: center;
-  border: var(--rule) solid var(--color-border-strong);
+  background: var(--color-surface);
+  border: var(--rule) solid var(--color-border-subtle);
   border-radius: var(--radius);
+  bottom: 0.75rem;
   display: flex;
-  flex: 0 0 auto;
   overflow: hidden;
+  position: absolute;
+  right: 0.75rem;
 }
 
-.graph-toolbar .graph-camera button {
+.graph-camera button {
+  background: transparent;
   border: 0;
+  color: var(--color-text-soft);
+  font-size: var(--font-size-xs);
+  min-height: var(--graph-overlay-control);
+  padding: 0 0.625rem;
 }
 
 .graph-camera button + button,
@@ -5738,11 +5748,6 @@ kbd {
   color: var(--color-accent-strong);
 }
 
-.graph-toolbar button[aria-expanded="true"] {
-  border-color: var(--color-border-strong);
-  color: var(--color-accent-strong);
-}
-
 .graph-release {
   margin-left: auto;
 }
@@ -5760,6 +5765,9 @@ kbd {
 }
 
 .graph-stage {
+  /* Both bottom overlays are this tall, and the key popover stacks off it. */
+  --graph-overlay-control: 1.875rem;
+
   min-height: 24rem;
   min-width: 0;
   position: relative;
@@ -5803,12 +5811,31 @@ kbd {
   color: var(--color-accent-strong);
 }
 
+/* Stacked above its own toggle, which holds the bottom-left corner. */
 .graph-legend {
-  bottom: 0.75rem;
+  bottom: calc(0.75rem + var(--graph-overlay-control) + var(--space-2));
   display: grid;
   gap: 0.3rem;
   left: 0.75rem;
   padding: 0.625rem 0.75rem;
+}
+
+.graph-key-toggle {
+  background: var(--color-surface);
+  border: var(--rule) solid var(--color-border-subtle);
+  border-radius: var(--radius);
+  bottom: 0.75rem;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  left: 0.75rem;
+  min-height: var(--graph-overlay-control);
+  padding: 0 0.625rem;
+  position: absolute;
+}
+
+.graph-key-toggle[aria-expanded="true"] {
+  border-color: var(--color-border-strong);
+  color: var(--color-accent-strong);
 }
 
 .graph-legend div {
@@ -5938,6 +5965,40 @@ kbd {
 .graph-inspector-heading span {
   color: var(--color-text-muted);
   font-size: var(--font-size-xs);
+}
+
+.graph-inspector-close {
+  align-items: center;
+  background: transparent;
+  border: var(--rule) solid transparent;
+  border-radius: var(--radius);
+  color: var(--color-text-muted);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: var(--font-size-sm);
+  height: 1.5rem;
+  justify-content: center;
+  min-height: 0;
+  padding: 0;
+  width: 1.5rem;
+}
+
+/* The sheet's coarse-pointer rule sits above the graph's own sizing, so the
+   later value wins and these have to restate it here. */
+@media (pointer: coarse) {
+  .graph-stage {
+    --graph-overlay-control: var(--control-height);
+  }
+
+  .graph-toolbar button {
+    min-height: var(--control-height);
+  }
+
+  .graph-inspector-close {
+    height: var(--control-height);
+    min-height: var(--control-height);
+    width: var(--control-height);
+  }
 }
 
 .graph-inspector-subject {
@@ -6105,6 +6166,12 @@ kbd {
 
   .graph-stage {
     min-height: 18rem;
+  }
+
+  /* Two fingers already zoom, and a stepper is a lot of chrome to lay over
+     18rem of drawing to say the same thing twice. */
+  .graph-camera {
+    display: none;
   }
 
   .graph-neighbourhood {


### PR DESCRIPTION
Two things you flagged: the `details` button is redundant, and the `[-]` on the details panel does nothing.

## The `[-]` was never a button

The inspector heading is a flex row, `justify-content: space-between`. Left held `Selected`; right held the kind label — which, with nothing selected, rendered as a bare `—`. An em dash, alone, in the exact corner a close button lives in. It read as a control because it looks like one.

The label moves into the heading proper (so the panel now says `SAVED ITEM` / `TAG` rather than a generic `Selected`), and the slot holds the close button it was impersonating.

## `details` is gone

The panel closes from its own heading now, which is where you reached for it.

**Selection reopens the inspector**, which this depends on: with no toolbar button left, dismissing it once would otherwise strand every later selection in a panel that cannot be seen. Canvas clicks, keyboard traversal and the neighbourhood list all route through one `selectNode` now.

## The toolbar is filters only

It was ten controls in one sideways-scrolling row — `−` `zoom%` `+` `Focus` `Fit all`, `tag links`, `co-mentions`, `orphans`, `legend`, `details`, plus `release N pinned`. The three chips that actually change what the graph shows came last.

Camera and key move onto the drawing, where the design puts them:

```
┌────────────────────────────────────────┐
│                              5 nodes · │
│                                        │
│              (graph)                   │
│                                        │
│ ┌────────┐                             │
│ │ ● item │                             │
│ │ ■ tag  │              ┌────────────┐ │
│ └────────┘              │ − 100% +   │ │
│ [ key ]                 │      reset │ │
└────────────────────────────────────────┘
```

Both corners were already overlay territory — the stats readout has held the third since the graph landed. Toolbar keeps `tag links`, `co-mentions`, `orphans` and `release N pinned`.

Two smaller things came with it: the zoom stepper is hidden on phones, where pinch already zooms and a stepper is a lot of chrome over 18rem of canvas; and the coarse-pointer touch sizing is restated after the graph's own rules, because the sheet's earlier `@media (pointer: coarse)` block was being overridden by them and had never actually applied to graph controls.

## One thing removed without replacement

**`Focus` is gone and nothing takes its place for pointer-only users.** Centring the selection stays on `C` with the canvas focused, and the neighbourhood list centres whatever it selects — but if you select a node, pan away, and want to return to it with the mouse, that route is gone. The design doesn't have a Focus button either, so this follows it, but it is a real capability drop rather than pure bloat removal. Say the word and I'll put it in the camera group as a fourth control, or restore the design's separate `Open` / `Center` pair in the inspector actions.

## Verification

- `npm test` — 30 pass, 0 fail
- `npm run check:design` — passed
- `npm run typecheck` — clean apart from the pre-existing missing-wasm error

**Not seen rendered.** Same environment limit as before: no MSVC linker here, so `npm run wasm` and therefore `vite build` cannot run locally. The overlay positions, the stacking of the key popover above its toggle, and the close button's alignment in the heading are all unverified by eye — worth a look, since this PR is mostly geometry.
